### PR TITLE
Import deployed subnets from a running network into avalanche-cli

### DIFF
--- a/cmd/subnetcmd/import_from_api.go
+++ b/cmd/subnetcmd/import_from_api.go
@@ -234,7 +234,7 @@ func importRunningSubnet(cmd *cobra.Command, args []string) error {
 		}
 		sc.VMVersion, err = app.Prompt.CaptureList("Pick the version for this VM", versions)
 	case models.CustomVM:
-		// versions,err = prompts.Capt
+		return fmt.Errorf("importing custom VMs is not yet implemented, but will be available soon")
 	default:
 		return fmt.Errorf("unexpected VM type: %v", vmType)
 	}

--- a/cmd/subnetcmd/import_from_api.go
+++ b/cmd/subnetcmd/import_from_api.go
@@ -1,0 +1,246 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+package subnetcmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/ava-labs/avalanche-cli/pkg/constants"
+	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	"github.com/ava-labs/avalanchego/api/info"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/rpc"
+	"github.com/ava-labs/avalanchego/vms/platformvm"
+	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/spacesvm/vm"
+	"github.com/spf13/cobra"
+)
+
+var (
+	genesisFilePath string
+	subnetIDstr     string
+	nodeURL         string
+)
+
+// avalanche subnet import
+func newImportFromNetworkCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "import-running [subnetPath]",
+		Short:        "Import an existing subnet config from running subnets",
+		RunE:         importRunningSubnet,
+		SilenceUsage: true,
+		Args:         cobra.MaximumNArgs(1),
+		Long: `The subnet import command will import a subnet configuration from a running network.
+
+The genesis file should be available from the disk for this to work. 
+By default, an imported subnet will not overwrite an existing subnet with the same name. 
+To allow overwrites, provide the --force flag.`,
+	}
+
+	cmd.Flags().StringVar(&nodeURL, "node-url", "", "[optional] URL of an already running subnet validator")
+
+	cmd.Flags().BoolVar(&deployTestnet, "fuji", false, "import from `fuji` (alias for `testnet`)")
+	cmd.Flags().BoolVar(&deployTestnet, "testnet", false, "import from `testnet` (alias for `fuji`)")
+	cmd.Flags().BoolVar(&deployMainnet, "mainnet", false, "import from `mainnet`")
+	cmd.Flags().BoolVar(&useSubnetEvm, "evm", false, "import a subnet-evm")
+	cmd.Flags().BoolVar(&useSpacesVM, "spacesvm", false, "use the SpacesVM as the base template")
+	cmd.Flags().BoolVar(&useCustom, "custom", false, "use a custom VM template")
+	cmd.Flags().BoolVarP(
+		&overwriteImport,
+		"force",
+		"f",
+		false,
+		"overwrite the existing configuration if one exists",
+	)
+	cmd.Flags().StringVar(
+		&genesisFilePath,
+		"genesis-file-path",
+		"",
+		"path to the genesis file",
+	)
+	cmd.Flags().StringVar(
+		&subnetIDstr,
+		"subnet-id",
+		"",
+		"the subnet ID",
+	)
+	return cmd
+}
+
+func importRunningSubnet(cmd *cobra.Command, args []string) error {
+	var err error
+
+	var network models.Network
+	switch {
+	case deployTestnet:
+		network = models.Fuji
+	case deployMainnet:
+		network = models.Mainnet
+	}
+
+	if network == models.Undefined {
+		networkStr, err := app.Prompt.CaptureList(
+			"Choose a network to import from",
+			[]string{models.Fuji.String(), models.Mainnet.String()},
+		)
+		if err != nil {
+			return err
+		}
+		network = models.NetworkFromString(networkStr)
+	}
+
+	if genesisFilePath == "" {
+		genesisFilePath, err = app.Prompt.CaptureExistingFilepath("Provide the path to the genesis file")
+		if err != nil {
+			return err
+		}
+	}
+
+	var reply *info.GetNodeVersionReply
+
+	if nodeURL == "" {
+		yes, err := app.Prompt.CaptureYesNo("Have nodes already been deployed to this subnet?")
+		if err != nil {
+			return err
+		}
+		if yes {
+			nodeURL, err = app.Prompt.CaptureString(
+				"Please provide an API URL of such a node so we can query its VM version (e.g. 111.22.33.44:5555)")
+			if err != nil {
+				return err
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), constants.RequestTimeout)
+			defer cancel()
+			infoAPI := info.NewClient(nodeURL)
+			options := []rpc.Option{}
+			reply, err = infoAPI.GetNodeVersion(ctx, options...)
+			if err != nil {
+				return fmt.Errorf("Failed to query node - is it running and reachable? %w", err)
+			}
+		}
+
+	}
+
+	var subnetID ids.ID
+	if subnetIDstr == "" {
+		subnetID, err = app.Prompt.CaptureID("What is the ID of the subnet?")
+		if err != nil {
+			return err
+		}
+	} else {
+		subnetID, err = ids.FromString(subnetIDstr)
+		if err != nil {
+			return err
+		}
+	}
+
+	var pubAPI string
+	switch network {
+	case models.Fuji:
+		pubAPI = constants.FujiAPIEndpoint
+	case models.Mainnet:
+		pubAPI = constants.MainnetAPIEndpoint
+	}
+	client := platformvm.NewClient(pubAPI)
+	ctx, cancel := context.WithTimeout(context.Background(), constants.RequestTimeout)
+	defer cancel()
+	options := []rpc.Option{}
+
+	ux.Logger.PrintToUser("Getting information from the %s network...", network.String())
+
+	chains, err := client.GetBlockchains(ctx, options...)
+	if err != nil {
+		return err
+	}
+
+	var (
+		blockchainID, vmID ids.ID
+		subnetName         string
+	)
+
+	for _, ch := range chains {
+		// NOTE: This supports only one chain per subnet
+		if ch.SubnetID == subnetID {
+			blockchainID = ch.ID
+			vmID = ch.VMID
+			subnetName = vm.Name
+			break
+		}
+	}
+
+	if blockchainID == ids.Empty || vmID == ids.Empty {
+		return fmt.Errorf("subnet ID %s not found on this network!", subnetIDstr)
+	}
+
+	ux.Logger.PrintToUser("Retrieved information. BlockchainID: %s, Name: %s, VMID: %s",
+		blockchainID.String(),
+		subnetName,
+		vmID.String(),
+	)
+	// TODO: it's probably possible to deploy VMs with the same name on a public network
+	// In this case, an import could clash because the tool supports unique names only
+
+	genBytes, err := os.ReadFile(genesisFilePath)
+	if err != nil {
+		return err
+	}
+
+	if err = app.WriteGenesisFile(subnetName, genBytes); err != nil {
+		return err
+	}
+
+	vmType := getVMFromFlag()
+	if vmType == "" {
+		subnetTypeStr, err := app.Prompt.CaptureList(
+			"What's this VM's type?",
+			[]string{models.SubnetEvm, models.SpacesVM, models.CustomVM},
+		)
+		if err != nil {
+			return err
+		}
+		vmType = models.VMTypeFromString(subnetTypeStr)
+	}
+
+	sc := &models.Sidecar{
+		Name:            subnetName,
+		VM:              vmType,
+		ImportedFromAPM: false,
+		Networks: map[string]models.NetworkData{
+			network.String(): {
+				SubnetID:     subnetID,
+				BlockchainID: blockchainID,
+			},
+		},
+		Subnet:  subnetName,
+		Version: constants.SidecarVersion,
+	}
+
+	if vmType == models.SubnetEvm {
+		var genesis core.Genesis
+		if err := json.Unmarshal(genBytes, &genesis); err != nil {
+			return err
+		}
+		sc.ChainID = genesis.Config.ChainID.String()
+		/*
+			  // TODO: can we get this one?
+				TokenName       string
+		*/
+	}
+
+	vmIDstr := vmID.String()
+	sc.ImportedVMID = vmIDstr // TODO: Is this correct?
+	if reply != nil {
+		for _, v := range reply.VMVersions {
+			if v == vmIDstr {
+				sc.VMVersion = v
+			}
+		}
+		sc.RPCVersion = int(reply.RPCProtocolVersion)
+	}
+
+	return app.CreateSidecar(sc)
+}

