### PR TITLE
add --filter flag to E2E

### DIFF
--- a/scripts/run.e2e.sh
+++ b/scripts/run.e2e.sh
@@ -9,6 +9,13 @@ else
     label_filter="!local_machine"
 fi
 
+description_filter=""
+if [ "$1" = "--filter" ]
+then
+    pat=$(echo $2 | tr ' ' '.')
+    description_filter="--ginkgo.focus=$pat"
+fi
+
 export RUN_E2E="true"
 
 if [ ! -d "tests/e2e/hardhat/node_modules" ]
@@ -27,7 +34,7 @@ export CGO_CFLAGS="-O -D__BLST_PORTABLE__"
 go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.1.3
 ACK_GINKGO_RC=true ginkgo build ./tests/e2e
 
-./tests/e2e/e2e.test --ginkgo.v --ginkgo.label-filter=$label_filter
+./tests/e2e/e2e.test --ginkgo.v --ginkgo.label-filter=$label_filter $description_filter
 
 EXIT_CODE=$?
 


### PR DESCRIPTION
Closes https://github.com/ava-labs/avalanche-cli/issues/636
Adds --filter flag to E2E script, for filtering based on test description. eg: ./scripts/run.e2e.sh --filter "can deploy a SubnetEvm subnet to local"