### PR TITLE
[AV-1736] Move network runner logs and configs from tmp to .avalanche-cli

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
 	"github.com/ava-labs/avalanche-cli/ux"
+	"github.com/ava-labs/avalanche-network-runner/client"
 	"github.com/spf13/cobra"
 )
 
@@ -42,7 +43,7 @@ func startNetwork(cmd *cobra.Command, args []string) error {
 	ctx := binutils.GetAsyncContext()
 
 	ux.Logger.PrintToUser(startMsg)
-	_, err = cli.LoadSnapshot(ctx, snapshotName, app.GetRunDir())
+	_, err = cli.LoadSnapshot(ctx, snapshotName, client.WithRootDataDir(app.GetRunDir()))
 	if err != nil {
 		return fmt.Errorf("failed to start network with the persisted snapshot: %s", err)
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"fmt"
+	"path"
 
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
@@ -15,7 +16,7 @@ var startCmd = &cobra.Command{
 	Use:   "start [snapshotName]",
 	Short: "Starts a stopped local network",
 	Long: `The network start command starts a local, multi-node Avalanche network
-on your machine. If "snapshotName" is provided, that snapshot will be used for starting the network 
+on your machine. If "snapshotName" is provided, that snapshot will be used for starting the network
 if it can be found. Otherwise, the last saved unnamed (default) snapshot will be used. The command may fail if the local network
 is already running or if no subnets have been deployed.`,
 
@@ -42,7 +43,8 @@ func startNetwork(cmd *cobra.Command, args []string) error {
 	ctx := binutils.GetAsyncContext()
 
 	ux.Logger.PrintToUser(startMsg)
-	_, err = cli.LoadSnapshot(ctx, snapshotName)
+	rootDataDir := path.Join(app.GetBaseDir(), "runs")
+	_, err = cli.LoadSnapshot(ctx, snapshotName, rootDataDir)
 	if err != nil {
 		return fmt.Errorf("failed to start network with the persisted snapshot: %s", err)
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -4,11 +4,13 @@ package cmd
 
 import (
 	"fmt"
+	"path"
 
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
 	"github.com/ava-labs/avalanche-cli/ux"
 	"github.com/ava-labs/avalanche-network-runner/client"
+	"github.com/ava-labs/avalanche-network-runner/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -43,7 +45,14 @@ func startNetwork(cmd *cobra.Command, args []string) error {
 	ctx := binutils.GetAsyncContext()
 
 	ux.Logger.PrintToUser(startMsg)
-	_, err = cli.LoadSnapshot(ctx, snapshotName, client.WithRootDataDir(app.GetRunDir()))
+
+	outputDirPrefix := path.Join(app.GetRunDir(), "restart")
+	outputDir, err := utils.MkDirWithTimestamp(outputDirPrefix)
+	if err != nil {
+		return err
+	}
+
+	_, err = cli.LoadSnapshot(ctx, snapshotName, client.WithRootDataDir(outputDir))
 	if err != nil {
 		return fmt.Errorf("failed to start network with the persisted snapshot: %s", err)
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -4,7 +4,6 @@ package cmd
 
 import (
 	"fmt"
-	"path"
 
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
@@ -43,8 +42,7 @@ func startNetwork(cmd *cobra.Command, args []string) error {
 	ctx := binutils.GetAsyncContext()
 
 	ux.Logger.PrintToUser(startMsg)
-	rootDataDir := path.Join(app.GetBaseDir(), "runs")
-	_, err = cli.LoadSnapshot(ctx, snapshotName, rootDataDir)
+	_, err = cli.LoadSnapshot(ctx, snapshotName, app.GetRunDir())
 	if err != nil {
 		return fmt.Errorf("failed to start network with the persisted snapshot: %s", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/ava-labs/avalanche-cli
 
 go 1.17
 
+replace github.com/ava-labs/avalanche-network-runner => ../avalanche-network-runner
+
 require (
 	github.com/ava-labs/avalanche-network-runner v1.1.1
 	github.com/ava-labs/avalanchego v1.7.13

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/ava-labs/avalanche-cli
 
 go 1.17
 
-replace github.com/ava-labs/avalanche-network-runner => ../avalanche-network-runner
-
 require (
 	github.com/ava-labs/avalanche-network-runner v1.1.1
 	github.com/ava-labs/avalanchego v1.7.13

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -17,6 +18,8 @@ import (
 
 const (
 	WriteReadReadPerms = 0o644
+
+	runDir = "runs"
 )
 
 var errChainIDExists = errors.New("The provided chain ID already exists! Try another one")
@@ -35,6 +38,10 @@ func New(baseDir string, log logging.Logger) *Avalanche {
 
 func (app *Avalanche) GetBaseDir() string {
 	return app.baseDir
+}
+
+func (app *Avalanche) GetRunDir() string {
+	return path.Join(app.baseDir, runDir)
 }
 
 func (app *Avalanche) GetGenesisPath(subnetName string) string {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -18,8 +18,6 @@ import (
 
 const (
 	WriteReadReadPerms = 0o644
-
-	runDir = "runs"
 )
 
 var errChainIDExists = errors.New("The provided chain ID already exists! Try another one")
@@ -41,7 +39,7 @@ func (app *Avalanche) GetBaseDir() string {
 }
 
 func (app *Avalanche) GetRunDir() string {
-	return path.Join(app.baseDir, runDir)
+	return path.Join(app.baseDir, constants.RunDir)
 }
 
 func (app *Avalanche) GetGenesisPath(subnetName string) string {

--- a/pkg/binutils/processes.go
+++ b/pkg/binutils/processes.go
@@ -120,13 +120,12 @@ func StartServerProcess(app app.Avalanche) error {
 	args := []string{"backend", "start"}
 	cmd := exec.Command(thisBin, args...)
 
-	outputFilePrefix := path.Join(app.GetBaseDir(), "runs", "server")
+	outputFilePrefix := path.Join(app.GetRunDir(), "server")
 	outputFilePath, err := utils.MkDirWithTimestamp(outputFilePrefix)
 	if err != nil {
 		return err
 	}
 	outputFile, err := os.Create(path.Join(outputFilePath, "avalanche-cli-backend"))
-	// outputFile, err := os.CreateTemp("", "avalanche-cli-backend*")
 	if err != nil {
 		return err
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -13,8 +13,9 @@ const (
 	LatestAvagoReleaseURL = "https://api.github.com/repos/ava-labs/avalanchego/releases/latest"
 	SubnetEVMReleaseURL   = "https://api.github.com/repos/ava-labs/subnet-evm/releases/latest"
 
-	ServerRunFile      = "/tmp/gRPCserver.run"
+	ServerRunFile      = "gRPCserver.run"
 	AvalancheCliBinDir = "bin"
+	RunDir             = "runs"
 	Sidecar_suffix     = "_sidecar.json"
 	Genesis_suffix     = "_genesis.json"
 

--- a/pkg/subnet/local.go
+++ b/pkg/subnet/local.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -22,7 +23,6 @@ import (
 	"github.com/ava-labs/avalanche-cli/ux"
 	"github.com/ava-labs/avalanche-network-runner/client"
 	"github.com/ava-labs/avalanche-network-runner/utils"
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/storage"
 	"github.com/ava-labs/coreth/core"
 	"github.com/ava-labs/coreth/params"
@@ -34,8 +34,7 @@ type SubnetDeployer struct {
 	getClientFunc       getGRPCClientFunc
 	binaryDownloader    binutils.PluginBinaryDownloader
 	healthCheckInterval time.Duration
-	log                 logging.Logger
-	baseDir             string
+	app                 app.Avalanche
 	backendStartedHere  bool
 }
 
@@ -46,8 +45,7 @@ func NewLocalSubnetDeployer(app *app.Avalanche) *SubnetDeployer {
 		getClientFunc:       binutils.NewGRPCClient,
 		binaryDownloader:    binutils.NewPluginBinaryDownloader(app.Log),
 		healthCheckInterval: 10 * time.Second,
-		log:                 app.Log,
-		baseDir:             app.GetBaseDir(),
+		app:                 *app,
 	}
 }
 
@@ -62,8 +60,8 @@ func (d *SubnetDeployer) DeployToLocalNetwork(chain string, chain_genesis string
 		return fmt.Errorf("failed querying if server process is running: %w", err)
 	}
 	if !isRunning {
-		d.log.Debug("gRPC server is not running")
-		if err := binutils.StartServerProcess(d.log); err != nil {
+		d.app.Log.Debug("gRPC server is not running")
+		if err := binutils.StartServerProcess(d.app); err != nil {
 			return fmt.Errorf("failed starting gRPC server process: %w", err)
 		}
 		d.backendStartedHere = true
@@ -114,6 +112,8 @@ func (d *SubnetDeployer) doDeploy(chain string, chain_genesis string) error {
 			"evaluated chain genesis file to be at %s but it does not seem to exist.", chain_genesis)
 	}
 
+	rootDataDir := path.Join(d.app.GetBaseDir(), "runs")
+
 	// we need the chainID just later, but it would be ugly to fail the whole deployment
 	// for a JSON unmarshalling error, so let's do it here already
 	genesis, err := getGenesis(chain_genesis)
@@ -130,15 +130,16 @@ func (d *SubnetDeployer) doDeploy(chain string, chain_genesis string) error {
 		client.WithPluginDir(pluginDir),
 		client.WithCustomVMs(customVMs),
 		client.WithGlobalNodeConfig("{\"log-level\":\"debug\", \"log-display-level\":\"debug\"}"),
+		client.WithRootDataDir(rootDataDir),
 	}
 
 	vmID, err := utils.VMID(chain)
 	if err != nil {
 		return fmt.Errorf("failed to create VM ID from %s: %w", chain, err)
 	}
-	d.log.Debug("this VM will get ID: %s", vmID.String())
+	d.app.Log.Debug("this VM will get ID: %s", vmID.String())
 
-	binDir := filepath.Join(d.baseDir, constants.AvalancheCliBinDir)
+	binDir := filepath.Join(d.app.GetBaseDir(), constants.AvalancheCliBinDir)
 	if err := d.binaryDownloader.Download(vmID, pluginDir, binDir); err != nil {
 		return err
 	}
@@ -155,7 +156,7 @@ func (d *SubnetDeployer) doDeploy(chain string, chain_genesis string) error {
 		return fmt.Errorf("failed to start network :%s", err)
 	}
 
-	d.log.Debug(info.String())
+	d.app.Log.Debug(info.String())
 	ux.Logger.PrintToUser("Network has been booted. Wait until healthy. Please be patient, this will take some time...")
 
 	endpoints, err := d.WaitForHealthy(ctx, cli, d.healthCheckInterval)
@@ -195,7 +196,7 @@ func (d *SubnetDeployer) doDeploy(chain string, chain_genesis string) error {
 // * if not, it downloads it and installs it (os - and archive dependent)
 // * returns the location of the avalanchego path
 func (d *SubnetDeployer) setupLocalEnv() (string, error) {
-	binDir := filepath.Join(d.baseDir, constants.AvalancheCliBinDir)
+	binDir := filepath.Join(d.app.GetBaseDir(), constants.AvalancheCliBinDir)
 	binPrefix := "avalanchego-v"
 
 	exists, avagoDir, err := d.binChecker.ExistsWithLatestVersion(binDir, binPrefix)
@@ -203,7 +204,7 @@ func (d *SubnetDeployer) setupLocalEnv() (string, error) {
 		return "", fmt.Errorf("failed trying to locate avalanchego binary: %s", binDir)
 	}
 	if exists {
-		d.log.Debug("local avalanchego found. skipping installation")
+		d.app.Log.Debug("local avalanchego found. skipping installation")
 		return avagoDir, nil
 	}
 
@@ -220,7 +221,7 @@ func (d *SubnetDeployer) setupLocalEnv() (string, error) {
 		}
 	*/
 
-	d.log.Info("Avalanchego version is: %s", version)
+	d.app.Log.Info("Avalanchego version is: %s", version)
 
 	// TODO: would be nice if we could also here just use binutils.DownloadLatestReleaseVersion(),
 	// but unfortunately we don't have a consistent naming scheme between avalanchego and subnet-evm
@@ -262,7 +263,7 @@ func (d *SubnetDeployer) setupLocalEnv() (string, error) {
 		return "", fmt.Errorf("OS not supported: %s", goos)
 	}
 
-	d.log.Debug("starting download from %s...", avalanchegoURL)
+	d.app.Log.Debug("starting download from %s...", avalanchegoURL)
 
 	resp, err := http.Get(avalanchegoURL)
 	if err != nil {
@@ -278,7 +279,7 @@ func (d *SubnetDeployer) setupLocalEnv() (string, error) {
 		return "", err
 	}
 
-	d.log.Debug("download successful. installing archive...")
+	d.app.Log.Debug("download successful. installing archive...")
 	if err := binutils.InstallArchive(ext, archive, binDir); err != nil {
 		return "", err
 	}
@@ -303,22 +304,22 @@ func (d *SubnetDeployer) WaitForHealthy(ctx context.Context, cli client.Client, 
 			return nil, ctx.Err()
 		case <-time.After(healthCheckInterval):
 			cancel <- struct{}{}
-			d.log.Debug("polling for health...")
+			d.app.Log.Debug("polling for health...")
 			go ux.PrintWait(cancel)
 			resp, err := cli.Health(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("the health check failed to complete. The server might be down or have crashed, check the logs! %s", err)
 			}
 			if resp.ClusterInfo == nil {
-				d.log.Debug("warning: ClusterInfo is nil. trying again...")
+				d.app.Log.Debug("warning: ClusterInfo is nil. trying again...")
 				continue
 			}
 			if len(resp.ClusterInfo.CustomVms) == 0 {
-				d.log.Debug("network is up but custom VMs are not installed yet. polling again...")
+				d.app.Log.Debug("network is up but custom VMs are not installed yet. polling again...")
 				continue
 			}
 			if !resp.ClusterInfo.CustomVmsHealthy {
-				d.log.Debug("network is up but custom VMs are not healthy. polling again...")
+				d.app.Log.Debug("network is up but custom VMs are not healthy. polling again...")
 				continue
 			}
 			endpoints := []string{}
@@ -327,7 +328,7 @@ func (d *SubnetDeployer) WaitForHealthy(ctx context.Context, cli client.Client, 
 					endpoints = append(endpoints, fmt.Sprintf("Endpoint at node %s for blockchain %q with VM ID %q: %s/ext/bc/%s/rpc", nodeInfo.Name, vmInfo.BlockchainId, vmID, nodeInfo.GetUri(), vmInfo.BlockchainId))
 				}
 			}
-			d.log.Debug("cluster is up, subnets deployed, VMs are installed!")
+			d.app.Log.Debug("cluster is up, subnets deployed, VMs are installed!")
 			close(cancel)
 			return endpoints, nil
 		}

--- a/pkg/subnet/local.go
+++ b/pkg/subnet/local.go
@@ -10,7 +10,6 @@ import (
 	"math/big"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -112,8 +111,6 @@ func (d *SubnetDeployer) doDeploy(chain string, chain_genesis string) error {
 			"evaluated chain genesis file to be at %s but it does not seem to exist.", chain_genesis)
 	}
 
-	rootDataDir := path.Join(d.app.GetBaseDir(), "runs")
-
 	// we need the chainID just later, but it would be ugly to fail the whole deployment
 	// for a JSON unmarshalling error, so let's do it here already
 	genesis, err := getGenesis(chain_genesis)
@@ -130,7 +127,7 @@ func (d *SubnetDeployer) doDeploy(chain string, chain_genesis string) error {
 		client.WithPluginDir(pluginDir),
 		client.WithCustomVMs(customVMs),
 		client.WithGlobalNodeConfig("{\"log-level\":\"debug\", \"log-display-level\":\"debug\"}"),
-		client.WithRootDataDir(rootDataDir),
+		client.WithRootDataDir(d.app.GetRunDir()),
 	}
 
 	vmID, err := utils.VMID(chain)

--- a/pkg/subnet/local.go
+++ b/pkg/subnet/local.go
@@ -123,11 +123,16 @@ func (d *SubnetDeployer) doDeploy(chain string, chain_genesis string) error {
 		chain: chain_genesis,
 	}
 
+	runDir := binutils.GetLatestRunDir()
+	if runDir == "" {
+		runDir = d.app.GetRunDir()
+	}
+
 	opts := []client.OpOption{
 		client.WithPluginDir(pluginDir),
 		client.WithCustomVMs(customVMs),
 		client.WithGlobalNodeConfig("{\"log-level\":\"debug\", \"log-display-level\":\"debug\"}"),
-		client.WithRootDataDir(d.app.GetRunDir()),
+		client.WithRootDataDir(runDir),
 	}
 
 	vmID, err := utils.VMID(chain)

--- a/pkg/subnet/local_test.go
+++ b/pkg/subnet/local_test.go
@@ -56,6 +56,10 @@ func TestDeployToLocal(t *testing.T) {
 	binDownloader := &mocks.PluginBinaryDownloader{}
 	binDownloader.On("Download", mock.AnythingOfType("ids.ID"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil)
 
+	app := app.Avalanche{
+		Log: logging.NoLog{},
+	}
+
 	testDeployer := &Deployer{
 		procChecker:         procChecker,
 		binChecker:          binChecker,

--- a/pkg/subnet/local_test.go
+++ b/pkg/subnet/local_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanche-cli/cmd/mocks"
+	"github.com/ava-labs/avalanche-cli/pkg/app"
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/ux"
@@ -55,13 +56,17 @@ func TestDeployToLocal(t *testing.T) {
 	binDownloader := &mocks.PluginBinaryDownloader{}
 	binDownloader.On("Download", mock.AnythingOfType("ids.ID"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil)
 
+	app := app.Avalanche{
+		Log: logging.NoLog{},
+	}
+
 	testDeployer := &SubnetDeployer{
 		procChecker:         procChecker,
 		binChecker:          binChecker,
 		getClientFunc:       getTestClientFunc,
 		binaryDownloader:    binDownloader,
 		healthCheckInterval: 500 * time.Millisecond,
-		log:                 logging.NoLog{},
+		app:                 app,
 	}
 
 	// create a simple genesis for the test

--- a/pkg/subnet/local_test.go
+++ b/pkg/subnet/local_test.go
@@ -169,7 +169,7 @@ func TestGetLatestAvagoVersion(t *testing.T) {
 func getTestClientFunc() (client.Client, error) {
 	c := &mocks.Client{}
 	fakeStartResponse := &rpcpb.StartResponse{}
-	c.On("Start", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fakeStartResponse, nil)
+	c.On("Start", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fakeStartResponse, nil)
 	fakeHealthResponse := &rpcpb.HealthResponse{
 		ClusterInfo: &rpcpb.ClusterInfo{
 			Healthy:          true, // currently actually not checked, should it, if CustomVmsHealthy already is?


### PR DESCRIPTION
Place network runner logs in the `.avalanche-cli/runs` directory.

Requires a network runner update before merging: https://github.com/ava-labs/avalanche-network-runner/pull/167