### PR TITLE
Update to latest subnet-evm code

### DIFF
--- a/cmd/subnetcmd/describe.go
+++ b/cmd/subnetcmd/describe.go
@@ -190,35 +190,35 @@ func printPrecompileTable(genesis core.Genesis) {
 	// Native Minting
 	if genesis.Config.GenesisPrecompiles[nativeminter.ConfigKey] != nil {
 		cfg := genesis.Config.GenesisPrecompiles[nativeminter.ConfigKey].(*nativeminter.Config)
-		buildAddressTable(table, "Native Minter", cfg.AdminAddresses, cfg.EnabledAddresses)
+		appendToAddressTable(table, "Native Minter", cfg.AdminAddresses, cfg.EnabledAddresses)
 		precompileSet = true
 	}
 
 	// Contract allow list
 	if genesis.Config.GenesisPrecompiles[deployerallowlist.ConfigKey] != nil {
 		cfg := genesis.Config.GenesisPrecompiles[deployerallowlist.ConfigKey].(*deployerallowlist.Config)
-		buildAddressTable(table, "Contract Allow List", cfg.AdminAddresses, cfg.EnabledAddresses)
+		appendToAddressTable(table, "Contract Allow List", cfg.AdminAddresses, cfg.EnabledAddresses)
 		precompileSet = true
 	}
 
 	// TX allow list
 	if genesis.Config.GenesisPrecompiles[txallowlist.ConfigKey] != nil {
 		cfg := genesis.Config.GenesisPrecompiles[txallowlist.Module.ConfigKey].(*txallowlist.Config)
-		buildAddressTable(table, "Tx Allow List", cfg.AdminAddresses, cfg.EnabledAddresses)
+		appendToAddressTable(table, "Tx Allow List", cfg.AdminAddresses, cfg.EnabledAddresses)
 		precompileSet = true
 	}
 
 	// Fee config allow list
 	if genesis.Config.GenesisPrecompiles[feemanager.ConfigKey] != nil {
 		cfg := genesis.Config.GenesisPrecompiles[feemanager.ConfigKey].(*feemanager.Config)
-		buildAddressTable(table, "Fee Config Allow List", cfg.AdminAddresses, cfg.EnabledAddresses)
+		appendToAddressTable(table, "Fee Config Allow List", cfg.AdminAddresses, cfg.EnabledAddresses)
 		precompileSet = true
 	}
 
 	// Reward config allow list
 	if genesis.Config.GenesisPrecompiles[rewardmanager.ConfigKey] != nil {
 		cfg := genesis.Config.GenesisPrecompiles[rewardmanager.ConfigKey].(*rewardmanager.Config)
-		buildAddressTable(table, "Reward Manager Allow List", cfg.AdminAddresses, cfg.EnabledAddresses)
+		appendToAddressTable(table, "Reward Manager Allow List", cfg.AdminAddresses, cfg.EnabledAddresses)
 		precompileSet = true
 	}
 
@@ -229,7 +229,7 @@ func printPrecompileTable(genesis core.Genesis) {
 	}
 }
 
