### PR TITLE
repeat yarn install a number of times

### DIFF
--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Yarn install
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 2
+          timeout_minutes: 10
           max_attempts: 3
           retry_on: error
           command: yarn --cwd ./tests/e2e/hardhat

--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -64,8 +64,12 @@ jobs:
         with:
           node-version: '14.x'
       - name: Yarn install
-        run: yarn
-        working-directory: ./tests/e2e/hardhat
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 2
+          max_attempts: 3
+          retry_on: error
+          command: yarn --cwd ./tests/e2e/hardhat
       - name: Run e2e tests
         shell: bash
         run: GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} scripts/run.e2e.sh


### PR DESCRIPTION
Closes https://github.com/ava-labs/avalanche-cli/issues/395
Workaround for yarn issues at CI on macos. Refs:
- https://github.com/yarnpkg/yarn/issues/8242
- https://github.com/actions/runner-images/issues/4896
Other option is to use yarn v2
