### PR TITLE
Remove incorrect genesis validity check

### DIFF
--- a/cmd/subnetcmd/deploy.go
+++ b/cmd/subnetcmd/deploy.go
@@ -196,9 +196,6 @@ func deploySubnet(_ *cobra.Command, args []string) error {
 	case models.SpacesVM:
 		var genesis spacesvmchain.Genesis
 		err = json.Unmarshal(chainGenesis, &genesis)
-	default:
-		var genesis map[string]interface{}
-		err = json.Unmarshal(chainGenesis, &genesis)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to validate genesis format: %w", err)


### PR DESCRIPTION
It seems like the avalanche-cli previously assumed that the `genesis` file needed to be `json` encoded... This is just not the case, as VMs define the genesis format. Generally, it would be better _not_ to use `json`, as that leads to bloat on the P-chain.