### PR TITLE
Don't add dependabot PRs to project

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -12,6 +12,7 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/add-to-project@v0.3.0
         with:


### PR DESCRIPTION
Dependabot pipelines are currently failing because dependabot-triggered actions can't access repo secrets. This disables the action for dependabot PRs and should allow their pipelines to pass.