### PR TITLE
Add Subnet Import/Export

### DIFF
--- a/cmd/subnetcmd/export.go
+++ b/cmd/subnetcmd/export.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+package subnetcmd
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/ava-labs/avalanche-cli/pkg/application"
+	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/spf13/cobra"
+)
+
+var exportOutput string
+
+// avalanche subnet list
+func newExportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "export [subnetName]",
+		Short:        "Export deployment details",
+		Long:         `The subnet export command prints the details of an existing subnet deploy.`,
+		RunE:         exportSubnet,
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+	}
+
+	cmd.Flags().StringVarP(
+		&exportOutput,
+		"output",
+		"o",
+		"",
+		"write the export data to the provided file path",
+	)
+
+	return cmd
+}
+
+func exportSubnet(cmd *cobra.Command, args []string) error {
+	var err error
+	if exportOutput == "" {
+		pathPrompt := "Enter file path to write export data to"
+		exportOutput, err = app.Prompt.CaptureString(pathPrompt)
+		if err != nil {
+			return err
+		}
+	}
+
+	subnetName := args[0]
+	sc, err := app.LoadSidecar(subnetName)
+	if err != nil {
+		return err
+	}
+
+	gen, err := app.LoadRawGenesis(subnetName)
+	if err != nil {
+		return err
+	}
+
+	exportData := models.Exportable{
+		Sidecar: sc,
+		Genesis: gen,
+	}
+
+	exportBytes, err := json.Marshal(exportData)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(exportOutput, exportBytes, application.WriteReadReadPerms)
+}

--- a/cmd/subnetcmd/export.go
+++ b/cmd/subnetcmd/export.go
@@ -16,9 +16,12 @@ var exportOutput string
 // avalanche subnet list
 func newExportCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "export [subnetName]",
-		Short:        "Export deployment details",
-		Long:         `The subnet export command prints the details of an existing subnet deploy.`,
+		Use:   "export [subnetName]",
+		Short: "Export deployment details",
+		Long: `The subnet export command prints the details of an existing subnet deploy.
+
+The command prompts for an output filename. You can also provide one with
+the --output flag.`,
 		RunE:         exportSubnet,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),

--- a/cmd/subnetcmd/import.go
+++ b/cmd/subnetcmd/import.go
@@ -1,0 +1,68 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+package subnetcmd
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+
+	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	"github.com/spf13/cobra"
+)
+
+var overwriteImport bool
+
+// avalanche subnet import
+func newImportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "import [subnetPath]",
+		Short:        "List all created subnet configurations",
+		RunE:         importSubnet,
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		Long: `The subnet list command prints the names of all created subnet
+configurations.`,
+	}
+	cmd.Flags().BoolVarP(&overwriteImport, "force", "f", false, "overwrite the existing configuration if one exists")
+	return cmd
+}
+
+func importSubnet(cmd *cobra.Command, args []string) error {
+	importPath := args[0]
+
+	importFileBytes, err := os.ReadFile(importPath)
+	if err != nil {
+		return err
+	}
+
+	importable := models.Exportable{}
+	err = json.Unmarshal(importFileBytes, &importable)
+	if err != nil {
+		return err
+	}
+
+	subnetName := importable.Sidecar.Name
+	if subnetName == "" {
+		return errors.New("export data is malformed: missing subnet name")
+	}
+
+	if app.GenesisExists(subnetName) && !overwriteImport {
+		return errors.New("subnet already exists. Use --" + forceFlag + " parameter to overwrite")
+	}
+
+	err = app.WriteGenesisFile(subnetName, importable.Genesis)
+	if err != nil {
+		return err
+	}
+
+	err = app.CreateSidecar(&importable.Sidecar)
+	if err != nil {
+		return err
+	}
+
+	ux.Logger.PrintToUser("Subnet imported successfully")
+
+	return nil
+}

--- a/cmd/subnetcmd/import.go
+++ b/cmd/subnetcmd/import.go
@@ -18,12 +18,14 @@ var overwriteImport bool
 func newImportCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "import [subnetPath]",
-		Short:        "List all created subnet configurations",
+		Short:        "Import an existing subnet config",
 		RunE:         importSubnet,
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
-		Long: `The subnet list command prints the names of all created subnet
-configurations.`,
+		Long: `The subnet import command accepts an exported subnet config file.
+
+By default, an imported subnet will not overwrite an existing subnet
+with the same name. To allow overwrites, provide the --force flag.`,
 	}
 	cmd.Flags().BoolVarP(&overwriteImport, "force", "f", false, "overwrite the existing configuration if one exists")
 	return cmd

--- a/cmd/subnetcmd/subnet.go
+++ b/cmd/subnetcmd/subnet.go
@@ -45,5 +45,9 @@ manage your subnet configurations and live deployments.`,
 	cmd.AddCommand(newJoinCmd())
 	// subnet addValidator
 	cmd.AddCommand(newAddValidatorCmd())
+	// subnet export
+	cmd.AddCommand(newExportCmd())
+	// subnet import
+	cmd.AddCommand(newImportCmd())
 	return cmd
 }

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -119,6 +119,16 @@ func (app *Avalanche) LoadEvmGenesis(subnetName string) (core.Genesis, error) {
 	return gen, err
 }
 
+func (app *Avalanche) LoadRawGenesis(subnetName string) ([]byte, error) {
+	genesisPath := app.GetGenesisPath(subnetName)
+	genesisBytes, err := os.ReadFile(genesisPath)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return genesisBytes, err
+}
+
 func (app *Avalanche) CreateSidecar(sc *models.Sidecar) error {
 	if sc.TokenName == "" {
 		sc.TokenName = constants.DefaultTokenName

--- a/pkg/models/exportable.go
+++ b/pkg/models/exportable.go
@@ -1,0 +1,6 @@
+package models
+
+type Exportable struct {
+	Sidecar Sidecar
+	Genesis []byte
+}

--- a/pkg/models/exportable.go
+++ b/pkg/models/exportable.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package models
 
 type Exportable struct {


### PR DESCRIPTION
Add commands to export subnet configurations to a file and import them in other CLI instances. With this, users can deploy a subnet with one validator and spin up additional validators on other nodes.

Closes #120 