### PR TITLE
Print RPC Endpoints in table format

### DIFF
--- a/cmd/networkcmd/start.go
+++ b/cmd/networkcmd/start.go
@@ -100,9 +100,32 @@ func startNetwork(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 	if len(endpoints) > 0 {
 		ux.Logger.PrintToUser("Network ready to use. Local network node endpoints:")
-		for _, u := range endpoints {
-			ux.Logger.PrintToUser(u)
+		/*
+			for _, u := range endpoints {
+				ux.Logger.PrintToUser(u)
+			}
+		*/
+		chainName := ""
+		sidecars, err := app.GetSidecarNames()
+		if err != nil {
+			// TODO do we want to return an error in this case?
+			// It's far fetched but if it occurs, we could just print the
+			// VM ID instead of the chain name
 		}
+		for _, s := range sidecars {
+			sc, err := app.LoadSidecar(s)
+			if err != nil {
+				// TODO same here - we could just try continue
+				continue
+			}
+			for blockchainID := range clusterInfo.CustomVms {
+				// if sc.Networks["local"] != nil {
+				if blockchainID == sc.Networks["local"].BlockchainID {
+					chainName = sc.Subnet
+				}
+			}
+		}
+		subnet.PrintTableEndpoints(clusterInfo, chainName)
 	}
 
 	return nil

--- a/cmd/networkcmd/start.go
+++ b/cmd/networkcmd/start.go
@@ -100,32 +100,7 @@ func startNetwork(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 	if len(endpoints) > 0 {
 		ux.Logger.PrintToUser("Network ready to use. Local network node endpoints:")
-		/*
-			for _, u := range endpoints {
-				ux.Logger.PrintToUser(u)
-			}
-		*/
-		chainName := ""
-		sidecars, err := app.GetSidecarNames()
-		if err != nil {
-			// TODO do we want to return an error in this case?
-			// It's far fetched but if it occurs, we could just print the
-			// VM ID instead of the chain name
-		}
-		for _, s := range sidecars {
-			sc, err := app.LoadSidecar(s)
-			if err != nil {
-				// TODO same here - we could just try continue
-				continue
-			}
-			for blockchainID := range clusterInfo.CustomVms {
-				// if sc.Networks["local"] != nil {
-				if blockchainID == sc.Networks["local"].BlockchainID {
-					chainName = sc.Subnet
-				}
-			}
-		}
-		subnet.PrintTableEndpoints(clusterInfo, chainName)
+		ux.PrintTableEndpoints(clusterInfo)
 	}
 
 	return nil

--- a/cmd/subnetcmd/deploy.go
+++ b/cmd/subnetcmd/deploy.go
@@ -120,7 +120,7 @@ func deploySubnet(cmd *cobra.Command, args []string) error {
 		app.Log.Debug("Deploy local")
 		sc, err := app.LoadSidecar(chain)
 		if err != nil {
-			return fmt.Errorf("creation of chains and subnet was successful, but failed to load sidecar for update: %w", err)
+			return fmt.Errorf("failed to load sidecar for later update: %w", err)
 		}
 		deployer := subnet.NewLocalSubnetDeployer(app)
 		subnetID, blockchainID, err := deployer.DeployToLocalNetwork(chain, chainGenesis)

--- a/cmd/subnetcmd/deploy.go
+++ b/cmd/subnetcmd/deploy.go
@@ -119,14 +119,31 @@ func deploySubnet(cmd *cobra.Command, args []string) error {
 	case models.Local:
 		app.Log.Debug("Deploy local")
 		deployer := subnet.NewLocalSubnetDeployer(app)
-		if err := deployer.DeployToLocalNetwork(chain, chainGenesis); err != nil {
+		subnetID, blockchainID, err := deployer.DeployToLocalNetwork(chain, chainGenesis)
+		if err != nil {
 			if deployer.BackendStartedHere() {
 				if innerErr := binutils.KillgRPCServerProcess(app); innerErr != nil {
 					app.Log.Warn("tried to kill the gRPC server process but it failed: %w", innerErr)
 				}
 			}
+			return err
 		}
-		return err
+		sc, err := app.LoadSidecar(chain)
+		if err != nil {
+			return fmt.Errorf("creation of chains and subnet was successful, but failed to load sidecar for update: %w", err)
+		}
+		if sc.Networks == nil {
+			sc.Networks = make(map[string]models.NetworkData)
+		}
+		sc.Networks[models.Local.String()] = models.NetworkData{
+			SubnetID:     subnetID,
+			BlockchainID: blockchainID,
+		}
+		if err := app.UpdateSidecar(&sc); err != nil {
+			return fmt.Errorf("creation of chains and subnet was successful, but failed to update sidecar: %w", err)
+		}
+		return nil
+
 	case models.Fuji: // just make the switch pass
 		if keyName == "" {
 			keyName, err = prompts.CaptureString("Which private key should be used to issue the transaction? (Provide key name)")

--- a/cmd/subnetcmd/deploy.go
+++ b/cmd/subnetcmd/deploy.go
@@ -118,6 +118,10 @@ func deploySubnet(cmd *cobra.Command, args []string) error {
 	switch network {
 	case models.Local:
 		app.Log.Debug("Deploy local")
+		sc, err := app.LoadSidecar(chain)
+		if err != nil {
+			return fmt.Errorf("creation of chains and subnet was successful, but failed to load sidecar for update: %w", err)
+		}
 		deployer := subnet.NewLocalSubnetDeployer(app)
 		subnetID, blockchainID, err := deployer.DeployToLocalNetwork(chain, chainGenesis)
 		if err != nil {
@@ -127,10 +131,6 @@ func deploySubnet(cmd *cobra.Command, args []string) error {
 				}
 			}
 			return err
-		}
-		sc, err := app.LoadSidecar(chain)
-		if err != nil {
-			return fmt.Errorf("creation of chains and subnet was successful, but failed to load sidecar for update: %w", err)
 		}
 		if sc.Networks == nil {
 			sc.Networks = make(map[string]models.NetworkData)

--- a/cmd/subnetcmd/describe.go
+++ b/cmd/subnetcmd/describe.go
@@ -65,6 +65,7 @@ func printDetails(genesis core.Genesis, sc models.Sidecar) {
 	header := []string{"Parameter", "Value"}
 	table.SetHeader(header)
 	table.SetRowLine(true)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
 
 	table.Append([]string{"Subnet Name", sc.Subnet})
 	table.Append([]string{"ChainID", genesis.Config.ChainID.String()})

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -186,6 +186,10 @@ func (app *Avalanche) listSideCarNames() ([]string, error) {
 	return names, nil
 }
 
+func (app *Avalanche) GetSidecarNames() ([]string, error) {
+	return app.listSideCarNames()
+}
+
 func (app *Avalanche) ChainIDExists(chainID string) (bool, error) {
 	sidecars, err := app.listSideCarNames()
 	if err != nil {

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -173,7 +173,7 @@ func (app *Avalanche) GetTokenName(subnetName string) string {
 	return sidecar.TokenName
 }
 
-func (app *Avalanche) listSideCarNames() ([]string, error) {
+func (app *Avalanche) GetSidecarNames() ([]string, error) {
 	matches, err := filepath.Glob(filepath.Join(app.baseDir, "*"+constants.SidecarSuffix))
 	if err != nil {
 		return nil, err
@@ -187,12 +187,8 @@ func (app *Avalanche) listSideCarNames() ([]string, error) {
 	return names, nil
 }
 
-func (app *Avalanche) GetSidecarNames() ([]string, error) {
-	return app.listSideCarNames()
-}
-
 func (app *Avalanche) ChainIDExists(chainID string) (bool, error) {
-	sidecars, err := app.listSideCarNames()
+	sidecars, err := app.GetSidecarNames()
 	if err != nil {
 		return false, err
 	}

--- a/pkg/subnet/local.go
+++ b/pkg/subnet/local.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/storage"
 	"github.com/ava-labs/coreth/core"
 	"github.com/ava-labs/coreth/params"
+	"github.com/olekukonko/tablewriter"
 )
 
 const (
@@ -223,9 +224,12 @@ func (d *LocalSubnetDeployer) doDeploy(chain string, chainGenesis string) error 
 
 	fmt.Println()
 	ux.Logger.PrintToUser("Network ready to use. Local network node endpoints:")
-	for _, u := range endpoints {
-		ux.Logger.PrintToUser(u)
-	}
+	/*
+		for _, u := range endpoints {
+			ux.Logger.PrintToUser(u)
+		}
+	*/
+	PrintTableEndpoints(clusterInfo, chain)
 	fmt.Println()
 	firstURL := endpoints[0]
 
@@ -429,6 +433,20 @@ func GetEndpoints(clusterInfo *rpcpb.ClusterInfo) []string {
 		}
 	}
 	return endpoints
+}
+
+func PrintTableEndpoints(clusterInfo *rpcpb.ClusterInfo, chain string) {
+	table := tablewriter.NewWriter(os.Stdout)
+	header := []string{"node", "VM", "URL"}
+	table.SetHeader(header)
+	table.SetRowLine(true)
+
+	for _, nodeInfo := range clusterInfo.NodeInfos {
+		for blockchainID := range clusterInfo.CustomVms {
+			table.Append([]string{nodeInfo.Name, chain, fmt.Sprintf("%s/ext/bc/%s/rpc", nodeInfo.GetUri(), blockchainID)})
+		}
+	}
+	table.Render()
 }
 
 // return true if vm has already been deployed

--- a/pkg/subnet/local.go
+++ b/pkg/subnet/local.go
@@ -248,9 +248,6 @@ func (d *LocalSubnetDeployer) doDeploy(chain string, chainGenesis string) (ids.I
 	// we can safely ignore errors here as the subnets have already been generated
 	subnetID, _ := ids.FromString(subnetIDStr)
 	var blockchainID ids.ID
-	// TODO: the specs say CustomVms is a map by VM ID,
-	// but it appears the key is the blockchain ID.
-	// If that's a bug, then we'd only need to access the map via VM ID
 	for _, info := range clusterInfo.CustomVms {
 		if info.VmId == chainVMID.String() {
 			blockchainID, _ = ids.FromString(info.BlockchainId)

--- a/pkg/subnet/local_test.go
+++ b/pkg/subnet/local_test.go
@@ -78,7 +78,7 @@ func TestDeployToLocal(t *testing.T) {
 	err = os.WriteFile(testGenesis.Name(), []byte(genesis), constants.DefaultPerms755)
 	assert.NoError(err)
 	// test actual deploy
-	err = testDeployer.DeployToLocalNetwork("test", testGenesis.Name())
+	_, _, err = testDeployer.DeployToLocalNetwork("test", testGenesis.Name())
 	assert.NoError(err)
 }
 

--- a/pkg/subnet/local_test.go
+++ b/pkg/subnet/local_test.go
@@ -33,7 +33,8 @@ var (
 	testSubnetID1     = ids.GenerateTestID().String()
 	testSubnetID2     = ids.GenerateTestID().String()
 
-	testVMID = "tGBrM2SXkAdNsqzb3SaFZZWMNdzjjFEUKteheTa4dhUwnfQyu" // VM ID of "test"
+	testVMID   = "tGBrM2SXkAdNsqzb3SaFZZWMNdzjjFEUKteheTa4dhUwnfQyu" // VM ID of "test"
+	testVMName = "test"
 
 	fakeHealthResponse = &rpcpb.HealthResponse{
 		ClusterInfo: &rpcpb.ClusterInfo{
@@ -50,10 +51,10 @@ var (
 				},
 			},
 			CustomVms: map[string]*rpcpb.CustomVmInfo{
-				"vm1": {
+				"bchain1": {
 					BlockchainId: testBlockChainID1,
 				},
-				"vm2": {
+				"bchain2": {
 					BlockchainId: testBlockChainID2,
 				},
 			},
@@ -116,7 +117,7 @@ func TestDeployToLocal(t *testing.T) {
 	err = os.WriteFile(testGenesis.Name(), []byte(genesis), constants.DefaultPerms755)
 	assert.NoError(err)
 	// test actual deploy
-	s, b, err := testDeployer.DeployToLocalNetwork("test", testGenesis.Name())
+	s, b, err := testDeployer.DeployToLocalNetwork(testVMName, testGenesis.Name())
 	assert.NoError(err)
 	assert.Equal(testSubnetID2, s.String())
 	assert.Equal(testBlockChainID2, b.String())
@@ -225,9 +226,9 @@ func getTestClientFunc() (client.Client, error) {
 	c.On("Health", mock.Anything).Return(fakeHealthResponse, nil).Twice()
 	// Afterwards, change the VmId so that TestDeployToLocal has the correct ID to check
 	alteredFakeResponse := proto.Clone(fakeHealthResponse).(*rpcpb.HealthResponse) // new(rpcpb.HealthResponse)
-	alteredFakeResponse.ClusterInfo.CustomVms["vm2"].VmId = testVMID
-	alteredFakeResponse.ClusterInfo.CustomVms["vm2"].VmName = "test"
-	alteredFakeResponse.ClusterInfo.CustomVms["vm1"].VmName = "vm1"
+	alteredFakeResponse.ClusterInfo.CustomVms["bchain2"].VmId = testVMID
+	alteredFakeResponse.ClusterInfo.CustomVms["bchain2"].VmName = testVMName
+	alteredFakeResponse.ClusterInfo.CustomVms["bchain1"].VmName = "bchain1"
 	c.On("Health", mock.Anything).Return(alteredFakeResponse, nil)
 	c.On("Close").Return(nil)
 	return c, nil

--- a/pkg/subnet/local_test.go
+++ b/pkg/subnet/local_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanche-network-runner/client"
 	"github.com/ava-labs/avalanche-network-runner/rpcpb"
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/perms"
 	"github.com/stretchr/testify/assert"
@@ -78,8 +79,10 @@ func TestDeployToLocal(t *testing.T) {
 	err = os.WriteFile(testGenesis.Name(), []byte(genesis), constants.DefaultPerms755)
 	assert.NoError(err)
 	// test actual deploy
-	_, _, err = testDeployer.DeployToLocalNetwork("test", testGenesis.Name())
+	s, b, err := testDeployer.DeployToLocalNetwork("test", testGenesis.Name())
 	assert.NoError(err)
+	assert.Equal(ids.Empty, s)
+	assert.Equal(ids.Empty, b)
 }
 
 func TestExistsWithLatestVersion(t *testing.T) {

--- a/pkg/ux/output.go
+++ b/pkg/ux/output.go
@@ -5,9 +5,12 @@ package ux
 import (
 	"fmt"
 	"io"
+	"os"
 	"time"
 
+	"github.com/ava-labs/avalanche-network-runner/rpcpb"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/olekukonko/tablewriter"
 )
 
 var Logger *UserLog
@@ -42,4 +45,19 @@ func PrintWait(cancel chan struct{}) {
 			return
 		}
 	}
+}
+
+// PrintTableEndpoints prints the endpoints coming from the healthy call
+func PrintTableEndpoints(clusterInfo *rpcpb.ClusterInfo) {
+	table := tablewriter.NewWriter(os.Stdout)
+	header := []string{"node", "VM", "URL"}
+	table.SetHeader(header)
+	table.SetRowLine(true)
+
+	for _, nodeInfo := range clusterInfo.NodeInfos {
+		for blockchainID, vmInfo := range clusterInfo.CustomVms {
+			table.Append([]string{nodeInfo.Name, vmInfo.VmName, fmt.Sprintf("%s/ext/bc/%s/rpc", nodeInfo.GetUri(), blockchainID)})
+		}
+	}
+	table.Render()
 }

--- a/tests/e2e/network/suite.go
+++ b/tests/e2e/network/suite.go
@@ -24,7 +24,7 @@ var _ = ginkgo.Describe("[Network]", func() {
 	ginkgo.It("can stop and restart a deployed subnet", func() {
 		commands.CreateSubnetConfig(subnetName, genesisPath)
 		deployOutput := commands.DeploySubnetLocally(subnetName)
-		rpc, err := utils.ParseRPCFromDeployOutput(deployOutput)
+		rpc, err := utils.ParseRPCFromOutput(deployOutput)
 		if err != nil {
 			fmt.Println(deployOutput)
 		}
@@ -53,7 +53,7 @@ var _ = ginkgo.Describe("[Network]", func() {
 
 		commands.StopNetwork()
 		restartOutput := commands.StartNetwork()
-		rpc, err = utils.ParseRPCFromRestartOutput(restartOutput)
+		rpc, err = utils.ParseRPCFromOutput(restartOutput)
 		if err != nil {
 			fmt.Println(restartOutput)
 		}

--- a/tests/e2e/subnet/suite.go
+++ b/tests/e2e/subnet/suite.go
@@ -29,7 +29,7 @@ var _ = ginkgo.Describe("[Subnet]", func() {
 	ginkgo.It("can deploy a subnet", func() {
 		commands.CreateSubnetConfig(subnetName, genesisPath)
 		deployOutput := commands.DeploySubnetLocally(subnetName)
-		rpc, err := utils.ParseRPCFromDeployOutput(deployOutput)
+		rpc, err := utils.ParseRPCFromOutput(deployOutput)
 		if err != nil {
 			fmt.Println(deployOutput)
 		}

--- a/tests/e2e/utils/helpers.go
+++ b/tests/e2e/utils/helpers.go
@@ -112,32 +112,19 @@ func stdoutParser(output string, queue string, capture string) (string, error) {
 	return "", errors.New("no queue string found")
 }
 
-func ParseRPCFromDeployOutput(output string) (string, error) {
+func ParseRPCFromOutput(output string) (string, error) {
 	// split output by newline
 	lines := strings.Split(output, "\n")
 	for _, line := range lines {
-		if strings.Contains(line, "RPC URL:") {
-			index := strings.Index(line, "http")
-			if index == -1 {
-				return "", errors.New("no url in RPC URL line")
-			}
-			return line[index:], nil
+		if !strings.Contains(line, "rpc") {
+			continue
 		}
-	}
-	return "", errors.New("no rpc url found")
-}
-
-func ParseRPCFromRestartOutput(output string) (string, error) {
-	// split output by newline
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
-		if strings.Contains(line, "Endpoint at node") {
-			index := strings.Index(line, "http")
-			if index == -1 {
-				return "", errors.New("no url in RPC URL line")
-			}
-			return line[index:], nil
+		startIndex := strings.Index(line, "http")
+		if startIndex == -1 {
+			return "", errors.New("no url in RPC URL line")
 		}
+		endIndex := strings.LastIndex(line, "rpc")
+		return line[startIndex : endIndex+3], nil
 	}
 	return "", errors.New("no rpc url found")
 }


### PR DESCRIPTION
Closes https://ava-labs.atlassian.net/browse/AV-1903

Also adds saving of network data (subnetID, blockchainID) to sidecar when deploying locally.