-func buildAddressTable(
+func appendToAddressTable(
 	table *tablewriter.Table,
 	label string,
 	adminAddresses []common.Address,

--- a/cmd/subnetcmd/describe.go
+++ b/cmd/subnetcmd/describe.go
@@ -4,6 +4,7 @@ package subnetcmd
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"os"
 	"strconv"
@@ -15,6 +16,12 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/subnet-evm/core"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/precompile/contracts/deployerallowlist"
+	"github.com/ava-labs/subnet-evm/precompile/contracts/feemanager"
+	"github.com/ava-labs/subnet-evm/precompile/contracts/nativeminter"
+	"github.com/ava-labs/subnet-evm/precompile/contracts/rewardmanager"
+	"github.com/ava-labs/subnet-evm/precompile/contracts/txallowlist"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -173,57 +180,73 @@ func printPrecompileTable(genesis core.Genesis) {
 	fmt.Print(art)
 
 	table := tablewriter.NewWriter(os.Stdout)
-	header := []string{"Precompile", "Admin"}
+	header := []string{"Precompile", "Admin", "Enabled"}
 	table.SetHeader(header)
-	table.SetAutoMergeCellsByColumnIndex([]int{0})
+	table.SetAutoMergeCellsByColumnIndex([]int{0, 1, 2})
 	table.SetRowLine(true)
 
 	precompileSet := false
 
 	// Native Minting
-	if genesis.Config.ContractNativeMinterConfig != nil {
-		for _, address := range genesis.Config.ContractNativeMinterConfig.AllowListAdmins {
-			table.Append([]string{"Native Minter", address.Hex()})
-			precompileSet = true
-		}
+	if genesis.Config.GenesisPrecompiles[nativeminter.ConfigKey] != nil {
+		cfg := genesis.Config.GenesisPrecompiles[nativeminter.ConfigKey].(*nativeminter.Config)
+		buildAddressTable(table, "Native Minter", cfg.AdminAddresses, cfg.EnabledAddresses)
+		precompileSet = true
 	}
 
 	// Contract allow list
-	if genesis.Config.ContractDeployerAllowListConfig != nil {
-		for _, address := range genesis.Config.ContractDeployerAllowListConfig.AllowListAdmins {
-			table.Append([]string{"Contract Allow list", address.Hex()})
-			precompileSet = true
-		}
+	if genesis.Config.GenesisPrecompiles[deployerallowlist.ConfigKey] != nil {
+		cfg := genesis.Config.GenesisPrecompiles[deployerallowlist.ConfigKey].(*deployerallowlist.Config)
+		buildAddressTable(table, "Contract Allow List", cfg.AdminAddresses, cfg.EnabledAddresses)
+		precompileSet = true
 	}
 
 	// TX allow list
-	if genesis.Config.TxAllowListConfig != nil {
-		for _, address := range genesis.Config.TxAllowListConfig.AllowListAdmins {
-			table.Append([]string{"Tx Allow list", address.Hex()})
-			precompileSet = true
-		}
+	if genesis.Config.GenesisPrecompiles[txallowlist.ConfigKey] != nil {
+		cfg := genesis.Config.GenesisPrecompiles[txallowlist.Module.ConfigKey].(*txallowlist.Config)
+		buildAddressTable(table, "Tx Allow List", cfg.AdminAddresses, cfg.EnabledAddresses)
+		precompileSet = true
 	}
 
 	// Fee config allow list
-	if genesis.Config.FeeManagerConfig != nil {
-		for _, address := range genesis.Config.FeeManagerConfig.AllowListAdmins {
-			table.Append([]string{"Fee Config Allow list", address.Hex()})
-			precompileSet = true
-		}
+	if genesis.Config.GenesisPrecompiles[feemanager.ConfigKey] != nil {
+		cfg := genesis.Config.GenesisPrecompiles[feemanager.ConfigKey].(*feemanager.Config)
+		buildAddressTable(table, "Fee Config Allow List", cfg.AdminAddresses, cfg.EnabledAddresses)
+		precompileSet = true
 	}
 
 	// Reward config allow list
-	if genesis.Config.RewardManagerConfig != nil {
-		for _, address := range genesis.Config.RewardManagerConfig.AllowListAdmins {
-			table.Append([]string{"Reward Manager Config Allow list", address.Hex()})
-			precompileSet = true
-		}
+	if genesis.Config.GenesisPrecompiles[rewardmanager.ConfigKey] != nil {
+		cfg := genesis.Config.GenesisPrecompiles[rewardmanager.ConfigKey].(*rewardmanager.Config)
+		buildAddressTable(table, "Reward Manager Allow List", cfg.AdminAddresses, cfg.EnabledAddresses)
+		precompileSet = true
 	}
 
 	if precompileSet {
 		table.Render()
 	} else {
 		ux.Logger.PrintToUser("No precompiles set")
+	}
+}
+
+func buildAddressTable(
+	table *tablewriter.Table,
+	label string,
+	adminAddresses []common.Address,
+	enabledAddresses []common.Address,
+) {
+	admins := len(adminAddresses)
+	enabled := len(enabledAddresses)
+	max := int(math.Max(float64(admins), float64(enabled)))
+	for i := 0; i < max; i++ {
+		var admin, enable string
+		if len(adminAddresses) >= i+1 && adminAddresses[i] != (common.Address{}) {
+			admin = adminAddresses[i].Hex()
+		}
+		if len(enabledAddresses) >= i+1 && enabledAddresses[i] != (common.Address{}) {
+			enable = enabledAddresses[i].Hex()
+		}
+		table.Append([]string{label, admin, enable})
 	}
 }
 

--- a/cmd/subnetcmd/upgradecmd/apply.go
+++ b/cmd/subnetcmd/upgradecmd/apply.go
@@ -340,7 +340,7 @@ func validateUpgrade(subnetName, networkKey string, sc *models.Sidecar, skipProm
 	for _, precmpUpgrade := range upgrds {
 		allowListCfg, ok := precmpUpgrade.Config.(*txallowlist.Config)
 		if !ok {
-			return nil, "", fmt.Errorf("expected txallowlist.Config, got %T", allowListCfg)
+			continue
 		}
 		if allowListCfg != nil {
 			if err := ensureAdminsHaveBalance(allowListCfg.AdminAddresses, subnetName); err != nil {

--- a/cmd/subnetcmd/upgradecmd/apply.go
+++ b/cmd/subnetcmd/upgradecmd/apply.go
@@ -493,8 +493,8 @@ func getAllUpgrades(file []byte) ([]params.PrecompileUpgrade, error) {
 	var precompiles params.UpgradeConfig
 
 	if err := json.Unmarshal(file, &precompiles); err != nil {
-		cause := fmt.Errorf(err.Error(), errInvalidPrecompiles)
-		return nil, fmt.Errorf("failed parsing JSON : %w", cause)
+		cause := fmt.Errorf("failed parsing JSON: %w", err)
+		return nil, fmt.Errorf(cause.Error()+" - %w ", errInvalidPrecompiles)
 	}
 
 	if len(precompiles.PrecompileUpgrades) == 0 {

--- a/cmd/subnetcmd/upgradecmd/apply.go
+++ b/cmd/subnetcmd/upgradecmd/apply.go
@@ -431,7 +431,7 @@ func validateUpgradeBytes(file, lockFile []byte, skipPrompting bool) ([]params.P
 }
 
 func getAllTimestamps(upgrades []params.PrecompileUpgrade) ([]int64, error) {
-	var allTimestamps []int64
+	allTimestamps := []int64{}
 
 	if len(upgrades) == 0 {
 		return nil, errNoBlockTimestamp
@@ -493,7 +493,7 @@ func getAllUpgrades(file []byte) ([]params.PrecompileUpgrade, error) {
 	var precompiles params.UpgradeConfig
 
 	if err := json.Unmarshal(file, &precompiles); err != nil {
-		return nil, fmt.Errorf("failed parsing JSON - %s: %w", err.Error(), errInvalidPrecompiles)
+		return nil, fmt.Errorf("failed parsing JSON - %w: %w", err, errInvalidPrecompiles)
 	}
 
 	if len(precompiles.PrecompileUpgrades) == 0 {

--- a/cmd/subnetcmd/upgradecmd/apply.go
+++ b/cmd/subnetcmd/upgradecmd/apply.go
@@ -493,7 +493,8 @@ func getAllUpgrades(file []byte) ([]params.PrecompileUpgrade, error) {
 	var precompiles params.UpgradeConfig
 
 	if err := json.Unmarshal(file, &precompiles); err != nil {
-		return nil, fmt.Errorf("failed parsing JSON - %w: %w", err, errInvalidPrecompiles)
+		cause := fmt.Errorf(err.Error(), errInvalidPrecompiles)
+		return nil, fmt.Errorf("failed parsing JSON : %w", cause)
 	}
 
 	if len(precompiles.PrecompileUpgrades) == 0 {

--- a/cmd/subnetcmd/upgradecmd/generate.go
+++ b/cmd/subnetcmd/upgradecmd/generate.go
@@ -22,7 +22,11 @@ import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/subnet-evm/commontype"
 	"github.com/ava-labs/subnet-evm/params"
-	"github.com/ava-labs/subnet-evm/precompile"
+	"github.com/ava-labs/subnet-evm/precompile/contracts/deployerallowlist"
+	"github.com/ava-labs/subnet-evm/precompile/contracts/feemanager"
+	"github.com/ava-labs/subnet-evm/precompile/contracts/nativeminter"
+	"github.com/ava-labs/subnet-evm/precompile/contracts/rewardmanager"
+	"github.com/ava-labs/subnet-evm/precompile/contracts/txallowlist"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/spf13/cobra"
@@ -242,14 +246,14 @@ func promptNativeMintParams(precompiles *[]params.PrecompileUpgrade, date time.T
 		}
 	}
 
-	config := precompile.NewContractNativeMinterConfig(
+	config := nativeminter.NewConfig(
 		big.NewInt(date.Unix()),
 		adminAddrs,
 		enabledAddrs,
 		initialMint,
 	)
 	upgrade := params.PrecompileUpgrade{
-		ContractNativeMinterConfig: config,
+		config,
 	}
 	*precompiles = append(*precompiles, upgrade)
 	return nil
@@ -266,7 +270,7 @@ func promptRewardManagerParams(precompiles *[]params.PrecompileUpgrade, date tim
 		return err
 	}
 
-	config := precompile.NewRewardManagerConfig(
+	config := rewardmanager.NewConfig(
 		big.NewInt(date.Unix()),
 		adminAddrs,
 		enabledAddrs,
@@ -274,7 +278,7 @@ func promptRewardManagerParams(precompiles *[]params.PrecompileUpgrade, date tim
 	)
 
 	upgrade := params.PrecompileUpgrade{
-		RewardManagerConfig: config,
+		config,
 	}
 	*precompiles = append(*precompiles, upgrade)
 	return nil
@@ -302,14 +306,14 @@ func promptFeeManagerParams(precompiles *[]params.PrecompileUpgrade, date time.T
 		feeConfig = &chainConfig.FeeConfig
 	}
 
-	config := precompile.NewFeeManagerConfig(
+	config := feemanager.NewConfig(
 		big.NewInt(date.Unix()),
 		adminAddrs,
 		enabledAddrs,
 		feeConfig,
 	)
 	upgrade := params.PrecompileUpgrade{
-		FeeManagerConfig: config,
+		config,
 	}
 	*precompiles = append(*precompiles, upgrade)
 	return nil
@@ -321,13 +325,13 @@ func promptContractAllowListParams(precompiles *[]params.PrecompileUpgrade, date
 		return err
 	}
 
-	config := precompile.NewContractDeployerAllowListConfig(
+	config := deployerallowlist.NewConfig(
 		big.NewInt(date.Unix()),
 		adminAddrs,
 		enabledAddrs,
 	)
 	upgrade := params.PrecompileUpgrade{
-		ContractDeployerAllowListConfig: config,
+		config,
 	}
 	*precompiles = append(*precompiles, upgrade)
 	return nil
@@ -339,13 +343,13 @@ func promptTxAllowListParams(precompiles *[]params.PrecompileUpgrade, date time.
 		return err
 	}
 
-	config := precompile.NewTxAllowListConfig(
+	config := txallowlist.NewConfig(
 		big.NewInt(date.Unix()),
 		adminAddrs,
 		enabledAddrs,
 	)
 	upgrade := params.PrecompileUpgrade{
-		TxAllowListConfig: config,
+		config,
 	}
 	*precompiles = append(*precompiles, upgrade)
 	return nil

--- a/cmd/subnetcmd/upgradecmd/generate.go
+++ b/cmd/subnetcmd/upgradecmd/generate.go
@@ -253,7 +253,7 @@ func promptNativeMintParams(precompiles *[]params.PrecompileUpgrade, date time.T
 		initialMint,
 	)
 	upgrade := params.PrecompileUpgrade{
-		config,
+		Config: config,
 	}
 	*precompiles = append(*precompiles, upgrade)
 	return nil
@@ -278,7 +278,7 @@ func promptRewardManagerParams(precompiles *[]params.PrecompileUpgrade, date tim
 	)
 
 	upgrade := params.PrecompileUpgrade{
-		config,
+		Config: config,
 	}
 	*precompiles = append(*precompiles, upgrade)
 	return nil
@@ -313,7 +313,7 @@ func promptFeeManagerParams(precompiles *[]params.PrecompileUpgrade, date time.T
 		feeConfig,
 	)
 	upgrade := params.PrecompileUpgrade{
-		config,
+		Config: config,
 	}
 	*precompiles = append(*precompiles, upgrade)
 	return nil
@@ -331,7 +331,7 @@ func promptContractAllowListParams(precompiles *[]params.PrecompileUpgrade, date
 		enabledAddrs,
 	)
 	upgrade := params.PrecompileUpgrade{
-		config,
+		Config: config,
 	}
 	*precompiles = append(*precompiles, upgrade)
 	return nil
@@ -349,7 +349,7 @@ func promptTxAllowListParams(precompiles *[]params.PrecompileUpgrade, date time.
 		enabledAddrs,
 	)
 	upgrade := params.PrecompileUpgrade{
-		config,
+		Config: config,
 	}
 	*precompiles = append(*precompiles, upgrade)
 	return nil

--- a/cmd/subnetcmd/upgradecmd/validate_test.go
+++ b/cmd/subnetcmd/upgradecmd/validate_test.go
@@ -88,8 +88,8 @@ func TestEarliestTimestamp(t *testing.T) {
 {"contractNativeMinterConfig":{"adminAddresses":["0xb794F5eA0ba39494cE839613fffBA74279579268"],"blockTimestamp":%d,"initialFeeConfig":{}}}
 ]}`,
 					time.Now().Add(10*time.Millisecond).Unix(),
+					time.Now().Add(15*time.Millisecond).Unix(),
 					time.Now().Add(20*time.Millisecond).Unix(),
-					time.Now().Add(30*time.Millisecond).Unix(),
 				)),
 			earliest:    targetEarliest,
 			expectedErr: errNoUpcomingUpgrades,

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ava-labs/avalanchego v1.9.11
 	github.com/ava-labs/coreth v0.11.8-rc.3
 	github.com/ava-labs/spacesvm v0.0.16-0.20230203183930-edab6c380a0c
-	github.com/ava-labs/subnet-evm v0.4.8
+	github.com/ava-labs/subnet-evm v0.4.12
 	github.com/docker/docker v23.0.1+incompatible
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/go-git/go-git/v5 v5.6.0

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/ava-labs/ledger-avalanche/go v0.0.0-20230105152938-00a24d05a8c7 h1:Ed
 github.com/ava-labs/ledger-avalanche/go v0.0.0-20230105152938-00a24d05a8c7/go.mod h1:XhiXSrh90sHUbkERzaxEftCmUz53eCijshDLZ4fByVM=
 github.com/ava-labs/spacesvm v0.0.16-0.20230203183930-edab6c380a0c h1:Y0GZ0D9M81+aBt1lA58grU0Cllwhd+CwFNrFfuF4DwE=
 github.com/ava-labs/spacesvm v0.0.16-0.20230203183930-edab6c380a0c/go.mod h1:HUsQDCUsbzjW9eN720eouhxPPwq9+p9azXgZ7GHQ4pQ=
-github.com/ava-labs/subnet-evm v0.4.8 h1:h9pDDqSQioEtUGyjhHJ3dT5Mh5BVxpBwVyil8Zb2r08=
-github.com/ava-labs/subnet-evm v0.4.8/go.mod h1:aDW6zumvQiR1SabE8kdcAZYkbxJ6WV3QKL61lu+OgIQ=
+github.com/ava-labs/subnet-evm v0.4.12 h1:8V7wJrbqHsSmKTuT9lzMlFyZ0v4+JWBrmEn2K1ajIiQ=
+github.com/ava-labs/subnet-evm v0.4.12/go.mod h1:q+jS2OsS8MJD5U+D9mZP2CK2ripmAFT2nr1V6qsMlHs=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/pkg/ux/duration.go
+++ b/pkg/ux/duration.go
@@ -15,26 +15,26 @@ func FormatDuration(d time.Duration) string {
 	y := d / (24 * 365 * time.Hour)
 	if y > 0 {
 		d -= y * 24 * 365 * time.Hour
-		sb.WriteString(fmt.Sprintf("%d years ", y))
+		_, _ = sb.WriteString(fmt.Sprintf("%d years ", y))
 	}
 	dd := d / (24 * time.Hour)
 	if dd > 0 {
 		d -= dd * 24 * time.Hour
-		sb.WriteString(fmt.Sprintf("%d days ", dd))
+		_, _ = sb.WriteString(fmt.Sprintf("%d days ", dd))
 	}
 	h := d / time.Hour
 	if h > 0 {
 		d -= h * time.Hour
-		sb.WriteString(fmt.Sprintf("%d hours ", h))
+		_, _ = sb.WriteString(fmt.Sprintf("%d hours ", h))
 	}
 	m := d / time.Minute
 	if m > 0 {
 		d -= m * time.Minute
-		sb.WriteString(fmt.Sprintf("%d minutes ", m))
+		_, _ = sb.WriteString(fmt.Sprintf("%d minutes ", m))
 	}
 	s := d / time.Second
 	if s > 0 {
-		sb.WriteString(fmt.Sprintf("%d seconds ", s))
+		_, _ = sb.WriteString(fmt.Sprintf("%d seconds ", s))
 	}
 
 	return sb.String()

--- a/pkg/vm/createEvm.go
+++ b/pkg/vm/createEvm.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"os"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/subnet-evm/core"
 	"github.com/ava-labs/subnet-evm/params"
+	"github.com/ava-labs/subnet-evm/precompile/contracts/txallowlist"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -112,8 +114,15 @@ func createEvmGenesis(
 		subnetEvmState.NextState(direction)
 	}
 
-	if conf != nil && conf.TxAllowListConfig != nil {
-		if err := ensureAdminsHaveBalance(conf.TxAllowListConfig.AllowListAdmins, allocation); err != nil {
+	if conf != nil && conf.GenesisPrecompiles[txallowlist.ConfigKey] != nil {
+		allowListCfg, ok := conf.GenesisPrecompiles[txallowlist.ConfigKey].(*txallowlist.Config)
+		if !ok {
+			return nil, nil, fmt.Errorf("expected config of type txallowlist.AllowListConfig, but got %T", allowListCfg)
+		}
+
+		if err := ensureAdminsHaveBalance(
+			allowListCfg.AdminAddresses,
+			allocation); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/tests/e2e/assets/test_upgrade.json
+++ b/tests/e2e/assets/test_upgrade.json
@@ -6,7 +6,6 @@
           "0x8db97c7cece249c2b98bdc0226cc4c2a57bf52fc",
           "0xab5801a7d398351b8be11c439e05c5b3259aec9b"
         ],
-        "enabledAddresses": null,
         "blockTimestamp": 2526843696
       }
     },
@@ -15,7 +14,6 @@
         "adminAddresses": [
           "0x8db97c7cece249c2b98bdc0226cc4c2a57bf52fc"
         ],
-        "enabledAddresses": null,
         "blockTimestamp": 2526849999,
         "initialMint": {
           "0xab5801a7d398351b8be11c439e05c5b3259aec9b": "0x5af3107a4000"

--- a/tests/e2e/assets/test_upgrade_2.json
+++ b/tests/e2e/assets/test_upgrade_2.json
@@ -6,7 +6,6 @@
           "0xF68C94B6a7000f1E695F6E49254e8Ac935009A70",
           "0x992515DfE6246FAa8f871DDd9E42Fa4fde84d9b6"
         ],
-        "enabledAddresses": null,
         "blockTimestamp": 2526843696
       }
     }


### PR DESCRIPTION
Latest subnet-evm code introduced breaking changes to the precompiles data structures. This PR adjusts to them.
Also added enabled address support to the createEVM workflow.

Closes https://github.com/ava-labs/avalanche-cli/issues/694 and https://github.com/ava-labs/avalanche-cli/issues/688