### PR TITLE
[AV-1882] Fix missing licenses

### DIFF
--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install license check
         run: go install github.com/google/addlicense@v1.0.0
       - name: Check license
-        run: addlicense -f ./LICENSE.header -check -v ./**/*.go
+        run: addlicense -f ./LICENSE.header -check -v ./**/*.go ./**/**/*.go ./**/**/**/*.go
   test:
     name: Golang Unit Tests v${{ matrix.go }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/cmd/subnetcmd/constants.go
+++ b/cmd/subnetcmd/constants.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package subnetcmd
 
 const (

--- a/pkg/binutils/binaries_test.go
+++ b/pkg/binutils/binaries_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package binutils
 
 import (

--- a/pkg/vm/airdrop.go
+++ b/pkg/vm/airdrop.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package vm
 
 import (

--- a/pkg/vm/descriptors.go
+++ b/pkg/vm/descriptors.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package vm
 
 import (

--- a/pkg/vm/evm_settings.go
+++ b/pkg/vm/evm_settings.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package vm
 
 import (

--- a/pkg/vm/fees.go
+++ b/pkg/vm/fees.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package vm
 
 import (

--- a/pkg/vm/precompiles.go
+++ b/pkg/vm/precompiles.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package vm
 
 import (

--- a/tests/e2e/commands/constants.go
+++ b/tests/e2e/commands/constants.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package commands
 
 const (

--- a/tests/e2e/commands/network.go
+++ b/tests/e2e/commands/network.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package commands
 
 import (

--- a/tests/e2e/commands/root.go
+++ b/tests/e2e/commands/root.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package commands
 
 import (

--- a/tests/e2e/commands/subnet.go
+++ b/tests/e2e/commands/subnet.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package commands
 
 import (

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package e2e
 
 import (

--- a/tests/e2e/network/suite.go
+++ b/tests/e2e/network/suite.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package network
 
 import (

--- a/tests/e2e/root/suite.go
+++ b/tests/e2e/root/suite.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package root
 
 import (

--- a/tests/e2e/subnet/suite.go
+++ b/tests/e2e/subnet/suite.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package subnet
 
 import (

--- a/tests/e2e/utils/constants.go
+++ b/tests/e2e/utils/constants.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package utils
 
 const (

--- a/tests/e2e/utils/helpers.go
+++ b/tests/e2e/utils/helpers.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package utils
 
 import (


### PR DESCRIPTION
For some reason the double star pattern isn't working. This makes it a bit more explicit but this will fail for depths greater than 3.