--- a/cmd/subnetcmd/subnet.go
+++ b/cmd/subnetcmd/subnet.go
@@ -55,5 +55,7 @@ manage your subnet configurations and live deployments.`,
 	cmd.AddCommand(newStatsCmd())
 	// subnet configure
 	cmd.AddCommand(newConfigureCmd())
+	// subnet import-running
+	cmd.AddCommand(newImportFromNetworkCmd())
 	return cmd
 }

--- a/pkg/application/downloader.go
+++ b/pkg/application/downloader.go
@@ -22,6 +22,7 @@ const githubVersionTagName = "tag_name"
 type Downloader interface {
 	Download(url string) ([]byte, error)
 	GetLatestReleaseVersion(releaseURL string) (string, error)
+	GetAllReleasesForRepo(org, repo string) ([]string, error)
 }
 
 type downloader struct{}
@@ -43,13 +44,40 @@ func (downloader) Download(url string) ([]byte, error) {
 	return io.ReadAll(resp.Body)
 }
 
-// GetLatestReleaseVersion returns the latest available version from github
-func (downloader) GetLatestReleaseVersion(releaseURL string) (string, error) {
-	// TODO: Question if there is a less error prone (= simpler) way to install latest avalanchego
-	// Maybe the binary package manager should also allow the actual avalanchego binary for download
-	request, err := http.NewRequest("GET", releaseURL, nil)
+func (d downloader) GetAllReleasesForRepo(org, repo string) ([]string, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases", org, repo)
+	body, err := d.doAPIRequest(url)
 	if err != nil {
-		return "", fmt.Errorf("failed to create request for latest version from %s: %w", releaseURL, err)
+		return nil, err
+	}
+	defer body.Close()
+
+	jsonBytes, err := io.ReadAll(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest binary version from %s: %w", url, err)
+	}
+
+	var releaseArr []map[string]interface{}
+	if err := json.Unmarshal(jsonBytes, &releaseArr); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal binary json version string: %w", err)
+	}
+
+	releases := make([]string, len(releaseArr))
+	for i, r := range releaseArr {
+		version := r[githubVersionTagName].(string)
+		if !semver.IsValid(version) {
+			return nil, fmt.Errorf("invalid version string: %s", version)
+		}
+		releases[i] = version
+	}
+
+	return releases, nil
+}
+
+func (downloader) doAPIRequest(url string) (io.ReadCloser, error) {
+	request, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for latest version from %s: %w", url, err)
 	}
 	token := os.Getenv(constants.GithubAPITokenEnvVarName)
 	if token != "" {
@@ -58,14 +86,25 @@ func (downloader) GetLatestReleaseVersion(releaseURL string) (string, error) {
 	}
 	resp, err := http.DefaultClient.Do(request)
 	if err != nil {
-		return "", fmt.Errorf("failed to get latest version from %s: %w", releaseURL, err)
+		return nil, fmt.Errorf("failed to get latest version from %s: %w", url, err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to get latest version from %s: unexpected http status code: %d", releaseURL, resp.StatusCode)
+		return nil, fmt.Errorf("failed to get latest version from %s: unexpected http status code: %d", url, resp.StatusCode)
 	}
-	defer resp.Body.Close()
+	return resp.Body, nil
+}
 
-	jsonBytes, err := io.ReadAll(resp.Body)
+// GetLatestReleaseVersion returns the latest available version from github
+func (d downloader) GetLatestReleaseVersion(releaseURL string) (string, error) {
+	// TODO: Question if there is a less error prone (= simpler) way to install latest avalanchego
+	// Maybe the binary package manager should also allow the actual avalanchego binary for download
+	body, err := d.doAPIRequest(releaseURL)
+	if err != nil {
+		return "", err
+	}
+	defer body.Close()
+
+	jsonBytes, err := io.ReadAll(body)
 	if err != nil {
 		return "", fmt.Errorf("failed to get latest binary version from %s: %w", releaseURL, err)
 	}

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -55,6 +55,7 @@ type Prompter interface {
 	CaptureDuration(promptStr string) (time.Duration, error)
 	CaptureDate(promptStr string) (time.Time, error)
 	CaptureNodeID(promptStr string) (ids.NodeID, error)
+	CaptureID(promptStr string) (ids.ID, error)
 	CaptureWeight(promptStr string) (uint64, error)
 	CaptureUint64(promptStr string) (uint64, error)
 	CapturePChainAddress(promptStr string, network models.Network) (string, error)
@@ -107,6 +108,11 @@ func validateTime(input string) error {
 	if t.Before(time.Now().Add(constants.StakingStartLeadTime)) {
 		return fmt.Errorf("time should be at least start from now + %s", constants.StakingStartLeadTime)
 	}
+	return err
+}
+
+func validateID(input string) error {
+	_, err := ids.FromString(input)
 	return err
 }
 
@@ -266,6 +272,19 @@ func (*realPrompter) CaptureDate(promptStr string) (time.Time, error) {
 	}
 
 	return time.Parse(constants.TimeParseLayout, timeStr)
+}
+
+func (*realPrompter) CaptureID(promptStr string) (ids.ID, error) {
+	prompt := promptui.Prompt{
+		Label:    promptStr,
+		Validate: validateID,
+	}
+
+	IDStr, err := prompt.Run()
+	if err != nil {
+		return ids.Empty, err
+	}
+	return ids.FromString(IDStr)
 }
 
 func (*realPrompter) CaptureNodeID(promptStr string) (ids.NodeID, error) {

--- a/pkg/vm/compatibility.go
+++ b/pkg/vm/compatibility.go
@@ -6,6 +6,7 @@ package vm
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 
 	"github.com/ava-labs/avalanche-cli/pkg/application"
@@ -57,6 +58,9 @@ func GetLatestAvalancheGoByProtocolVersion(app *application.Avalanche, rpcVersio
 	if err = json.Unmarshal(compatibilityBytes, &parsedCompat); err != nil {
 		return "", err
 	}
+
+	fmt.Println(parsedCompat)
+	fmt.Println(rpcVersion)
 
 	eligibleVersions, ok := parsedCompat[strconv.Itoa(rpcVersion)]
 	if !ok {

--- a/pkg/vm/compatibility.go
+++ b/pkg/vm/compatibility.go
@@ -6,7 +6,6 @@ package vm
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 
 	"github.com/ava-labs/avalanche-cli/pkg/application"
@@ -58,9 +57,6 @@ func GetLatestAvalancheGoByProtocolVersion(app *application.Avalanche, rpcVersio
 	if err = json.Unmarshal(compatibilityBytes, &parsedCompat); err != nil {
 		return "", err
 	}
-
-	fmt.Println(parsedCompat)
-	fmt.Println(rpcVersion)
 
 	eligibleVersions, ok := parsedCompat[strconv.Itoa(rpcVersion)]
 	if !ok {


### PR DESCRIPTION
This PR is a first iteration allowing imports of deployed network, supporting public networks only for now.

There are a lot of possible edge cases possible, but this PR should be good to go for the standard use case where a subnet has been deployed with subnet-cli.

Custom VMs are not yet supported but will be available in the next iteration.