### PR TITLE
Added Subnet-EVM name migration

### DIFF
--- a/cmd/subnetcmd/delete.go
+++ b/cmd/subnetcmd/delete.go
@@ -4,9 +4,9 @@ package subnetcmd
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/ava-labs/avalanche-cli/pkg/models"
-	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/spf13/cobra"
 )
 
@@ -23,11 +23,12 @@ func newDeleteCmd() *cobra.Command {
 
 func deleteSubnet(cmd *cobra.Command, args []string) error {
 	// TODO sanitize this input
-	sidecarPath := app.GetSidecarPath(args[0])
-	genesisPath := app.GetGenesisPath(args[0])
-	customVMPath := app.GetCustomVMPath(args[0])
+	subnetName := args[0]
+	subnetDir := filepath.Join(app.GetSubnetDir(), subnetName)
 
-	sidecar, err := app.LoadSidecar(args[0])
+	customVMPath := app.GetCustomVMPath(subnetName)
+
+	sidecar, err := app.LoadSidecar(subnetName)
 	if err != nil {
 		return err
 	}
@@ -47,17 +48,9 @@ func deleteSubnet(cmd *cobra.Command, args []string) error {
 	// but only if no other subnet is using it.
 	// More info: https://github.com/ava-labs/avalanche-cli/issues/246
 
-	if _, err := os.Stat(genesisPath); err == nil {
+	if _, err := os.Stat(subnetDir); err == nil {
 		// exists
-		os.Remove(genesisPath)
-	} else {
-		return err
-	}
-
-	if _, err := os.Stat(sidecarPath); err == nil {
-		// exists
-		os.Remove(sidecarPath)
-		ux.Logger.PrintToUser("Deleted subnet")
+		os.RemoveAll(subnetDir)
 	} else {
 		return err
 	}

--- a/internal/migrations/README.md
+++ b/internal/migrations/README.md
@@ -1,11 +1,12 @@
 # Migrations
 
-## Why migrations
+## Why Migrations
+
 The idea is to introduce a standardized process for internal changes of the
 `Avalanche` tool which usually require scripting.
 
-By running these migrations, we don't require external scripting, 
-encapsulating different subsequent internal changes in sort of a 
+By running these migrations, we don't require external scripting,
+encapsulating different subsequent internal changes in sort of a
 managed, reproducible way which also represents its history.
 
 The concept is obviously borrowed from databases where migrations
@@ -13,11 +14,13 @@ are being applied to update database structures and its data
 to new versions of schemas and applications.
 
 ## Limitations
+
 Usually migrations have a rollback path which can be applied in case of failures.
 This tool currently does not support rollbacks.
 
-## General structure
-* The application calls all migrations implemnted when booting 
+## General Structure
+
+* The application calls all migrations implemnted when booting
 * Each migration is iterated in order (the order is "enforced" via the index in the migrations map)
 * Each migration checks itself if it needs to be applied
 * The first migration which is getting applied prints a message to the user
@@ -25,6 +28,7 @@ This tool currently does not support rollbacks.
 * If no migration ran at all, nothing is being printed
 
 ## Implementation
+
 * Migrations need to reside in `internal/migrations`
 * Each new migration should be added into a separate file in the package
 * Each new migration needs to implement a `migrationFunc`

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -29,8 +29,9 @@ func RunMigrations(app *application.Avalanche) error {
 		showMsg: true,
 		migrations: map[int]migrationFunc{
 			// add new migrations here in rising index order
-			// next one is 1
+			// next one is 2
 			0: migrateTopLevelFiles,
+			1: migrateSubnetEVMNames,
 		},
 	}
 	return runner.run(app)

--- a/internal/migrations/subnetEVMRename.go
+++ b/internal/migrations/subnetEVMRename.go
@@ -1,0 +1,34 @@
+package migrations
+
+import (
+	"os"
+
+	"github.com/ava-labs/avalanche-cli/pkg/application"
+	"github.com/ava-labs/avalanche-cli/pkg/models"
+)
+
+const oldSubnetEVM = "SubnetEVM"
+
+func migrateSubnetEVMNames(app *application.Avalanche, runner *migrationRunner) error {
+	subnetDir := app.GetSubnetDir()
+	subnets, err := os.ReadDir(subnetDir)
+	if err != nil {
+		return err
+	}
+
+	for _, subnet := range subnets {
+		sc, err := app.LoadSidecar(subnet.Name())
+		if err != nil {
+			return err
+		}
+
+		if string(sc.VM) == oldSubnetEVM {
+			runner.printMigrationMessage()
+			sc.VM = models.SubnetEvm
+			if err = app.UpdateSidecar(&sc); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/internal/migrations/subnetEVMRename.go
+++ b/internal/migrations/subnetEVMRename.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package migrations
 
 import (

--- a/internal/migrations/subnetEVMRename.go
+++ b/internal/migrations/subnetEVMRename.go
@@ -5,6 +5,7 @@ package migrations
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/ava-labs/avalanche-cli/pkg/application"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
@@ -20,6 +21,15 @@ func migrateSubnetEVMNames(app *application.Avalanche, runner *migrationRunner) 
 	}
 
 	for _, subnet := range subnets {
+		// disregard any empty subnet directories
+		dirContents, err := os.ReadDir(filepath.Join(subnetDir, subnet.Name()))
+		if err != nil {
+			return err
+		}
+		if len(dirContents) == 0 {
+			continue
+		}
+
 		sc, err := app.LoadSidecar(subnet.Name())
 		if err != nil {
 			return err

--- a/internal/migrations/subnetEVMRename_test.go
+++ b/internal/migrations/subnetEVMRename_test.go
@@ -1,0 +1,88 @@
+package migrations
+
+import (
+	"io"
+	"testing"
+
+	"github.com/ava-labs/avalanche-cli/pkg/application"
+	"github.com/ava-labs/avalanche-cli/pkg/config"
+	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanche-cli/pkg/prompts"
+	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubnetEVMRenameMigration(t *testing.T) {
+	type test struct {
+		name       string
+		sc         *models.Sidecar
+		expectedVM string
+	}
+
+	subnetName := "test"
+
+	tests := []test{
+		{
+			name: "Convert SubnetEVM",
+			sc: &models.Sidecar{
+				Name: subnetName,
+				VM:   "SubnetEVM",
+			},
+			expectedVM: "Subnet-EVM",
+		},
+		{
+			name: "Preserve Subnet-EVM",
+			sc: &models.Sidecar{
+				Name: subnetName,
+				VM:   "Subnet-EVM",
+			},
+			expectedVM: "Subnet-EVM",
+		},
+		{
+			name: "Ignore SpacesVM",
+			sc: &models.Sidecar{
+				Name: subnetName,
+				VM:   "SpacesVM",
+			},
+			expectedVM: "SpacesVM",
+		},
+		{
+			name: "Ignore unknown",
+			sc: &models.Sidecar{
+				Name: subnetName,
+				VM:   "unknown",
+			},
+			expectedVM: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ux.NewUserLog(logging.NoLog{}, io.Discard)
+			require := require.New(t)
+			testDir := t.TempDir()
+
+			app := &application.Avalanche{}
+			app.Setup(testDir, logging.NoLog{}, config.New(), prompts.NewPrompter(), application.NewDownloader())
+
+			err := app.CreateSidecar(tt.sc)
+			require.NoError(err)
+
+			runner := migrationRunner{
+				showMsg: true,
+				running: false,
+				migrations: map[int]migrationFunc{
+					0: migrateSubnetEVMNames,
+				},
+			}
+			// run the migration
+			err = runner.run(app)
+			require.NoError(err)
+
+			loadedSC, err := app.LoadSidecar(tt.sc.Name)
+			require.NoError(err)
+			require.Equal(tt.expectedVM, string(loadedSC.VM))
+		})
+	}
+}

--- a/internal/migrations/subnetEVMRename_test.go
+++ b/internal/migrations/subnetEVMRename_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package migrations
 
 import (

--- a/tests/e2e/testcases/subnet/local/suite.go
+++ b/tests/e2e/testcases/subnet/local/suite.go
@@ -52,6 +52,7 @@ var _ = ginkgo.Describe("[Local Subnet]", ginkgo.Ordered, func() {
 
 		// delete custom vm
 		utils.DeleteCustomBinary(subnetName)
+		utils.DeleteCustomBinary(secondSubnetName)
 	})
 
 	ginkgo.It("can deploy a custom vm subnet to local", func() {


### PR DESCRIPTION
Our subnet describe bug was caused by us migrating the constant `SubnetEVM` to `Subnet-EVM` for documentation purposes. This caused some string matching errors. The fix was to introduce a new migration to move all `SubnetEVM` references to use the new `Subnet-EVM` name.

Closes #492 