### PR TITLE
Silence usage for errors for cmds with no args

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -18,7 +18,8 @@ var listCmd = &cobra.Command{
 	Short: "List all created subnet configurations",
 	Long: `The subnet list command prints the names of all created subnet
 configurations.`,
-	RunE: listGenesis,
+	RunE:         listGenesis,
+	SilenceUsage: true,
 }
 
 type subnetMatrix [][]string

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -19,8 +19,9 @@ on your machine. If "snapshotName" is provided, that snapshot will be used for s
 if it can be found. Otherwise, the last saved unnamed (default) snapshot will be used. The command may fail if the local network
 is already running or if no subnets have been deployed.`,
 
-	RunE: startNetwork,
-	Args: cobra.MaximumNArgs(1),
+	RunE:         startNetwork,
+	Args:         cobra.MaximumNArgs(1),
+	SilenceUsage: true,
 }
 
 func startNetwork(cmd *cobra.Command, args []string) error {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -17,8 +17,9 @@ var statusCmd = &cobra.Command{
 	Long: `The network status command prints whether or not a local Avalanche
 network is running and some basic stats about the network.`,
 
-	RunE: networkStatus,
-	Args: cobra.ExactArgs(0),
+	RunE:         networkStatus,
+	Args:         cobra.ExactArgs(0),
+	SilenceUsage: true,
 }
 
 func networkStatus(cmd *cobra.Command, args []string) error {

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -21,8 +21,9 @@ If "snapshotName" is provided, the state will be saved under this named snapshot
 restarted with "network start <snapshotName>". Otherwise, the default snapshot will be created, or overwritten 
 if it exists. The default snapshot can then be restarted without parameter ("network start").`,
 
-	RunE: stopNetwork,
-	Args: cobra.MaximumNArgs(1),
+	RunE:         stopNetwork,
+	Args:         cobra.MaximumNArgs(1),
+	SilenceUsage: true,
 }
 
 func stopNetwork(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
A cmd prints the usage help when it returns with an error.

Silence the usage print for commands where no argument is needed.