### PR TITLE
Sanitize Paths and Fix Genesis Filepath Issue

### DIFF
--- a/cmd/subnetcmd/deploy.go
+++ b/cmd/subnetcmd/deploy.go
@@ -111,6 +111,8 @@ func deploySubnet(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	genesisPath := app.GetGenesisPath(chain)
+
 	switch network {
 	case models.Local:
 		app.Log.Debug("Deploy local")
@@ -119,7 +121,7 @@ func deploySubnet(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to load sidecar for later update: %w", err)
 		}
 		deployer := subnet.NewLocalSubnetDeployer(app)
-		subnetID, blockchainID, err := deployer.DeployToLocalNetwork(chain, chainGenesis)
+		subnetID, blockchainID, err := deployer.DeployToLocalNetwork(chain, chainGenesis, genesisPath)
 		if err != nil {
 			if deployer.BackendStartedHere() {
 				if innerErr := binutils.KillgRPCServerProcess(app); innerErr != nil {

--- a/cmd/subnetcmd/deploy.go
+++ b/cmd/subnetcmd/deploy.go
@@ -106,7 +106,10 @@ func deploySubnet(cmd *cobra.Command, args []string) error {
 	// deploy based on chosen network
 	ux.Logger.PrintToUser("Deploying %s to %s", chains, network.String())
 	chain := chains[0]
-	chainGenesis := filepath.Join(app.GetBaseDir(), fmt.Sprintf("%s_genesis.json", chain))
+	chainGenesis, err := app.LoadRawGenesis(chain)
+	if err != nil {
+		return err
+	}
 
 	switch network {
 	case models.Local:

--- a/cmd/subnetcmd/join.go
+++ b/cmd/subnetcmd/join.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -19,7 +20,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
 	"github.com/spf13/cobra"
-	"google.golang.org/appengine/user"
 )
 
 var (
@@ -321,13 +321,19 @@ take effect.`
 }
 
 func createPlugin(subnetName string, pluginDir string) (string, error) {
-	homeDir := user.Current().HomeDir
+	usr, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	homeDir := usr.HomeDir
 	if pluginDir == "~" {
 		// In case of "~", which won't be caught by the "else if"
 		pluginDir = homeDir
 	} else if strings.HasPrefix(pluginDir, "~/") {
 		pluginDir = filepath.Join(homeDir, pluginDir[2:])
 	}
+
+	fmt.Println("Plugin Dir", pluginDir)
 
 	chainVMID, err := utils.VMID(subnetName)
 	if err != nil {

--- a/cmd/subnetcmd/join.go
+++ b/cmd/subnetcmd/join.go
@@ -163,11 +163,21 @@ but until the node is whitelisted, it will not be able to validate this subnet.`
 		}
 	}
 
+	avagoConfigPath, err := sanitizePath(avagoConfigPath)
+	if err != nil {
+		return err
+	}
+
 	if pluginDir == "" {
 		pluginDir, err = app.Prompt.CaptureString("Path to your avalanchego plugin dir (likely avalanchego/build/plugins)")
 		if err != nil {
 			return err
 		}
+	}
+
+	pluginDir, err := sanitizePath(pluginDir)
+	if err != nil {
+		return err
 	}
 
 	vmPath, err := createPlugin(sc.Name, pluginDir)
@@ -321,20 +331,6 @@ take effect.`
 }
 
 func createPlugin(subnetName string, pluginDir string) (string, error) {
-	usr, err := user.Current()
-	if err != nil {
-		return "", err
-	}
-	homeDir := usr.HomeDir
-	if pluginDir == "~" {
-		// In case of "~", which won't be caught by the "else if"
-		pluginDir = homeDir
-	} else if strings.HasPrefix(pluginDir, "~/") {
-		pluginDir = filepath.Join(homeDir, pluginDir[2:])
-	}
-
-	fmt.Println("Plugin Dir", pluginDir)
-
 	chainVMID, err := utils.VMID(subnetName)
 	if err != nil {
 		return "", fmt.Errorf("failed to create VM ID from %s: %w", subnetName, err)
@@ -349,4 +345,19 @@ func createPlugin(subnetName string, pluginDir string) (string, error) {
 
 	vmPath := filepath.Join(pluginDir, chainVMID.String())
 	return vmPath, nil
+}
+
+func sanitizePath(path string) (string, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	homeDir := usr.HomeDir
+	if path == "~" {
+		// In case of "~", which won't be caught by the "else if"
+		path = homeDir
+	} else if strings.HasPrefix(path, "~/") {
+		path = filepath.Join(homeDir, path[2:])
+	}
+	return path, nil
 }

--- a/cmd/subnetcmd/join.go
+++ b/cmd/subnetcmd/join.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
 	"github.com/spf13/cobra"
+	"google.golang.org/appengine/user"
 )
 
 var (
@@ -320,6 +321,14 @@ take effect.`
 }
 
 func createPlugin(subnetName string, pluginDir string) (string, error) {
+	homeDir := user.Current().HomeDir
+	if pluginDir == "~" {
+		// In case of "~", which won't be caught by the "else if"
+		pluginDir = homeDir
+	} else if strings.HasPrefix(pluginDir, "~/") {
+		pluginDir = filepath.Join(homeDir, pluginDir[2:])
+	}
+
 	chainVMID, err := utils.VMID(subnetName)
 	if err != nil {
 		return "", fmt.Errorf("failed to create VM ID from %s: %w", subnetName, err)

--- a/cmd/subnetcmd/join.go
+++ b/cmd/subnetcmd/join.go
@@ -284,7 +284,7 @@ func editConfigFile(subnetID string, networkID string, configFile string) error 
 	if err != nil {
 		return fmt.Errorf("failed to pack JSON to bytes for the config file: %w", err)
 	}
-	if err := os.WriteFile(avagoConfigPath, writeBytes, constants.DefaultPerms755); err != nil {
+	if err := os.WriteFile(configFile, writeBytes, constants.DefaultPerms755); err != nil {
 		return fmt.Errorf("failed to write JSON config file, check permissions? %w", err)
 	}
 	msg := `The config file has been edited. To use it, make sure to start the node with the '--config-file' option, e.g.

--- a/pkg/subnet/local.go
+++ b/pkg/subnet/local.go
@@ -66,7 +66,7 @@ type setDefaultSnapshotFunc func(string, bool) error
 // DeployToLocalNetwork does the heavy lifting:
 // * it checks the gRPC is running, if not, it starts it
 // * kicks off the actual deployment
-func (d *LocalSubnetDeployer) DeployToLocalNetwork(chain string, chainGenesis string) (ids.ID, ids.ID, error) {
+func (d *LocalSubnetDeployer) DeployToLocalNetwork(chain string, chainGenesis []byte) (ids.ID, ids.ID, error) {
 	if err := d.StartServer(); err != nil {
 		return ids.Empty, ids.Empty, err
 	}
@@ -105,7 +105,7 @@ func (d *LocalSubnetDeployer) BackendStartedHere() bool {
 // - deploy a new blockchain for the given VM ID, genesis, and available subnet ID
 // - waits completion of operation
 // - show status
-func (d *LocalSubnetDeployer) doDeploy(chain string, chainGenesis string) (ids.ID, ids.ID, error) {
+func (d *LocalSubnetDeployer) doDeploy(chain string, chainGenesis []byte) (ids.ID, ids.ID, error) {
 	avalancheGoBinPath, pluginDir, err := d.SetupLocalEnv()
 	if err != nil {
 		return ids.Empty, ids.Empty, err
@@ -117,15 +117,10 @@ func (d *LocalSubnetDeployer) doDeploy(chain string, chainGenesis string) (ids.I
 	}
 	defer cli.Close()
 
-	exists, err := storage.FileExists(chainGenesis)
-	if !exists || err != nil {
-		return ids.Empty, ids.Empty, fmt.Errorf(
-			"evaluated chain genesis file to be at %s but it does not seem to exist", chainGenesis)
-	}
-
 	// we need the chainID just later, but it would be ugly to fail the whole deployment
 	// for a JSON unmarshalling error, so let's do it here already
-	genesis, err := getGenesis(chainGenesis)
+	var genesis core.Genesis
+	err = json.Unmarshal(chainGenesis, &genesis)
 	if err != nil {
 		return ids.Empty, ids.Empty, fmt.Errorf("failed to unpack chain ID from genesis: %w", err)
 	}
@@ -188,12 +183,14 @@ func (d *LocalSubnetDeployer) doDeploy(chain string, chainGenesis string) (ids.I
 	}
 	subnetIDStr := subnetIDs[numBlockchains%len(subnetIDs)]
 
+	genesisStr := string(chainGenesis)
+
 	// create a new blockchain on the already started network, associated to
 	// the given VM ID, genesis, and available subnet ID
 	blockchainSpecs := []*rpcpb.BlockchainSpec{
 		{
 			VmName:   chain,
-			Genesis:  chainGenesis,
+			Genesis:  genesisStr,
 			SubnetId: &subnetIDStr,
 		},
 	}

--- a/pkg/subnet/local.go
+++ b/pkg/subnet/local.go
@@ -457,22 +457,6 @@ func (d *LocalSubnetDeployer) installNeededPlugins(chainVMID ids.ID, clusterInfo
 	return nil
 }
 
-// getGenesis extracts the chain genesis from the provided genesis file
-// we don't need to check the existence of the file as we already did before
-// TODO: We should probably store this in some global object when asking the user so we don't need
-// to unpack this here anymore. The sidecar seems the best candidate
-func getGenesis(genesisFile string) (core.Genesis, error) {
-	var genesis core.Genesis
-	genBytes, err := os.ReadFile(genesisFile)
-	if err != nil {
-		return genesis, err
-	}
-	if err := json.Unmarshal(genBytes, &genesis); err != nil {
-		return genesis, err
-	}
-	return genesis, nil
-}
-
 // Initialize default snapshot with bootstrap snapshot archive
 // If force flag is set to true, overwrite the default snapshot if it exists
 func SetDefaultSnapshot(snapshotsDir string, force bool) error {

--- a/pkg/subnet/local.go
+++ b/pkg/subnet/local.go
@@ -66,11 +66,11 @@ type setDefaultSnapshotFunc func(string, bool) error
 // DeployToLocalNetwork does the heavy lifting:
 // * it checks the gRPC is running, if not, it starts it
 // * kicks off the actual deployment
-func (d *LocalSubnetDeployer) DeployToLocalNetwork(chain string, chainGenesis []byte) (ids.ID, ids.ID, error) {
+func (d *LocalSubnetDeployer) DeployToLocalNetwork(chain string, chainGenesis []byte, genesisPath string) (ids.ID, ids.ID, error) {
 	if err := d.StartServer(); err != nil {
 		return ids.Empty, ids.Empty, err
 	}
-	return d.doDeploy(chain, chainGenesis)
+	return d.doDeploy(chain, chainGenesis, genesisPath)
 }
 
 func (d *LocalSubnetDeployer) StartServer() error {
@@ -105,7 +105,7 @@ func (d *LocalSubnetDeployer) BackendStartedHere() bool {
 // - deploy a new blockchain for the given VM ID, genesis, and available subnet ID
 // - waits completion of operation
 // - show status
-func (d *LocalSubnetDeployer) doDeploy(chain string, chainGenesis []byte) (ids.ID, ids.ID, error) {
+func (d *LocalSubnetDeployer) doDeploy(chain string, chainGenesis []byte, genesisPath string) (ids.ID, ids.ID, error) {
 	avalancheGoBinPath, pluginDir, err := d.SetupLocalEnv()
 	if err != nil {
 		return ids.Empty, ids.Empty, err
@@ -183,14 +183,12 @@ func (d *LocalSubnetDeployer) doDeploy(chain string, chainGenesis []byte) (ids.I
 	}
 	subnetIDStr := subnetIDs[numBlockchains%len(subnetIDs)]
 
-	genesisStr := string(chainGenesis)
-
 	// create a new blockchain on the already started network, associated to
 	// the given VM ID, genesis, and available subnet ID
 	blockchainSpecs := []*rpcpb.BlockchainSpec{
 		{
 			VmName:   chain,
-			Genesis:  genesisStr,
+			Genesis:  genesisPath,
 			SubnetId: &subnetIDStr,
 		},
 	}

--- a/pkg/subnet/local_test.go
+++ b/pkg/subnet/local_test.go
@@ -117,7 +117,7 @@ func TestDeployToLocal(t *testing.T) {
 	err = os.WriteFile(testGenesis.Name(), []byte(genesis), constants.DefaultPerms755)
 	assert.NoError(err)
 	// test actual deploy
-	s, b, err := testDeployer.DeployToLocalNetwork(testVMName, testGenesis.Name())
+	s, b, err := testDeployer.DeployToLocalNetwork(testVMName, []byte(genesis), testGenesis.Name())
 	assert.NoError(err)
 	assert.Equal(testSubnetID2, s.String())
 	assert.Equal(testBlockChainID2, b.String())

--- a/pkg/subnet/public.go
+++ b/pkg/subnet/public.go
@@ -60,7 +60,7 @@ func (d *PublicDeployer) AddValidator(subnet ids.ID, nodeID ids.NodeID, weight u
 	return nil
 }
 
-func (d *PublicDeployer) Deploy(controlKeys []string, threshold uint32, chain, genesis string) (ids.ID, ids.ID, error) {
+func (d *PublicDeployer) Deploy(controlKeys []string, threshold uint32, chain string, genesis []byte) (ids.ID, ids.ID, error) {
 	wallet, api, err := d.loadWallet()
 	if err != nil {
 		return ids.Empty, ids.Empty, err
@@ -76,7 +76,7 @@ func (d *PublicDeployer) Deploy(controlKeys []string, threshold uint32, chain, g
 	}
 	ux.Logger.PrintToUser("Subnet has been created with ID: %s. Now creating blockchain...", subnetID.String())
 
-	blockchainID, err := d.createBlockchainTx(chain, vmID, subnetID, []byte(genesis), wallet)
+	blockchainID, err := d.createBlockchainTx(chain, vmID, subnetID, genesis, wallet)
 	if err != nil {
 		return ids.Empty, ids.Empty, err
 	}


### PR DESCRIPTION
Sanitize paths to allow for using `~/` in your path.

Also fixes an issue where we are passing the genesis filepath in the create blockchain tx instead of the actual genesis bytes.

Closes #149 Closes #151