### PR TITLE
Fix addValidator Defaults

### DIFF
--- a/cmd/subnetcmd/addValidator.go
+++ b/cmd/subnetcmd/addValidator.go
@@ -126,6 +126,9 @@ func addValidator(cmd *cobra.Command, args []string) error {
 	}
 
 	ux.Logger.PrintToUser("Inputs complete, issuing transaction to add the provided validator information...")
+	ux.Logger.PrintToUser("Start time: %s", start.Format(constants.TimeParseLayout))
+	ux.Logger.PrintToUser("End time: %s", start.Add(duration).Format(constants.TimeParseLayout))
+	ux.Logger.PrintToUser("Weight: %d", weight)
 	return nil
 	// deployer := subnet.NewPublicDeployer(app, app.GetKeyPath(keyName), network)
 	// return deployer.AddValidator(subnetID, nodeID, weight, start, duration)

--- a/cmd/subnetcmd/addValidator.go
+++ b/cmd/subnetcmd/addValidator.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanche-cli/pkg/subnet"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanchego/ids"
 	avago_constants "github.com/ava-labs/avalanchego/utils/constants"
@@ -121,15 +122,14 @@ func addValidator(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ux.Logger.PrintToUser("Inputs complete, issuing transaction to add the provided validator information...")
 	ux.Logger.PrintToUser("NodeID: %s", nodeID.String())
 	ux.Logger.PrintToUser("Network: %s", network.String())
 	ux.Logger.PrintToUser("Start time: %s", start.Format(constants.TimeParseLayout))
 	ux.Logger.PrintToUser("End time: %s", start.Add(duration).Format(constants.TimeParseLayout))
 	ux.Logger.PrintToUser("Weight: %d", weight)
-	return nil
-	// deployer := subnet.NewPublicDeployer(app, app.GetKeyPath(keyName), network)
-	// return deployer.AddValidator(subnetID, nodeID, weight, start, duration)
+	ux.Logger.PrintToUser("Inputs complete, issuing transaction to add the provided validator information...")
+	deployer := subnet.NewPublicDeployer(app, app.GetKeyPath(keyName), network)
+	return deployer.AddValidator(subnetID, nodeID, uint64(weight), start, duration)
 }
 
 func promptDuration(start time.Time) (time.Duration, error) {

--- a/cmd/subnetcmd/join.go
+++ b/cmd/subnetcmd/join.go
@@ -138,7 +138,7 @@ but until the node is whitelisted, it will not be able to validate this subnet.`
 		)
 		choice, err := app.Prompt.CaptureList(
 			"How would you like to update the avalanchego config?",
-			[]string{choiceManual, choiceAutomatic},
+			[]string{choiceAutomatic, choiceManual},
 		)
 		if err != nil {
 			return err

--- a/cmd/subnetcmd/join.go
+++ b/cmd/subnetcmd/join.go
@@ -144,6 +144,7 @@ but until the node is whitelisted, it will not be able to validate this subnet.`
 			return err
 		}
 		if choice == choiceManual {
+			pluginDir = app.GetTmpPluginDir()
 			vmPath, err := createPlugin(sc.Name, pluginDir)
 			if err != nil {
 				return err

--- a/internal/mocks/prompter.go
+++ b/internal/mocks/prompter.go
@@ -279,14 +279,14 @@ func (_m *Prompter) CaptureUint64(promptStr string) (uint64, error) {
 }
 
 // CaptureWeight provides a mock function with given fields: promptStr
-func (_m *Prompter) CaptureWeight(promptStr string) (uint64, error) {
+func (_m *Prompter) CaptureWeight(promptStr string) (int64, error) {
 	ret := _m.Called(promptStr)
 
-	var r0 uint64
-	if rf, ok := ret.Get(0).(func(string) uint64); ok {
+	var r0 int64
+	if rf, ok := ret.Get(0).(func(string) int64); ok {
 		r0 = rf(promptStr)
 	} else {
-		r0 = ret.Get(0).(uint64)
+		r0 = ret.Get(0).(int64)
 	}
 
 	var r1 error

--- a/internal/mocks/prompter.go
+++ b/internal/mocks/prompter.go
@@ -279,14 +279,14 @@ func (_m *Prompter) CaptureUint64(promptStr string) (uint64, error) {
 }
 
 // CaptureWeight provides a mock function with given fields: promptStr
-func (_m *Prompter) CaptureWeight(promptStr string) (int64, error) {
+func (_m *Prompter) CaptureWeight(promptStr string) (uint64, error) {
 	ret := _m.Called(promptStr)
 
-	var r0 int64
-	if rf, ok := ret.Get(0).(func(string) int64); ok {
+	var r0 uint64
+	if rf, ok := ret.Get(0).(func(string) uint64); ok {
 		r0 = rf(promptStr)
 	} else {
-		r0 = ret.Get(0).(int64)
+		r0 = ret.Get(0).(uint64)
 	}
 
 	var r1 error

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -51,7 +51,7 @@ const (
 	MaxStakeDuration = 24 * 365 * time.Hour
 	MaxStakeWeight   = 100
 	MinStakeWeight   = 1
-	DefaultWeight
+	DefaultWeight    = 20
 
 	// The absolute minimum is 25 seconds, but set to 5 minutes to allow for
 	// time to go through the command

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -46,10 +46,14 @@ const (
 	KeyDir    = "key"
 	KeySuffix = ".pk"
 
-	TimeParseLayout      = "2006-01-02 15:04:05"
-	MinStakeDuration     = 24 * 14 * time.Hour
-	MaxStakeDuration     = 24 * 365 * time.Hour
-	StakingStartLeadTime = 25 * time.Second
+	TimeParseLayout  = "2006-01-02 15:04:05"
+	MinStakeDuration = 24 * 14 * time.Hour
+	MaxStakeDuration = 24 * 365 * time.Hour
+
+	// The absolute minimum is 25 seconds, but set to 5 minutes to allow for
+	// time to go through the command
+	StakingStartLeadTime   = 5 * time.Minute
+	StakingMinimumLeadTime = 25 * time.Second
 
 	DefaultConfigFileName = ".avalanche-cli"
 	DefaultConfigFileType = "json"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -46,14 +46,14 @@ const (
 	KeyDir    = "key"
 	KeySuffix = ".pk"
 
-	TimeParseLayout  = "2006-01-02 15:04:05"
-	MinStakeDuration = 24 * 14 * time.Hour
-	MaxStakeDuration = 24 * 365 * time.Hour
-	MaxStakeWeight   = 100
-	MinStakeWeight   = 1
-	DefaultWeight    = 20
+	TimeParseLayout    = "2006-01-02 15:04:05"
+	MinStakeDuration   = 24 * 14 * time.Hour
+	MaxStakeDuration   = 24 * 365 * time.Hour
+	MaxStakeWeight     = 100
+	MinStakeWeight     = 1
+	DefaultStakeWeight = 20
 
-	// The absolute minimum is 25 seconds, but set to 5 minutes to allow for
+	// The absolute minimum is 25 seconds, but set to 1 minute to allow for
 	// time to go through the command
 	StakingStartLeadTime   = 1 * time.Minute
 	StakingMinimumLeadTime = 25 * time.Second

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -55,7 +55,7 @@ const (
 
 	// The absolute minimum is 25 seconds, but set to 5 minutes to allow for
 	// time to go through the command
-	StakingStartLeadTime   = 5 * time.Minute
+	StakingStartLeadTime   = 1 * time.Minute
 	StakingMinimumLeadTime = 25 * time.Second
 
 	DefaultConfigFileName = ".avalanche-cli"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -49,6 +49,9 @@ const (
 	TimeParseLayout  = "2006-01-02 15:04:05"
 	MinStakeDuration = 24 * 14 * time.Hour
 	MaxStakeDuration = 24 * 365 * time.Hour
+	MaxStakeWeight   = 100
+	MinStakeWeight   = 1
+	DefaultWeight
 
 	// The absolute minimum is 25 seconds, but set to 5 minutes to allow for
 	// time to go through the command

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -37,7 +37,7 @@ type Prompter interface {
 	CaptureDuration(promptStr string) (time.Duration, error)
 	CaptureDate(promptStr string) (time.Time, error)
 	CaptureNodeID(promptStr string) (ids.NodeID, error)
-	CaptureWeight(promptStr string) (uint64, error)
+	CaptureWeight(promptStr string) (int64, error)
 	CaptureUint64(promptStr string) (uint64, error)
 	CapturePChainAddress(promptStr string, network models.Network) (string, error)
 }
@@ -110,7 +110,7 @@ func validateWeight(input string) error {
 	if err != nil {
 		return err
 	}
-	if val < 1 || val > 100 {
+	if val < constants.MinStakeWeight || val > constants.MaxStakeWeight {
 		return errors.New("the weight must be an integer between 1 and 100")
 	}
 	return nil
@@ -168,7 +168,7 @@ func (*realPrompter) CaptureNodeID(promptStr string) (ids.NodeID, error) {
 	return ids.NodeIDFromString(nodeIDStr)
 }
 
-func (*realPrompter) CaptureWeight(promptStr string) (uint64, error) {
+func (*realPrompter) CaptureWeight(promptStr string) (int64, error) {
 	prompt := promptui.Prompt{
 		Label:    promptStr,
 		Validate: validateWeight,
@@ -179,7 +179,7 @@ func (*realPrompter) CaptureWeight(promptStr string) (uint64, error) {
 		return 0, err
 	}
 
-	return strconv.ParseUint(amountStr, 10, 64)
+	return strconv.ParseInt(amountStr, 10, 64)
 }
 
 func (*realPrompter) CaptureUint64(promptStr string) (uint64, error) {

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -37,7 +37,7 @@ type Prompter interface {
 	CaptureDuration(promptStr string) (time.Duration, error)
 	CaptureDate(promptStr string) (time.Time, error)
 	CaptureNodeID(promptStr string) (ids.NodeID, error)
-	CaptureWeight(promptStr string) (int64, error)
+	CaptureWeight(promptStr string) (uint64, error)
 	CaptureUint64(promptStr string) (uint64, error)
 	CapturePChainAddress(promptStr string, network models.Network) (string, error)
 }
@@ -168,7 +168,7 @@ func (*realPrompter) CaptureNodeID(promptStr string) (ids.NodeID, error) {
 	return ids.NodeIDFromString(nodeIDStr)
 }
 
-func (*realPrompter) CaptureWeight(promptStr string) (int64, error) {
+func (*realPrompter) CaptureWeight(promptStr string) (uint64, error) {
 	prompt := promptui.Prompt{
 		Label:    promptStr,
 		Validate: validateWeight,
@@ -179,7 +179,7 @@ func (*realPrompter) CaptureWeight(promptStr string) (int64, error) {
 		return 0, err
 	}
 
-	return strconv.ParseInt(amountStr, 10, 64)
+	return strconv.ParseUint(amountStr, 10, 64)
 }
 
 func (*realPrompter) CaptureUint64(promptStr string) (uint64, error) {


### PR DESCRIPTION
I reworked how `addValidator` captures fields to make it more like our `subnet create` flow. We specify default values even if not provided but also allow users to customize.

The default start time is five minutes from now. The default weight is 20 and the default duration is the validator's end time on the primary network.

Closes #142 Closes #143 Closes #132