### PR TITLE
do not sugest to update ledger app for a connection error

### DIFF
--- a/cmd/keycmd/list.go
+++ b/cmd/keycmd/list.go
@@ -13,11 +13,9 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/key"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
-	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanchego/ids"
 	ledger "github.com/ava-labs/avalanchego/utils/crypto/ledger"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
 	"github.com/ava-labs/coreth/ethclient"
@@ -264,12 +262,10 @@ func getLedgerIndicesInfo(
 ) ([]addressInfo, error) {
 	ledgerDevice, err := ledger.New()
 	if err != nil {
-		ux.Logger.PrintToUser(logging.LightRed.Wrap("Error accessing ledger device. Please update ledger app to >= v0.6.5."))
 		return nil, err
 	}
 	addresses, err := ledgerDevice.Addresses(ledgerIndices)
 	if err != nil {
-		ux.Logger.PrintToUser(logging.LightRed.Wrap("Error accessing ledger device. Please update ledger app to >= v0.6.5."))
 		return nil, err
 	}
 	if len(addresses) != len(ledgerIndices) {

--- a/cmd/subnetcmd/deploy.go
+++ b/cmd/subnetcmd/deploy.go
@@ -661,7 +661,6 @@ func GetKeychain(
 	if useLedger {
 		ledgerDevice, err := ledger.New()
 		if err != nil {
-			ux.Logger.PrintToUser(logging.LightRed.Wrap("Error accessing ledger device. Please update ledger app to >= v0.6.5."))
 			return kc, err
 		}
 		// ask for addresses here to print user msg for ledger interaction
@@ -678,7 +677,6 @@ func GetKeychain(
 		// get formatted addresses for ux
 		addresses, err := ledgerDevice.Addresses(ledgerIndices)
 		if err != nil {
-			ux.Logger.PrintToUser(logging.LightRed.Wrap("Error accessing ledger device. Please update ledger app to >= v0.6.5."))
 			return kc, err
 		}
 		addrStrs := []string{}


### PR DESCRIPTION
Closes https://github.com/ava-labs/avalanche-cli/issues/625
ledger-avalanche library already sugests that, and taken into consideration the specific app version