### PR TITLE
use the chain name as a blockchain alias

### DIFF
--- a/pkg/subnet/local.go
+++ b/pkg/subnet/local.go
@@ -209,6 +209,7 @@ func (d *LocalDeployer) doDeploy(chain string, chainGenesis []byte, genesisPath 
 			Genesis:            genesisPath,
 			SubnetId:           &subnetIDStr,
 			ChainConfig:        chainConfig,
+			BlockchainAlias:    chain,
 			PerNodeChainConfig: perNodeChainConfig,
 		},
 	}

--- a/pkg/ux/output.go
+++ b/pkg/ux/output.go
@@ -51,7 +51,7 @@ func PrintWait(cancel chan struct{}) {
 // PrintTableEndpoints prints the endpoints coming from the healthy call
 func PrintTableEndpoints(clusterInfo *rpcpb.ClusterInfo) {
 	table := tablewriter.NewWriter(os.Stdout)
-	header := []string{"node", "VM", "URL"}
+	header := []string{"node", "VM", "URL", "ALIAS_URL"}
 	table.SetHeader(header)
 	table.SetRowLine(true)
 
@@ -62,7 +62,7 @@ func PrintTableEndpoints(clusterInfo *rpcpb.ClusterInfo) {
 	for _, nodeName := range clusterInfo.NodeNames {
 		nodeInfo := nodeInfos[nodeName]
 		for blockchainID, chainInfo := range clusterInfo.CustomChains {
-			table.Append([]string{nodeInfo.Name, chainInfo.ChainName, fmt.Sprintf("%s/ext/bc/%s/rpc", nodeInfo.GetUri(), blockchainID)})
+			table.Append([]string{nodeInfo.Name, chainInfo.ChainName, fmt.Sprintf("%s/ext/bc/%s/rpc", nodeInfo.GetUri(), blockchainID), fmt.Sprintf("%s/ext/bc/%s/rpc", nodeInfo.GetUri(), chainInfo.ChainName)})
 		}
 	}
 	table.Render()

--- a/tests/e2e/utils/helpers.go
+++ b/tests/e2e/utils/helpers.go
@@ -319,7 +319,7 @@ func ParseRPCsFromOutput(output string) ([]string, error) {
 		if startIndex == -1 {
 			return nil, fmt.Errorf("no url in RPC URL line: %s", line)
 		}
-		endIndex := strings.LastIndex(line, "rpc")
+		endIndex := strings.Index(line, "rpc")
 		rpc := line[startIndex : endIndex+3]
 		rpcComponents := strings.Split(rpc, "/")
 		if len(rpcComponents) != expectedRPCComponentsLen {


### PR DESCRIPTION
Related to the issue #476 
I chose to use the subnet name as the blockchain alias. I figured it was not useful to ask for another parameter since there can only have one chain per subnet with avalanche-cli.