### PR TITLE
Added custom VM create flow

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -109,6 +109,13 @@ func setupEnv() (string, error) {
 		os.Exit(1)
 	}
 
+	// Create custom vm dir if it doesn't exist
+	vmDir := filepath.Join(baseDir, constants.AvalancheCliBinDir, constants.CustomVMDir)
+	if err = os.MkdirAll(vmDir, os.ModePerm); err != nil {
+		fmt.Printf("failed creating the vm dir %s: %s\n", vmDir, err)
+		os.Exit(1)
+	}
+
 	return baseDir, nil
 }
 

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -159,7 +159,7 @@ func (app *Avalanche) CreateSidecar(sc *models.Sidecar) error {
 	// but better safe than sorry
 	exists, err := app.ChainIDExists(sc.ChainID)
 	if err != nil {
-		return fmt.Errorf("unable to determine if chainID is unique: %s", err)
+		return fmt.Errorf("unable to determine if chainID is unique: %w", err)
 	}
 	if exists {
 		return errChainIDExists

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -60,4 +60,6 @@ const (
 
 	DefaultConfigFileName = ".avalanche-cli"
 	DefaultConfigFileType = "json"
+
+	CustomVMDir = "vms"
 )

--- a/tests/e2e/commands/subnet.go
+++ b/tests/e2e/commands/subnet.go
@@ -23,7 +23,7 @@ func CreateSubnetConfig(subnetName string, genesisPath string) {
 		CLIBinary,
 		SubnetCmd,
 		"create",
-		"--file",
+		"--genesis",
 		genesisPath,
 		"--evm",
 		subnetName,


### PR DESCRIPTION
I refactored our `subnet create` flow to accommodate custom VMs. Custom VMs accept a genesis and copy the VM binary to our `~/.avalanche-cli/bin/vms` directory.

Closes #154 