### PR TITLE
List validators

### DIFF
--- a/cmd/subnetcmd/subnet.go
+++ b/cmd/subnetcmd/subnet.go
@@ -66,5 +66,7 @@ manage your Subnet configurations and live deployments.`,
 	cmd.AddCommand(newRemoveValidatorCmd())
 	// subnet elastic
 	cmd.AddCommand(newElasticCmd())
+	// subnet validators
+	cmd.AddCommand(newValidatorsCmd())
 	return cmd
 }

--- a/cmd/subnetcmd/validators.go
+++ b/cmd/subnetcmd/validators.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package subnetcmd
 
 import (

--- a/cmd/subnetcmd/validators.go
+++ b/cmd/subnetcmd/validators.go
@@ -60,7 +60,7 @@ func printValidators(_ *cobra.Command, args []string) error {
 	if network == models.Undefined {
 		// no flag was set, prompt user
 		networkStr, err := app.Prompt.CaptureList(
-			"Choose a network to deploy on",
+			"Choose a network to list validators from",
 			[]string{models.Local.String(), models.Fuji.String(), models.Mainnet.String()},
 		)
 		if err != nil {
@@ -108,7 +108,7 @@ func printPublicValidators(subnetID ids.ID, network models.Network) error {
 }
 
 func printValidatorsFromList(validators []platformvm.ClientPermissionlessValidator) error {
-	header := []string{"NodeID", "Stake Amount", "Delegator Weight", "Start Time", "End Time"}
+	header := []string{"NodeID", "Stake Amount", "Delegator Weight", "Start Time", "End Time", "Type"}
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader(header)
 	table.SetRowLine(true)
@@ -119,12 +119,18 @@ func printValidatorsFromList(validators []platformvm.ClientPermissionlessValidat
 			delegatorWeight = *validator.DelegatorWeight
 		}
 
+		validatorType := "permissioned"
+		if validator.PotentialReward != nil && *validator.PotentialReward > 0 {
+			validatorType = "elastic"
+		}
+
 		table.Append([]string{
 			validator.NodeID.String(),
 			strconv.FormatUint(*validator.StakeAmount, 10),
 			strconv.FormatUint(delegatorWeight, 10),
 			formatUnixTime(validator.StartTime),
 			formatUnixTime(validator.EndTime),
+			validatorType,
 		})
 	}
 

--- a/cmd/subnetcmd/validators.go
+++ b/cmd/subnetcmd/validators.go
@@ -1,0 +1,135 @@
+package subnetcmd
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/ava-labs/avalanche-cli/cmd/flags"
+	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanche-cli/pkg/subnet"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/platformvm"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+var (
+	validatorsLocal   bool
+	validatorsTestnet bool
+	validatorsMainnet bool
+)
+
+// avalanche subnet validators
+func newValidatorsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "validators [subnetName]",
+		Short: "List a subnet's validators",
+		Long: `The subnet validators command lists the validators of a subnet and provides
+severarl statistics about them.`,
+		RunE:         printValidators,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+	}
+	cmd.Flags().BoolVarP(&validatorsLocal, "local", "l", false, "deploy to a local network")
+	cmd.Flags().BoolVarP(&validatorsTestnet, "testnet", "t", false, "deploy to testnet (alias to `fuji`)")
+	cmd.Flags().BoolVarP(&validatorsTestnet, "fuji", "f", false, "deploy to fuji (alias to `testnet`")
+	cmd.Flags().BoolVarP(&validatorsMainnet, "mainnet", "m", false, "deploy to mainnet")
+	return cmd
+}
+
+func printValidators(_ *cobra.Command, args []string) error {
+	if !flags.EnsureMutuallyExclusive([]bool{validatorsLocal, validatorsTestnet, validatorsMainnet}) {
+		return errMutuallyExlusiveNetworks
+	}
+
+	var network models.Network
+	switch {
+	case validatorsLocal:
+		network = models.Local
+	case validatorsTestnet:
+		network = models.Fuji
+	case validatorsMainnet:
+		network = models.Mainnet
+	}
+
+	if network == models.Undefined {
+		// no flag was set, prompt user
+		networkStr, err := app.Prompt.CaptureList(
+			"Choose a network to deploy on",
+			[]string{models.Local.String(), models.Fuji.String(), models.Mainnet.String()},
+		)
+		if err != nil {
+			return err
+		}
+		network = models.NetworkFromString(networkStr)
+	}
+
+	// get the subnetID
+	sc, err := app.LoadSidecar(args[0])
+	if err != nil {
+		return err
+	}
+
+	deployInfo, ok := sc.Networks[network.String()]
+	if !ok {
+		return errors.New("no deployment found for subnet")
+	}
+
+	subnetID := deployInfo.SubnetID
+
+	if network == models.Local {
+		return printLocalValidators(subnetID)
+	} else {
+		return printPublicValidators(subnetID, network)
+	}
+}
+
+func printLocalValidators(subnetID ids.ID) error {
+	validators, err := subnet.GetSubnetValidators(subnetID)
+	if err != nil {
+		return err
+	}
+
+	return printValidatorsFromList(validators)
+}
+
+func printPublicValidators(subnetID ids.ID, network models.Network) error {
+	validators, err := subnet.GetPublicSubnetValidators(subnetID, network)
+	if err != nil {
+		return err
+	}
+
+	return printValidatorsFromList(validators)
+}
+
+func printValidatorsFromList(validators []platformvm.ClientPermissionlessValidator) error {
+	header := []string{"NodeID", "Stake Amount", "Delegator Weight", "Start Time", "End Time"}
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader(header)
+	table.SetRowLine(true)
+
+	for _, validator := range validators {
+		var delegatorWeight uint64
+		if validator.DelegatorWeight != nil {
+			delegatorWeight = *validator.DelegatorWeight
+		}
+
+		table.Append([]string{
+			validator.NodeID.String(),
+			strconv.FormatUint(*validator.StakeAmount, 10),
+			strconv.FormatUint(delegatorWeight, 10),
+			formatUnixTime(validator.StartTime),
+			formatUnixTime(validator.EndTime),
+		})
+	}
+
+	table.Render()
+
+	return nil
+}
+
+func formatUnixTime(unixTime uint64) string {
+	return time.Unix(int64(unixTime), 0).Format(time.RFC3339)
+}

--- a/pkg/subnet/public.go
+++ b/pkg/subnet/public.go
@@ -450,3 +450,25 @@ func IsSubnetValidator(subnetID ids.ID, nodeID ids.NodeID, network models.Networ
 
 	return !(len(vals) == 0), nil
 }
+
+func GetPublicSubnetValidators(subnetID ids.ID, network models.Network) ([]platformvm.ClientPermissionlessValidator, error) {
+	var apiURL string
+	switch network {
+	case models.Mainnet:
+		apiURL = constants.MainnetAPIEndpoint
+	case models.Fuji:
+		apiURL = constants.FujiAPIEndpoint
+	default:
+		return nil, fmt.Errorf("invalid network: %s", network)
+	}
+	pClient := platformvm.NewClient(apiURL)
+	ctx, cancel := context.WithTimeout(context.Background(), constants.E2ERequestTimeout)
+	defer cancel()
+
+	vals, err := pClient.GetCurrentValidators(ctx, subnetID, []ids.NodeID{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current validators")
+	}
+
+	return vals, nil
+}

--- a/tests/e2e/commands/subnet.go
+++ b/tests/e2e/commands/subnet.go
@@ -896,3 +896,19 @@ func AddPermissionlessValidator(subnetName string, nodeID string, stakeAmount st
 	}
 	return string(output), err
 }
+
+/* #nosec G204 */
+func ListValidators(subnetName string, network string) (string, error) {
+	// Create config
+	cmd := exec.Command(
+		CLIBinary,
+		SubnetCmd,
+		"validators",
+		subnetName,
+		"--"+network,
+		"--"+constants.SkipUpdateFlag,
+	)
+
+	out, err := cmd.Output()
+	return string(out), err
+}

--- a/tests/e2e/testcases/subnet/local/suite.go
+++ b/tests/e2e/testcases/subnet/local/suite.go
@@ -393,6 +393,28 @@ var _ = ginkgo.Describe("[Local Subnet]", ginkgo.Ordered, func() {
 
 		commands.DeleteSubnetConfig(subnetName)
 	})
+
+	ginkgo.It("can list a subnet's validators", func() {
+		nodeIDs := []string{
+			"NodeID-P7oB2McjBGgW2NXXWVYjV8JEDFoW9xDE5",
+			"NodeID-GWPcbFJZFfZreETSoWjPimr846mXEKCtu",
+			"NodeID-NFBbbJ4qCmNaCzeW7sxErhvWqvEQMnYcN",
+			"NodeID-MFrZFVCXPv5iCn6M9K6XduxGTYp891xXZ",
+			"NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg",
+		}
+
+		commands.CreateSubnetEvmConfig(subnetName, utils.SubnetEvmGenesisPath)
+		deployOutput := commands.DeploySubnetLocally(subnetName)
+		_, err := utils.ParseRPCsFromOutput(deployOutput)
+		if err != nil {
+			fmt.Println(deployOutput)
+		}
+		gomega.Expect(err).Should(gomega.BeNil())
+
+		output, err := commands.ListValidators(subnetName, "local")
+
+		commands.DeleteSubnetConfig(subnetName)
+	})
 })
 
 var _ = ginkgo.Describe("[Subnet Compatibility]", func() {

--- a/tests/e2e/testcases/subnet/local/suite.go
+++ b/tests/e2e/testcases/subnet/local/suite.go
@@ -412,6 +412,11 @@ var _ = ginkgo.Describe("[Local Subnet]", ginkgo.Ordered, func() {
 		gomega.Expect(err).Should(gomega.BeNil())
 
 		output, err := commands.ListValidators(subnetName, "local")
+		gomega.Expect(err).Should(gomega.BeNil())
+
+		for _, nodeID := range nodeIDs {
+			gomega.Expect(output).Should(gomega.ContainSubstring(nodeID))
+		}
 
 		commands.DeleteSubnetConfig(subnetName)
 	})


### PR DESCRIPTION
Add a command to list validators for a subnet. Works for local, fuji, and mainnet. Closes #733 