### PR TITLE
Fix no such linter error on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release (with lint and test) 
+name: Release (with lint and test)
 
 on:
   push:
@@ -17,7 +17,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.29
+          version: v1.43
           working-directory: .
           args: --timeout 3m
       - name: Install license check


### PR DESCRIPTION
This is the issuer that broke our release pipeline on Friday. I had to add binaries manually.