### PR TITLE
Add ledger/mainnet support to public subnet operations

### DIFF
--- a/cmd/subnetcmd/addValidator.go
+++ b/cmd/subnetcmd/addValidator.go
@@ -159,17 +159,9 @@ func addValidator(cmd *cobra.Command, args []string) error {
 	       ux.Logger.PrintToUser("Please provide extended public key on the ledger device")
 	   } else {
 	*/
-	var networkID uint32
-	switch network {
-	case models.Fuji:
-		networkID = avago_constants.FujiID
-	case models.Mainnet:
-		networkID = avago_constants.MainnetID
-	case models.Local:
-		// used for E2E testing of public related paths
-		networkID = constants.LocalNetworkID
-	default:
-		return fmt.Errorf("unsupported public network")
+	networkID, err := network.NetworkID()
+	if err != nil {
+		return err
 	}
 	sf, err := key.LoadSoft(networkID, app.GetKeyPath(keyName))
 	if err != nil {
@@ -177,7 +169,7 @@ func addValidator(cmd *cobra.Command, args []string) error {
 	}
 	kc = sf.KeyChain()
 	// }
-	deployer := subnet.NewPublicDeployer(app, kc, network)
+	deployer := subnet.NewPublicDeployer(app, false, kc, network)
 	return deployer.AddValidator(subnetID, nodeID, weight, start, duration)
 }
 

--- a/cmd/subnetcmd/addValidator.go
+++ b/cmd/subnetcmd/addValidator.go
@@ -144,7 +144,7 @@ func addValidator(cmd *cobra.Command, args []string) error {
 	ux.Logger.PrintToUser("End time: %s", start.Add(duration).Format(constants.TimeParseLayout))
 	ux.Logger.PrintToUser("Weight: %d", weight)
 	ux.Logger.PrintToUser("Inputs complete, issuing transaction to add the provided validator information...")
-	deployer := subnet.NewPublicDeployer(app, app.GetKeyPath(keyName), network)
+	deployer := subnet.NewPublicDeployer(app, false, app.GetKeyPath(keyName), network)
 	return deployer.AddValidator(subnetID, nodeID, weight, start, duration)
 }
 

--- a/cmd/subnetcmd/deploy.go
+++ b/cmd/subnetcmd/deploy.go
@@ -176,6 +176,8 @@ func deploySubnet(cmd *cobra.Command, args []string) error {
 
 	genesisPath := app.GetGenesisPath(chain)
 
+	useLedger := false
+
 	switch network {
 	case models.Local:
 		app.Log.Debug("Deploy local")
@@ -232,8 +234,9 @@ func deploySubnet(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-	case models.Mainnet: // in the future, just make the switch pass, fuij/main implementation is the same (for now)
-		return errors.New("deploying to mainnet is not yet supported") // for now not supported
+	case models.Mainnet:
+		useLedger = true
+
 	default:
 		return errors.New("not implemented")
 	}
@@ -269,7 +272,7 @@ func deploySubnet(cmd *cobra.Command, args []string) error {
 	}
 
 	// deploy to public network
-	deployer := subnet.NewPublicDeployer(app, app.GetKeyPath(keyName), network)
+	deployer := subnet.NewPublicDeployer(app, useLedger, app.GetKeyPath(keyName), network)
 	subnetID, blockchainID, err := deployer.Deploy(controlKeys, threshold, chain, chainGenesis)
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,13 @@ module github.com/ava-labs/avalanche-cli
 
 go 1.18
 
+replace github.com/ava-labs/avalanchego => ../avalanchego-internal/
+
+replace github.com/zondax/ledger-go => ../ledger-go/
+
 require (
 	github.com/ava-labs/apm v0.0.4
+	github.com/ava-labs/avalanche-ledger-go v0.0.7-0.20221005140653-03a39d34a581
 	github.com/ava-labs/avalanche-network-runner v1.2.4-0.20221003163451-7d3d1bfa924f
 	github.com/ava-labs/avalanchego v1.8.6
 	github.com/ava-labs/coreth v0.10.0-rc.1
@@ -30,6 +35,7 @@ require (
 )
 
 require (
+	github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20220517143526-88bb52951d5b // indirect
@@ -109,6 +115,7 @@ require (
 	github.com/otiai10/copy v1.7.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.13.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
@@ -131,6 +138,8 @@ require (
 	github.com/tyler-smith/go-bip39 v1.0.2 // indirect
 	github.com/xanzy/ssh-agent v0.3.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
+	github.com/zondax/hid v0.9.0 // indirect
+	github.com/zondax/ledger-go v0.12.2 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec h1:1Qb69mGp/UtRPn422BH4/Y4Q3SLUrD9KHuDkm8iodFc=
+github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec/go.mod h1:CD8UlnlLDiqb36L110uqiP2iSflVjx9g/3U9hCI4q2U=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
@@ -68,10 +70,10 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/ava-labs/apm v0.0.4 h1:0IUwxCyvqwr2sbbEKhSI7VzpPG3Z+e180ulJwNiKkBk=
 github.com/ava-labs/apm v0.0.4/go.mod h1:4MNcyEvWajJm2JnezC7vgHuA220ppoQYOMh5vM+iH4Q=
+github.com/ava-labs/avalanche-ledger-go v0.0.7-0.20221005140653-03a39d34a581 h1:YQxMjM1yeerg+so/rtdaQNfIiROI2ir07SDcH/YyMvE=
+github.com/ava-labs/avalanche-ledger-go v0.0.7-0.20221005140653-03a39d34a581/go.mod h1:TU0U64JTMF1uCr7aS4BOrDY1bnHh6i5FenFXTsssm/c=
 github.com/ava-labs/avalanche-network-runner v1.2.4-0.20221003163451-7d3d1bfa924f h1:9mcWnEt0J51SGUQ9q/bcg7C7iAJc3C9XRNh87TRQdyI=
 github.com/ava-labs/avalanche-network-runner v1.2.4-0.20221003163451-7d3d1bfa924f/go.mod h1:itR+KLMfvHu7yeZdwHkDanOImRyG3xtsZJai3UC7sk4=
-github.com/ava-labs/avalanchego v1.8.6 h1:eYyW/m1+3o8HbhXsd6k52hcGxDTyGYfXHj7PX7fqc4A=
-github.com/ava-labs/avalanchego v1.8.6/go.mod h1:nYYiHRS6LmA+05rLVLDjaVjB3D7LZwAmBqYi0mweEgI=
 github.com/ava-labs/coreth v0.10.0-rc.1 h1:OIJmXLpKzkyBjmrbPqFEYGM+suewknNOb3iLctWluuM=
 github.com/ava-labs/coreth v0.10.0-rc.1/go.mod h1:o9MtalIgKMH3PY7Ca4GDHMziEvGPxaAtKFaLd6uJvJI=
 github.com/ava-labs/spacesvm v0.0.8 h1:up9zFc9yMvCOFCkP9F96nBACgpNDMZ9LXQjU0Ta3l4M=
@@ -530,6 +532,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPRg=
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zondax/hid v0.9.0 h1:eiT3P6vNxAEVxXMw66eZUAAnU2zD33JBkfG/EnfAKl8=
+github.com/zondax/hid v0.9.0/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -80,7 +80,7 @@ func WithFeeDeduct(fee uint64) OpOption {
 	}
 }
 
-func getHRP(networkID uint32) string {
+func GetHRP(networkID uint32) string {
 	switch networkID {
 	case constants.LocalID:
 		return constants.LocalHRP

--- a/pkg/key/soft_key.go
+++ b/pkg/key/soft_key.go
@@ -135,7 +135,7 @@ func NewSoft(networkID uint32, opts ...SOpOption) (*SoftKey, error) {
 	}
 
 	// Parse HRP to create valid address
-	hrp := getHRP(networkID)
+	hrp := GetHRP(networkID)
 	m.pAddr, err = address.Format("P", hrp, m.privKey.PublicKey().Address().Bytes())
 	if err != nil {
 		return nil, err

--- a/pkg/models/network.go
+++ b/pkg/models/network.go
@@ -39,7 +39,7 @@ func (s Network) NetworkID() (uint32, error) {
 	case Local:
 		return constants.LocalNetworkID, nil
 	}
-	return 0, fmt.Errorf("unsupported public network")
+	return 0, fmt.Errorf("unsupported network")
 }
 
 func NetworkFromString(s string) Network {

--- a/pkg/models/network.go
+++ b/pkg/models/network.go
@@ -2,7 +2,12 @@
 // See the file LICENSE for licensing terms.
 package models
 
-import "github.com/ava-labs/avalanchego/utils/constants"
+import (
+	"fmt"
+
+	"github.com/ava-labs/avalanche-cli/pkg/constants"
+	avago_constants "github.com/ava-labs/avalanchego/utils/constants"
+)
 
 type Network int64
 
@@ -25,16 +30,16 @@ func (s Network) String() string {
 	return "Unknown Network"
 }
 
-func (s Network) NetworkID() uint32 {
+func (s Network) NetworkID() (uint32, error) {
 	switch s {
 	case Mainnet:
-		return constants.MainnetID
+		return avago_constants.MainnetID, nil
 	case Fuji:
-		return constants.FujiID
+		return avago_constants.FujiID, nil
 	case Local:
-		return 0
+		return constants.LocalNetworkID, nil
 	}
-	return 0
+	return 0, fmt.Errorf("unsupported public network")
 }
 
 func NetworkFromString(s string) Network {

--- a/pkg/subnet/public.go
+++ b/pkg/subnet/public.go
@@ -57,7 +57,7 @@ func (d *PublicDeployer) AddValidator(subnet ids.ID, nodeID ids.NodeID, weight u
 		Subnet: subnet,
 	}
 	if d.usingLedger {
-		ux.Logger.PrintToUser("*** Please sign hash on the ledger device (add validator transaction) *** ")
+		ux.Logger.PrintToUser("*** Please sign add validator hash on the ledger device *** ")
 	}
 	id, err := wallet.P().IssueAddSubnetValidatorTx(validator)
 	if err != nil {
@@ -132,7 +132,7 @@ func (d *PublicDeployer) createBlockchainTx(chainName string, vmID, subnetID ids
 	options := []common.Option{}
 	fxIDs := make([]ids.ID, 0)
 	if d.usingLedger {
-		ux.Logger.PrintToUser("*** Please sign hash on the ledger device (create blockchain transaction) *** ")
+		ux.Logger.PrintToUser("*** Please sign blockchain creation hash on the ledger device *** ")
 	}
 	return wallet.P().IssueCreateChainTx(subnetID, genesis, vmID, fxIDs, chainName, options...)
 }
@@ -153,7 +153,7 @@ func (d *PublicDeployer) createSubnetTx(controlKeys []string, threshold uint32, 
 	}
 	opts := []common.Option{}
 	if d.usingLedger {
-		ux.Logger.PrintToUser("*** Please sign hash on the ledger device (create subnet transaction) *** ")
+		ux.Logger.PrintToUser("*** Please sign subnet creation hash on the ledger device *** ")
 	}
 	return wallet.P().IssueCreateSubnetTx(owners, opts...)
 }

--- a/pkg/subnet/public.go
+++ b/pkg/subnet/public.go
@@ -26,15 +26,17 @@ import (
 
 type PublicDeployer struct {
 	LocalDeployer
+	useLedger   bool
 	privKeyPath string
 	network     models.Network
 	app         *application.Avalanche
 }
 
-func NewPublicDeployer(app *application.Avalanche, privKeyPath string, network models.Network) *PublicDeployer {
+func NewPublicDeployer(app *application.Avalanche, useLedger bool, privKeyPath string, network models.Network) *PublicDeployer {
 	return &PublicDeployer{
 		LocalDeployer: *NewLocalDeployer(app, "", ""),
 		app:           app,
+		useLedger:     useLedger,
 		privKeyPath:   privKeyPath,
 		network:       network,
 	}
@@ -111,6 +113,9 @@ func (d *PublicDeployer) loadWallet(preloadTxs ...ids.ID) (primary.Wallet, error
 	case models.Fuji:
 		api = constants.FujiAPIEndpoint
 		networkID = avago_constants.FujiID
+	case models.Mainnet:
+		api = constants.MainnetAPIEndpoint
+		networkID = avago_constants.MainnetID
 	case models.Local:
 		// used for E2E testing of public related paths
 		api = constants.LocalAPIEndpoint
@@ -164,6 +169,8 @@ func (d *PublicDeployer) validateWalletIsSubnetOwner(controlKeys []string, thres
 	switch d.network {
 	case models.Fuji:
 		networkID = avago_constants.FujiID
+	case models.Mainnet:
+		networkID = avago_constants.MainnetID
 	case models.Local:
 		// used for E2E testing of public related paths
 		networkID = constants.LocalNetworkID


### PR DESCRIPTION
Due to go.mod replacements, lint/test/e2e will only work on local machine. But the PR is open to enable review.

# Deps
go.mod replacements:
- put github.com/ava-labs/avalanchego-internal@ledger into ../avalanchego-internal/
- put github.com/felipemadero/ledger-go@fix-device-lookup-on-linux into ../ledger-go/
anr:
- use github.com/ava-labs/avalanche-network-runner@ledger-tests

# Usage
anr: (both commands will ask for ledger interaction)
- go run main.go server
- go run main.go control start --avalanchego-path AVALANCHEGO_PATH

cli: (commands will ask for ledger interaction if needed) (choose "Use creation key only" on subnet deploy) (change start-time to a future one relative to command execution) 
- export SIMULATE_PUBLIC_NETWORK=true
- go run main.go subnet deploy SUBNET_NAME --mainnet --threshold 1 
- go run main.go subnet addValidator SUBNET_NAME --mainnet --nodeID NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg --weight 20 --start-time "2022-10-19 00:00:00" --staking-period 24h