### PR TITLE
Re-enable test

### DIFF
--- a/tests/e2e/testcases/upgrade/suite.go
+++ b/tests/e2e/testcases/upgrade/suite.go
@@ -4,11 +4,13 @@
 package apm
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/ava-labs/avalanche-cli/cmd/subnetcmd/upgradecmd"
 	"github.com/ava-labs/avalanche-cli/pkg/application"
@@ -20,6 +22,7 @@ import (
 	anr_utils "github.com/ava-labs/avalanche-network-runner/utils"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/subnet-evm/params"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
@@ -179,43 +182,39 @@ var _ = ginkgo.Describe("[Upgrade local network]", ginkgo.Ordered, func() {
 		gomega.Expect(out).Should(gomega.ContainSubstring(upgradecmd.ErrSubnetNotDeployedOutput))
 	})
 
-	/*
-		// temporarily disable this test as with subnet-evm-0.4.10 it fails
-		// due to missing content in the API response used in CheckUpgradeIsDeployed
-		ginkgo.It("can create and apply to locally running subnet", func() {
-			commands.CreateSubnetEvmConfig(subnetName, utils.SubnetEvmGenesisPath)
+	ginkgo.It("can create and apply to locally running subnet", func() {
+		commands.CreateSubnetEvmConfig(subnetName, utils.SubnetEvmGenesisPath)
 
-			deployOutput := commands.DeploySubnetLocally(subnetName)
+		deployOutput := commands.DeploySubnetLocally(subnetName)
 
-			_, err = commands.ImportUpgradeBytes(subnetName, upgradeBytesPath)
-			gomega.Expect(err).Should(gomega.BeNil())
+		_, err = commands.ImportUpgradeBytes(subnetName, upgradeBytesPath)
+		gomega.Expect(err).Should(gomega.BeNil())
 
-			_, err = commands.ApplyUpgradeLocal(subnetName)
-			gomega.Expect(err).Should(gomega.BeNil())
+		_, err = commands.ApplyUpgradeLocal(subnetName)
+		gomega.Expect(err).Should(gomega.BeNil())
 
-			upgradeBytes, err := os.ReadFile(upgradeBytesPath)
-			gomega.Expect(err).Should(gomega.BeNil())
+		upgradeBytes, err := os.ReadFile(upgradeBytesPath)
+		gomega.Expect(err).Should(gomega.BeNil())
 
-			var precmpUpgrades params.UpgradeConfig
-			err = json.Unmarshal(upgradeBytes, &precmpUpgrades)
-			gomega.Expect(err).Should(gomega.BeNil())
+		var precmpUpgrades params.UpgradeConfig
+		err = json.Unmarshal(upgradeBytes, &precmpUpgrades)
+		gomega.Expect(err).Should(gomega.BeNil())
 
-			rpcs, err := utils.ParseRPCsFromOutput(deployOutput)
-			if err != nil {
-				fmt.Println(deployOutput)
-			}
-			err = utils.CheckUpgradeIsDeployed(rpcs[0], precmpUpgrades)
-			gomega.Expect(err).Should(gomega.BeNil())
+		rpcs, err := utils.ParseRPCsFromOutput(deployOutput)
+		if err != nil {
+			fmt.Println(deployOutput)
+		}
+		err = utils.CheckUpgradeIsDeployed(rpcs[0], precmpUpgrades)
+		gomega.Expect(err).Should(gomega.BeNil())
 
-			app := application.New()
-			app.Setup(utils.GetBaseDir(), logging.NoLog{}, nil, nil, nil)
+		app := application.New()
+		app.Setup(utils.GetBaseDir(), logging.NoLog{}, nil, nil, nil)
 
-			stripped := stripWhitespaces(string(upgradeBytes))
-			lockUpgradeBytes, err := app.ReadLockUpgradeFile(subnetName)
-			gomega.Expect(err).Should(gomega.BeNil())
-			gomega.Expect([]byte(stripped)).Should(gomega.Equal(lockUpgradeBytes))
-		})
-	*/
+		stripped := stripWhitespaces(string(upgradeBytes))
+		lockUpgradeBytes, err := app.ReadLockUpgradeFile(subnetName)
+		gomega.Expect(err).Should(gomega.BeNil())
+		gomega.Expect([]byte(stripped)).Should(gomega.Equal(lockUpgradeBytes))
+	})
 
 	ginkgo.It("can create and update future", func() {
 		subnetEVMVersion1 := binaryToVersion[utils.SoloSubnetEVMKey1]
@@ -420,7 +419,6 @@ var _ = ginkgo.Describe("[Upgrade local network]", ginkgo.Ordered, func() {
 	})
 })
 
-/*
 func stripWhitespaces(str string) string {
 	return strings.Map(func(r rune) rune {
 		if unicode.IsSpace(r) {
@@ -431,4 +429,3 @@ func stripWhitespaces(str string) string {
 		return r
 	}, str)
 }
-*/


### PR DESCRIPTION
The subnet-evm precompile test was disabled due to a regresssion in subnet-evm.

As subnet-evm already has a new release with the issue addressed, re-enable the test