### PR TITLE
Added flag to releaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,11 +2,13 @@
 builds:
   - id: avalanche-cli
     main: ./main.go
-    binary: avalanche 
+    binary: avalanche
     flags:
       - -v
     # windows is ignored by default, as the `goos` field by default only
     # contains linux and darwin
+    ldflags:
+      - -X 'github.com/ava-labs/avalanche-cli/cmd.Version={{.Version}}'
     ignore:
       - goos: darwin
         goarch: 386
@@ -18,4 +20,4 @@ release:
   # Default is extracted from the origin remote URL or empty if its private hosted.
   github:
     owner: ava-labs
-    name: avalanche-cli 
+    name: avalanche-cli


### PR DESCRIPTION
The release pipeline injects the version field into the `main` package by default, we need to put it in cmd. This fixes the `--version` flag in released builds.