### PR TITLE
Choose correct avago version in network start

### DIFF
--- a/cmd/networkcmd/clean.go
+++ b/cmd/networkcmd/clean.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
+	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/shirou/gopsutil/process"
@@ -72,6 +73,27 @@ func clean(*cobra.Command, []string) error {
 		}
 	}
 
+	return removeLocalDeployInfoFromSidecars()
+}
+
+func removeLocalDeployInfoFromSidecars() error {
+	// Remove all local deployment info from sidecar files
+	deployedSubnets, err := subnet.GetLocallyDeployedSubnetsFromFile(app)
+	if err != nil {
+		return err
+	}
+
+	for _, subnet := range deployedSubnets {
+		sc, err := app.LoadSidecar(subnet)
+		if err != nil {
+			return err
+		}
+
+		delete(sc.Networks, models.Local.String())
+		if err = app.UpdateSidecar(&sc); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/cmd/networkcmd/clean_test.go
+++ b/cmd/networkcmd/clean_test.go
@@ -6,7 +6,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ava-labs/avalanche-cli/internal/testutils"
+	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/stretchr/testify/require"
 )
@@ -23,4 +26,37 @@ func TestCleanBins(t *testing.T) {
 	require.NoFileExists(f.Name())
 	require.NoFileExists(f2.Name())
 	require.NoDirExists(dir)
+}
+
+func Test_removeLocalDeployInfoFromSidecars(t *testing.T) {
+	app = testutils.SetupTestInTempDir(t)
+
+	subnetName := "test1"
+
+	// emptyMap := make(map[string]models.NetworkData)
+	localMap := make(map[string]models.NetworkData)
+
+	localMap[models.Local.String()] = models.NetworkData{
+		SubnetID:     ids.ID{1, 2, 3, 4},
+		BlockchainID: ids.ID{1, 2, 3, 4},
+	}
+
+	sc := models.Sidecar{
+		Name:     subnetName,
+		Networks: localMap,
+	}
+
+	err := app.CreateSidecar(&sc)
+	require.NoError(t, err)
+
+	loadedSC, err := app.LoadSidecar(subnetName)
+	require.NoError(t, err)
+	require.Contains(t, loadedSC.Networks, models.Local.String())
+
+	err = removeLocalDeployInfoFromSidecars()
+	require.NoError(t, err)
+
+	loadedSC, err = app.LoadSidecar(subnetName)
+	require.NoError(t, err)
+	require.NotContains(t, loadedSC.Networks, models.Local.String())
 }

--- a/cmd/networkcmd/clean_test.go
+++ b/cmd/networkcmd/clean_test.go
@@ -33,7 +33,6 @@ func Test_removeLocalDeployInfoFromSidecars(t *testing.T) {
 
 	subnetName := "test1"
 
-	// emptyMap := make(map[string]models.NetworkData)
 	localMap := make(map[string]models.NetworkData)
 
 	localMap[models.Local.String()] = models.NetworkData{

--- a/cmd/networkcmd/start.go
+++ b/cmd/networkcmd/start.go
@@ -166,9 +166,6 @@ func determineAvagoVersion(userProvidedAvagoVersion string) (string, error) {
 			currentRPCVersion = sc.RPCVersion
 		}
 
-		fmt.Println("currentRPCVersion", currentRPCVersion)
-		fmt.Println("sc.RPCVersion", sc.RPCVersion)
-
 		if sc.RPCVersion != currentRPCVersion {
 			return "", fmt.Errorf(
 				"RPC version mismatch. Expected %d, got %d for Subnet %s. Upgrade all subnets to the same RPC version to launch the network",

--- a/cmd/networkcmd/start.go
+++ b/cmd/networkcmd/start.go
@@ -43,6 +43,16 @@ already running.`,
 }
 
 func StartNetwork(*cobra.Command, []string) error {
+	// Need to determine which subnets have been deployed
+	locallyDeployedSubnets, err := subnet.GetLocallyDeployedSubnetsFromFile(app)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Deployed subnets:", locallyDeployedSubnets)
+
+	// For each deployed subnet, check RPC versions
+
 	sd := subnet.NewLocalDeployer(app, avagoVersion, "")
 
 	if err := sd.StartServer(); err != nil {

--- a/cmd/networkcmd/start.go
+++ b/cmd/networkcmd/start.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
+	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	"github.com/ava-labs/avalanche-cli/pkg/vm"
 	"github.com/ava-labs/avalanche-network-runner/client"
 	"github.com/ava-labs/avalanche-network-runner/server"
 	"github.com/ava-labs/avalanche-network-runner/utils"
@@ -17,9 +19,11 @@ import (
 )
 
 var (
-	avagoVersion string
-	snapshotName string
+	userProvidedAvagoVersion string
+	snapshotName             string
 )
+
+const latest = "latest"
 
 func newStartCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -36,22 +40,17 @@ already running.`,
 		SilenceUsage: true,
 	}
 
-	cmd.Flags().StringVar(&avagoVersion, "avalanchego-version", "latest", "use this version of avalanchego (ex: v1.17.12)")
+	cmd.Flags().StringVar(&userProvidedAvagoVersion, "avalanchego-version", latest, "use this version of avalanchego (ex: v1.17.12)")
 	cmd.Flags().StringVar(&snapshotName, "snapshot-name", constants.DefaultSnapshotName, "name of snapshot to use to start the network from")
 
 	return cmd
 }
 
 func StartNetwork(*cobra.Command, []string) error {
-	// Need to determine which subnets have been deployed
-	locallyDeployedSubnets, err := subnet.GetLocallyDeployedSubnetsFromFile(app)
+	avagoVersion, err := determineAvagoVersion(userProvidedAvagoVersion)
 	if err != nil {
 		return err
 	}
-
-	fmt.Println("Deployed subnets:", locallyDeployedSubnets)
-
-	// For each deployed subnet, check RPC versions
 
 	sd := subnet.NewLocalDeployer(app, avagoVersion, "")
 
@@ -131,4 +130,64 @@ func StartNetwork(*cobra.Command, []string) error {
 	}
 
 	return nil
+}
+
+func determineAvagoVersion(userProvidedAvagoVersion string) (string, error) {
+	// a specific user provided version should override this calculation, so just return
+	if userProvidedAvagoVersion != latest {
+		return userProvidedAvagoVersion, nil
+	}
+
+	// Need to determine which subnets have been deployed
+	locallyDeployedSubnets, err := subnet.GetLocallyDeployedSubnetsFromFile(app)
+	if err != nil {
+		return "", err
+	}
+
+	// if no subnets have been deployed, use latest
+	if len(locallyDeployedSubnets) == 0 {
+		return latest, nil
+	}
+
+	currentRPCVersion := -1
+
+	// For each deployed subnet, check RPC versions
+	for _, deployedSubnet := range locallyDeployedSubnets {
+		sc, err := app.LoadSidecar(deployedSubnet)
+		if err != nil {
+			return "", err
+		}
+
+		if sc.VM == models.CustomVM {
+			continue
+		}
+
+		if currentRPCVersion == -1 {
+			currentRPCVersion = sc.RPCVersion
+		}
+
+		fmt.Println("currentRPCVersion", currentRPCVersion)
+		fmt.Println("sc.RPCVersion", sc.RPCVersion)
+
+		if sc.RPCVersion != currentRPCVersion {
+			return "", fmt.Errorf(
+				"RPC version mismatch. Expected %d, got %d for Subnet %s. Upgrade all subnets to the same RPC version to launch the network",
+				currentRPCVersion,
+				sc.RPCVersion,
+				sc.Name,
+			)
+		}
+	}
+
+	// If currentRPCVersion == -1, then only custom subnets have been deployed, the user must provide the version explicitly if not latest
+	if currentRPCVersion == -1 {
+		ux.Logger.PrintToUser("No Subnet RPC version found. Using latest AvalancheGo version")
+		return latest, nil
+	}
+
+	return vm.GetLatestAvalancheGoByProtocolVersion(
+		app,
+		currentRPCVersion,
+		constants.AvalancheGoCompatibilityURL,
+	)
 }

--- a/cmd/networkcmd/start_test.go
+++ b/cmd/networkcmd/start_test.go
@@ -97,7 +97,21 @@ func Test_determineAvagoVersion(t *testing.T) {
 			name:          "single custom",
 			userAvago:     "latest",
 			sidecars:      []models.Sidecar{scCustom},
-			expectedAvago: "v1.9.2",
+			expectedAvago: "latest",
+			expectedErr:   false,
+		},
+		{
+			name:          "custom plus user selected",
+			userAvago:     "v1.9.1",
+			sidecars:      []models.Sidecar{scCustom},
+			expectedAvago: "v1.9.1",
+			expectedErr:   false,
+		},
+		{
+			name:          "multi sc matching plus custom",
+			userAvago:     "latest",
+			sidecars:      []models.Sidecar{sc1, sc2, scCustom},
+			expectedAvago: "v1.9.1",
 			expectedErr:   false,
 		},
 	}

--- a/cmd/networkcmd/start_test.go
+++ b/cmd/networkcmd/start_test.go
@@ -11,9 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	testAvagoCompat = []byte("{\"19\": [\"v1.9.2\"],\"18\": [\"v1.9.1\"],\"17\": [\"v1.9.0\",\"v1.8.0\"]}")
-)
+var testAvagoCompat = []byte("{\"19\": [\"v1.9.2\"],\"18\": [\"v1.9.1\"],\"17\": [\"v1.9.0\",\"v1.8.0\"]}")
 
 func Test_determineAvagoVersion(t *testing.T) {
 	subnetName1 := "test1"
@@ -21,7 +19,6 @@ func Test_determineAvagoVersion(t *testing.T) {
 	subnetName3 := "test3"
 	subnetName4 := "test4"
 
-	// emptyMap := make(map[string]models.NetworkData)
 	localMap := make(map[string]models.NetworkData)
 
 	localMap[models.Local.String()] = models.NetworkData{

--- a/cmd/networkcmd/start_test.go
+++ b/cmd/networkcmd/start_test.go
@@ -1,0 +1,128 @@
+package networkcmd
+
+import (
+	"testing"
+
+	"github.com/ava-labs/avalanche-cli/internal/mocks"
+	"github.com/ava-labs/avalanche-cli/internal/testutils"
+	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testAvagoCompat = []byte("{\"19\": [\"v1.9.2\"],\"18\": [\"v1.9.1\"],\"17\": [\"v1.9.0\",\"v1.8.0\"]}")
+)
+
+func Test_determineAvagoVersion(t *testing.T) {
+	subnetName1 := "test1"
+	subnetName2 := "test2"
+	subnetName3 := "test3"
+	subnetName4 := "test4"
+
+	// emptyMap := make(map[string]models.NetworkData)
+	localMap := make(map[string]models.NetworkData)
+
+	localMap[models.Local.String()] = models.NetworkData{
+		SubnetID:     ids.ID{1, 2, 3, 4},
+		BlockchainID: ids.ID{1, 2, 3, 4},
+	}
+
+	sc1 := models.Sidecar{
+		Name:       subnetName1,
+		Networks:   localMap,
+		VM:         models.SubnetEvm,
+		RPCVersion: 18,
+	}
+
+	sc2 := models.Sidecar{
+		Name:       subnetName2,
+		Networks:   localMap,
+		VM:         models.SubnetEvm,
+		RPCVersion: 18,
+	}
+
+	sc3 := models.Sidecar{
+		Name:       subnetName3,
+		Networks:   localMap,
+		VM:         models.SubnetEvm,
+		RPCVersion: 19,
+	}
+
+	scCustom := models.Sidecar{
+		Name:     subnetName4,
+		Networks: localMap,
+		VM:       models.CustomVM,
+	}
+
+	type test struct {
+		name          string
+		userAvago     string
+		sidecars      []models.Sidecar
+		expectedAvago string
+		expectedErr   bool
+	}
+
+	tests := []test{
+		{
+			name:          "user not latest",
+			userAvago:     "v1.9.5",
+			sidecars:      []models.Sidecar{sc1},
+			expectedAvago: "v1.9.5",
+			expectedErr:   false,
+		},
+		{
+			name:          "single sc",
+			userAvago:     "latest",
+			sidecars:      []models.Sidecar{sc1},
+			expectedAvago: "v1.9.1",
+			expectedErr:   false,
+		},
+		{
+			name:          "multi sc matching",
+			userAvago:     "latest",
+			sidecars:      []models.Sidecar{sc1, sc2},
+			expectedAvago: "v1.9.1",
+			expectedErr:   false,
+		},
+		{
+			name:          "multi sc mismatch",
+			userAvago:     "latest",
+			sidecars:      []models.Sidecar{sc1, sc3},
+			expectedAvago: "",
+			expectedErr:   true,
+		},
+		{
+			name:          "single custom",
+			userAvago:     "latest",
+			sidecars:      []models.Sidecar{scCustom},
+			expectedAvago: "v1.9.2",
+			expectedErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app = testutils.SetupTestInTempDir(t)
+			mockDownloader := &mocks.Downloader{}
+			mockDownloader.On("Download", mock.Anything).Return(testAvagoCompat, nil)
+			mockDownloader.On("GetLatestReleaseVersion", mock.Anything).Return("v1.9.2", nil)
+
+			app.Downloader = mockDownloader
+
+			for i := range tt.sidecars {
+				err := app.CreateSidecar(&tt.sidecars[i])
+				require.NoError(t, err)
+			}
+
+			avagoVersion, err := determineAvagoVersion(tt.userAvago)
+			if tt.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.expectedAvago, avagoVersion)
+		})
+	}
+}

--- a/cmd/networkcmd/start_test.go
+++ b/cmd/networkcmd/start_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package networkcmd
 
 import (

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,6 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/ava-labs/apm v0.0.4 h1:0IUwxCyvqwr2sbbEKhSI7VzpPG3Z+e180ulJwNiKkBk=
 github.com/ava-labs/apm v0.0.4/go.mod h1:4MNcyEvWajJm2JnezC7vgHuA220ppoQYOMh5vM+iH4Q=
-github.com/ava-labs/avalanche-network-runner v1.3.7-0.20230214202745-270485c24e61 h1:DR7owbKuW0a7Yb/4+BwUC9TQeMYq0hPyGHYojFKv6MQ=
-github.com/ava-labs/avalanche-network-runner v1.3.7-0.20230214202745-270485c24e61/go.mod h1:qv0AO8uL7lDD6L7wMo3RlvCaF5y8rnqPETHi5pak4WY=
 github.com/ava-labs/avalanche-network-runner v1.3.7 h1:XjJFtEitvXsI91EaLxBQLMH/THdd7ewWTHwNT+S7MgE=
 github.com/ava-labs/avalanche-network-runner v1.3.7/go.mod h1:qv0AO8uL7lDD6L7wMo3RlvCaF5y8rnqPETHi5pak4WY=
 github.com/ava-labs/avalanchego v1.9.8 h1:5SHKqkWpBn9Pqxg2qpzDZ7FQqYFapzaCZwArapBdqAA=

--- a/internal/testutils/setup.go
+++ b/internal/testutils/setup.go
@@ -25,5 +25,6 @@ func SetupTestInTempDir(t *testing.T) *application.Avalanche {
 
 	app := application.New()
 	app.Setup(testDir, logging.NoLog{}, &config.Config{}, nil, nil)
+	ux.NewUserLog(logging.NoLog{}, io.Discard)
 	return app
 }

--- a/internal/testutils/setup.go
+++ b/internal/testutils/setup.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"testing"
 
+	"github.com/ava-labs/avalanche-cli/pkg/application"
+	"github.com/ava-labs/avalanche-cli/pkg/config"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/stretchr/testify/require"
@@ -16,4 +18,12 @@ func SetupTest(t *testing.T) *require.Assertions {
 	// use io.Discard to not print anything
 	ux.NewUserLog(logging.NoLog{}, io.Discard)
 	return require.New(t)
+}
+
+func SetupTestInTempDir(t *testing.T) *application.Avalanche {
+	testDir := t.TempDir()
+
+	app := application.New()
+	app.Setup(testDir, logging.NoLog{}, &config.Config{}, nil, nil)
+	return app
 }

--- a/pkg/subnet/deployStatus.go
+++ b/pkg/subnet/deployStatus.go
@@ -1,0 +1,40 @@
+package subnet
+
+import (
+	"os"
+
+	"github.com/ava-labs/avalanche-cli/pkg/application"
+	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanche-cli/pkg/ux"
+)
+
+func GetLocallyDeployedSubnetsFromFile(app *application.Avalanche) ([]string, error) {
+	allSubnetDirs, err := os.ReadDir(app.GetSubnetDir())
+	if err != nil {
+		return nil, err
+	}
+
+	deployedSubnets := []string{}
+
+	for _, subnetDir := range allSubnetDirs {
+		// read sidecar file
+		sc, err := app.LoadSidecar(subnetDir.Name())
+		if err == os.ErrNotExist {
+			// don't fail on missing sidecar file, just warn
+			ux.Logger.PrintToUser("warning: inconsistent subnet directory. No sidecar file found for subnet %s", subnetDir.Name())
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		// check if sidecar contains local deployment info in Networks map
+
+		// if so, add to list of deployed subnets
+		if _, ok := sc.Networks[models.Local.String()]; ok {
+			deployedSubnets = append(deployedSubnets, sc.Name)
+		}
+	}
+
+	return deployedSubnets, nil
+}

--- a/pkg/subnet/deployStatus.go
+++ b/pkg/subnet/deployStatus.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package subnet
 
 import (

--- a/pkg/subnet/deployStatus.go
+++ b/pkg/subnet/deployStatus.go
@@ -32,7 +32,6 @@ func GetLocallyDeployedSubnetsFromFile(app *application.Avalanche) ([]string, er
 		}
 
 		// check if sidecar contains local deployment info in Networks map
-
 		// if so, add to list of deployed subnets
 		if _, ok := sc.Networks[models.Local.String()]; ok {
 			deployedSubnets = append(deployedSubnets, sc.Name)


### PR DESCRIPTION
This change stores local deployment status in the sidecar file and clears local deploy state when resetting the network. Using this change, the `network start` command now finds every deployed subnet and looks for a matching AvaGo version or throws an error if no match is possible.

Closes #639 #640