### PR TITLE
remove network restart operation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ava-labs/avalanche-cli
 go 1.17
 
 require (
-	github.com/ava-labs/avalanche-network-runner v1.1.2-0.20220627191201-dc01ae797c3f
+	github.com/ava-labs/avalanche-network-runner v1.1.3-0.20220704232354-77d303474a50
 	github.com/ava-labs/avalanchego v1.7.13
 	github.com/ava-labs/coreth v0.8.12-rc.1
 	github.com/ava-labs/subnet-evm v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/ava-labs/avalanche-network-runner v1.1.1 h1:nofZVOsbIDDXekPMc+2FHHpsa
 github.com/ava-labs/avalanche-network-runner v1.1.1/go.mod h1:7Wowcer7/2sMLCF6oI66wHX6rBKg9HyZlMAF5jw6OcQ=
 github.com/ava-labs/avalanche-network-runner v1.1.2-0.20220627191201-dc01ae797c3f h1:eikK1Ytj5jXw3HVsbNk66RENyqqRZoe6t+S7pJ+hJ3c=
 github.com/ava-labs/avalanche-network-runner v1.1.2-0.20220627191201-dc01ae797c3f/go.mod h1:7Wowcer7/2sMLCF6oI66wHX6rBKg9HyZlMAF5jw6OcQ=
+github.com/ava-labs/avalanche-network-runner v1.1.3-0.20220704232354-77d303474a50 h1:7absD0yEBdySe+Bs+YDIV5neN9rVggce6g8s1/N0a1A=
+github.com/ava-labs/avalanche-network-runner v1.1.3-0.20220704232354-77d303474a50/go.mod h1:7Wowcer7/2sMLCF6oI66wHX6rBKg9HyZlMAF5jw6OcQ=
 github.com/ava-labs/avalanchego v1.7.13 h1:Jh+BBoio6li+DRiRMEeipM+J3AA5TcrJGtR/X1ccMmA=
 github.com/ava-labs/avalanchego v1.7.13/go.mod h1:h1y5dOSGoHJjLMpsTQjO5fdesN24XgBM0fIOqUouuUg=
 github.com/ava-labs/coreth v0.8.12-rc.1 h1:kGRBhFuYsl1bNyJhygs6NdxXjHbcY4NxenWAPRyuyDA=

--- a/pkg/subnet/local.go
+++ b/pkg/subnet/local.go
@@ -164,11 +164,7 @@ func (d *Deployer) doDeploy(chain string, chainGenesis string) error {
 
 	ux.Logger.PrintToUser("VMs ready.")
 
-	if networkBooted {
-		if err := restartNetwork(ctx, cli, avalancheGoBinPath, pluginDir, runDir); err != nil {
-			return err
-		}
-	} else {
+	if !networkBooted {
 		if err := startNetwork(ctx, cli, avalancheGoBinPath, pluginDir, runDir); err != nil {
 			return err
 		}
@@ -534,46 +530,6 @@ func startNetwork(
 	)
 	if err != nil {
 		return fmt.Errorf("failed to start network :%s", err)
-	}
-	return nil
-}
-
-// make snapshot of current state and reload it again
-func restartNetwork(
-	ctx context.Context,
-	cli client.Client,
-	avalancheGoBinPath string,
-	pluginDir string,
-	runDir string,
-) error {
-	tmpSnapshotName := fmt.Sprintf("restart-tmp-%d", time.Now().Unix())
-	ux.Logger.PrintToUser("Restarting network...")
-	_, err := cli.SaveSnapshot(
-		ctx,
-		tmpSnapshotName,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to save snapshot :%s", err)
-	}
-	loadSnapshotOpts := []client.OpOption{
-		client.WithPluginDir(pluginDir),
-		client.WithExecPath(avalancheGoBinPath),
-		client.WithRootDataDir(runDir),
-	}
-	_, err = cli.LoadSnapshot(
-		ctx,
-		tmpSnapshotName,
-		loadSnapshotOpts...,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to load snapshot :%s", err)
-	}
-	_, err = cli.RemoveSnapshot(
-		ctx,
-		tmpSnapshotName,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to remove snapshot :%s", err)
 	}
 	return nil
 }


### PR DESCRIPTION
- avoid network restart when deploying a subnet over a started network, by using new ANR branch that calls admin.LoadVMs