### PR TITLE
replace ledger sim wait seconds with interaction end notification channel

### DIFF
--- a/docs/ledger-simulator.md
+++ b/docs/ledger-simulator.md
@@ -13,10 +13,10 @@ It uses the `@zondax/zemu` js library to:
 - Previous steps can take some time. Once the app and rpc entry is ready, it prints a custom msg `SIMULATED LEDGER DEV READY` as a means to communicate 
   with the test code (or the user) that the simulator can start receiving requests (eg connect to it, ask for addresses, etc).
 - Instructs the simulated app (using simulated button presses from the zemu library) to sign `numApprovals` transactions. This number of transactions
-  to be approved must be in concordance with the number of transactions that the golang test asks the ledger to approve. In the meantime, the avalanche app
-  can also be queried by golang code so as for example to get the ledger addresses.
-- Wait for all transactions to be received and approved
-- Wait a user-given number of seconds.
+  to be approved must be in concordance with the number of transactions that the golang test asks the ledger to approve. 
+- Wait for all transactions to be received and approved. In the meantime, the avalanche app can be queried by golang code so as
+  for example to get the ledger addresses.
+- Wait for the user to press enter to end the simulator. In the meantime, the avalanche app can be queried by golang code.
 - Close the rpc entry point, closes the simulator, stops and remove the docker container.
 
 So, two main points of interaction with the simulated avalanche ledger app are available:
@@ -24,16 +24,15 @@ So, two main points of interaction with the simulated avalanche ledger app are a
 1. Interaction with the ledger from the golang app as if it were a real device: asking for addresses, sending txs to be signed.
 2. Interaction with the simulated physical ledger from the typescript code: pressing the ledger buttons in order to sign the transactions.
 
-The script receives three arguments: 
+The script receives two arguments: 
 
 - the number of transactions to sign (could be zero)
-- the number of seconds to wait after signing 
 - the seed for the ledger, that controls the ledger addresses (could be one word)
 
 Eg to start the ledger app and sign one transaction (will wait -with timeout- for that transaction to be sent):
 
 ```bash
-ts-node launcheAndApproveTxs.ts 1 0 ledger-seed
+ts-node launcheAndApproveTxs.ts 1 ledger-seed
 ```
 
 It can be executed directly by command line, or from inside golang test code.
@@ -56,14 +55,16 @@ Currently the rpc endpoint is hardcoded in ledger golang library to: `127.0.0.1:
 
 ## How a golang test executes and interacts with the typescript script
 
-The test should call `utils.StartLedgerSim(numApprovals, waitSeconds, ledgerSeed, showStdout)` by providing:
+The test should call `utils.StartLedgerSim(numApprovals, ledgerSeed, showStdout)` by providing:
 
 - number of txs to be approved by the ledger
-- number of seconds to be wait by ledger after approvals
 - seed for the ledger
 - wether to show stdout
 
-The function returns a channel that should be waited for to be confident the simulator stopped.
+The function returns two channels:
+
+- first one should be closed to notify the simulator that it can start shutdown process
+- second one should be waited for to be confident that the simulator stopped.
 
 See example on `deploy subnet to mainnet` test
 

--- a/tests/e2e/ledgerSim/launchAndApproveTxs.ts
+++ b/tests/e2e/ledgerSim/launchAndApproveTxs.ts
@@ -1,4 +1,10 @@
+import { createInterface } from "readline";
 import Zemu, { DEFAULT_START_OPTIONS } from "@zondax/zemu";
+
+const rl = createInterface({
+	input: process.stdin,
+	output: process.stdout
+});
 
 const Resolve = require('path').resolve
 
@@ -9,11 +15,14 @@ const grpcPort = 3002;
 const transportPort = 9998;
 const speculosApiPort = 5000;
 
-const numApprovals = parseInt(process.argv[2], 10);
-const waitSeconds = parseInt(process.argv[3], 10);
+var numApprovals = parseInt(process.argv[2], 10);
+if (isNaN(numApprovals)) {
+	numApprovals = 0;
+}
+
 var appSeed = "equip will roof matter pink blind book anxiety banner elbow sun young";
-if (process.argv[4] != undefined) {
-  appSeed = process.argv[4];
+if (process.argv[3] != undefined) {
+  appSeed = process.argv[3];
 }
 
 const options = {
@@ -35,12 +44,11 @@ async function main() {
   await sim.waitForText("Ready", waitTimeout, true);
   const readyScreen = await sim.snapshot();
 
-  console.log("")
-  console.log("SIMULATED LEDGER DEV READY")
-
-  await Zemu.sleep(waitSeconds*1000);
+  console.log("");
+  console.log("SIMULATED LEDGER DEV READY");
 
   for (let i = 0; i < numApprovals; i++) {
+    console.log("Ready to approve tx", i+1, "of", numApprovals);
     await sim.deleteEvents();
     await sim.waitUntilScreenIs(readyScreen, waitTimeout);
     await sim.waitUntilScreenIsNot(readyScreen, waitTimeout);
@@ -48,6 +56,11 @@ async function main() {
   }
 
   await Zemu.sleep(waitUntilClose);
+
+  await new Promise(resolve => {
+    rl.question("PRESS ENTER TO END SIMULATOR\n", resolve)
+  });
+
   await sim.close();
   await Zemu.stopAllEmuContainers();
 }

--- a/tests/e2e/testcases/subnet/public/suite.go
+++ b/tests/e2e/testcases/subnet/public/suite.go
@@ -99,7 +99,7 @@ var _ = ginkgo.Describe("[Public Subnet]", func() {
 
 	ginkgo.It("deploy subnet to mainnet", func() {
 		if os.Getenv("LEDGER_SIM") != "" {
-			_ = utils.StartLedgerSim(8, 0, ledger1Seed, true)
+			_, _ = utils.StartLedgerSim(8, ledger1Seed, true)
 		}
 		// fund ledger address
 		feeConfig := genesis.MainnetParams.TxFeeConfig
@@ -257,25 +257,28 @@ var _ = ginkgo.Describe("[Public Subnet]", func() {
 		gomega.Expect(err).Should(gomega.BeNil())
 
 		// obtain ledger1 addr
-		ledgerSimEndCh := utils.StartLedgerSim(0, 1, ledger1Seed, false)
+		interactionEndCh, ledgerSimEndCh := utils.StartLedgerSim(0, ledger1Seed, false)
 		ledger1Addr, err := utils.GetLedgerAddress(models.Local, 0)
 		gomega.Expect(err).Should(gomega.BeNil())
+		close(interactionEndCh)
 		<-ledgerSimEndCh
 
 		// obtain ledger2 addr
-		ledgerSimEndCh = utils.StartLedgerSim(0, 1, ledger2Seed, false)
+		interactionEndCh, ledgerSimEndCh = utils.StartLedgerSim(0, ledger2Seed, false)
 		ledger2Addr, err := utils.GetLedgerAddress(models.Local, 0)
 		gomega.Expect(err).Should(gomega.BeNil())
+		close(interactionEndCh)
 		<-ledgerSimEndCh
 
 		// obtain ledger3 addr
-		ledgerSimEndCh = utils.StartLedgerSim(0, 1, ledger3Seed, false)
+		interactionEndCh, ledgerSimEndCh = utils.StartLedgerSim(0, ledger3Seed, false)
 		ledger3Addr, err := utils.GetLedgerAddress(models.Local, 0)
 		gomega.Expect(err).Should(gomega.BeNil())
+		close(interactionEndCh)
 		<-ledgerSimEndCh
 
 		// start the deploy process with ledger2
-		ledgerSimEndCh = utils.StartLedgerSim(3, 0, ledger2Seed, true)
+		interactionEndCh, ledgerSimEndCh = utils.StartLedgerSim(3, ledger2Seed, true)
 
 		// multisig deploy from unfunded ledger2 should not create any subnet/blockchain
 		gomega.Expect(err).Should(gomega.BeNil())
@@ -289,7 +292,7 @@ var _ = ginkgo.Describe("[Public Subnet]", func() {
 		toMatch := "(?s).+Ledger addresses:.+  " + ledger2Addr + ".+Error: insufficient funds.+"
 		matched, err := regexp.MatchString(toMatch, s)
 		gomega.Expect(err).Should(gomega.BeNil())
-		gomega.Expect(matched).Should(gomega.Equal(true))
+		gomega.Expect(matched).Should(gomega.Equal(true), "no match between command output %q and pattern %q", s, toMatch)
 
 		// let's fund the ledger
 		err = utils.FundLedgerAddress(genesis.MainnetParams.TxFeeConfig.CreateSubnetTxFee + genesis.MainnetParams.TxFeeConfig.CreateBlockchainTxFee)
@@ -309,9 +312,10 @@ var _ = ginkgo.Describe("[Public Subnet]", func() {
 			"Addresses remaining to sign the tx\\s+" + ledger3Addr + ".+"
 		matched, err = regexp.MatchString(toMatch, s)
 		gomega.Expect(err).Should(gomega.BeNil())
-		gomega.Expect(matched).Should(gomega.Equal(true))
+		gomega.Expect(matched).Should(gomega.Equal(true), "no match between command output %q and pattern %q", s, toMatch)
 
 		// wait for end of ledger2 simulation
+		close(interactionEndCh)
 		<-ledgerSimEndCh
 
 		// try to commit before signature is complete (no funded wallet needed for commit)
@@ -325,21 +329,22 @@ var _ = ginkgo.Describe("[Public Subnet]", func() {
 			".+Error: tx is not fully signed.+"
 		matched, err = regexp.MatchString(toMatch, s)
 		gomega.Expect(err).Should(gomega.BeNil())
-		gomega.Expect(matched).Should(gomega.Equal(true))
+		gomega.Expect(matched).Should(gomega.Equal(true), "no match between command output %q and pattern %q", s, toMatch)
 
 		// try to sign using unauthorized ledger1
-		ledgerSimEndCh = utils.StartLedgerSim(0, 1, ledger1Seed, true)
+		interactionEndCh, ledgerSimEndCh = utils.StartLedgerSim(0, ledger1Seed, true)
 		s = commands.TransactionSignWithLedger(
 			subnetName,
 			txPath,
 			true,
 		)
+		close(interactionEndCh)
 		<-ledgerSimEndCh
 		toMatch = "(?s).+Ledger addresses:.+  " + ledger1Addr + ".+There are no required subnet auth keys present in the wallet.+" +
 			"Expected one of:\\s+" + ledger3Addr + ".+Error: no remaining signer address present in wallet.*"
 		matched, err = regexp.MatchString(toMatch, s)
 		gomega.Expect(err).Should(gomega.BeNil())
-		gomega.Expect(matched).Should(gomega.Equal(true))
+		gomega.Expect(matched).Should(gomega.Equal(true), "no match between command output %q and pattern %q", s, toMatch)
 
 		// try to commit before signature is complete
 		s = commands.TransactionCommit(
@@ -352,21 +357,22 @@ var _ = ginkgo.Describe("[Public Subnet]", func() {
 			".+Error: tx is not fully signed.+"
 		matched, err = regexp.MatchString(toMatch, s)
 		gomega.Expect(err).Should(gomega.BeNil())
-		gomega.Expect(matched).Should(gomega.Equal(true))
+		gomega.Expect(matched).Should(gomega.Equal(true), "no match between command output %q and pattern %q", s, toMatch)
 
 		// try to sign using ledger2 which already signed
-		ledgerSimEndCh = utils.StartLedgerSim(0, 1, ledger2Seed, true)
+		interactionEndCh, ledgerSimEndCh = utils.StartLedgerSim(0, ledger2Seed, true)
 		s = commands.TransactionSignWithLedger(
 			subnetName,
 			txPath,
 			true,
 		)
+		close(interactionEndCh)
 		<-ledgerSimEndCh
 		toMatch = "(?s).+Ledger addresses:.+  " + ledger2Addr + ".+There are no required subnet auth keys present in the wallet.+" +
 			"Expected one of:\\s+" + ledger3Addr + ".+Error: no remaining signer address present in wallet.*"
 		matched, err = regexp.MatchString(toMatch, s)
 		gomega.Expect(err).Should(gomega.BeNil())
-		gomega.Expect(matched).Should(gomega.Equal(true))
+		gomega.Expect(matched).Should(gomega.Equal(true), "no match between command output %q and pattern %q", s, toMatch)
 
 		// try to commit before signature is complete
 		s = commands.TransactionCommit(
@@ -379,33 +385,35 @@ var _ = ginkgo.Describe("[Public Subnet]", func() {
 			".+Error: tx is not fully signed.+"
 		matched, err = regexp.MatchString(toMatch, s)
 		gomega.Expect(err).Should(gomega.BeNil())
-		gomega.Expect(matched).Should(gomega.Equal(true))
+		gomega.Expect(matched).Should(gomega.Equal(true), "no match between command output %q and pattern %q", s, toMatch)
 
 		// sign with ledger3
-		ledgerSimEndCh = utils.StartLedgerSim(1, 0, ledger3Seed, true)
+		interactionEndCh, ledgerSimEndCh = utils.StartLedgerSim(1, ledger3Seed, true)
 		s = commands.TransactionSignWithLedger(
 			subnetName,
 			txPath,
 			false,
 		)
+		close(interactionEndCh)
 		<-ledgerSimEndCh
 		toMatch = "(?s).+Ledger addresses:.+  " + ledger3Addr + ".+Tx is fully signed, and ready to be committed.+"
 		matched, err = regexp.MatchString(toMatch, s)
 		gomega.Expect(err).Should(gomega.BeNil())
-		gomega.Expect(matched).Should(gomega.Equal(true))
+		gomega.Expect(matched).Should(gomega.Equal(true), "no match between command output %q and pattern %q", s, toMatch)
 
 		// try to sign using ledger3 which already signedtx is already fully signed"
-		ledgerSimEndCh = utils.StartLedgerSim(0, 1, ledger3Seed, true)
+		interactionEndCh, ledgerSimEndCh = utils.StartLedgerSim(0, ledger3Seed, true)
 		s = commands.TransactionSignWithLedger(
 			subnetName,
 			txPath,
 			true,
 		)
+		close(interactionEndCh)
 		<-ledgerSimEndCh
 		toMatch = "(?s).*Tx is fully signed, and ready to be committed.+Error: tx is already fully signed"
 		matched, err = regexp.MatchString(toMatch, s)
 		gomega.Expect(err).Should(gomega.BeNil())
-		gomega.Expect(matched).Should(gomega.Equal(true))
+		gomega.Expect(matched).Should(gomega.Equal(true), "no match between command output %q and pattern %q", s, toMatch)
 
 		// commit after complete signature
 		s = commands.TransactionCommit(
@@ -416,7 +424,7 @@ var _ = ginkgo.Describe("[Public Subnet]", func() {
 		toMatch = "(?s).+DEPLOYMENT RESULTS.+Blockchain ID.+"
 		matched, err = regexp.MatchString(toMatch, s)
 		gomega.Expect(err).Should(gomega.BeNil())
-		gomega.Expect(matched).Should(gomega.Equal(true))
+		gomega.Expect(matched).Should(gomega.Equal(true), "no match between command output %q and pattern %q", s, toMatch)
 
 		// try to commit again
 		s = commands.TransactionCommit(
@@ -427,6 +435,6 @@ var _ = ginkgo.Describe("[Public Subnet]", func() {
 		toMatch = "(?s).*Error: failed to decode client response: couldn't issue tx: failed to read consumed.+"
 		matched, err = regexp.MatchString(toMatch, s)
 		gomega.Expect(err).Should(gomega.BeNil())
-		gomega.Expect(matched).Should(gomega.Equal(true))
+		gomega.Expect(matched).Should(gomega.Equal(true), "no match between command output %q and pattern %q", s, toMatch)
 	})
 })

--- a/tests/e2e/testcases/subnet/public/suite.go
+++ b/tests/e2e/testcases/subnet/public/suite.go
@@ -98,8 +98,9 @@ var _ = ginkgo.Describe("[Public Subnet]", func() {
 	})
 
 	ginkgo.It("deploy subnet to mainnet", func() {
+		var interactionEndCh, ledgerSimEndCh chan struct{}
 		if os.Getenv("LEDGER_SIM") != "" {
-			_, _ = utils.StartLedgerSim(8, ledger1Seed, true)
+			interactionEndCh, ledgerSimEndCh = utils.StartLedgerSim(8, ledger1Seed, true)
 		}
 		// fund ledger address
 		feeConfig := genesis.MainnetParams.TxFeeConfig
@@ -122,6 +123,8 @@ var _ = ginkgo.Describe("[Public Subnet]", func() {
 			_ = commands.SimulateMainnetAddValidator(subnetName, nodeInfo.ID, start, "24h", "20")
 			nodeIdx++
 		}
+		close(interactionEndCh)
+		<-ledgerSimEndCh
 		fmt.Println(logging.LightBlue.Wrap("EXECUTING NON INTERACTIVE PART OF THE TEST: JOIN/WHITELIST/WAIT/HARDHAT"))
 		// join to copy vm binary and update config file
 		for _, nodeInfo := range nodeInfos {

--- a/tests/e2e/utils/helpers.go
+++ b/tests/e2e/utils/helpers.go
@@ -514,7 +514,7 @@ func RunLedgerSim(
 			}
 			if line == "PRESS ENTER TO END SIMULATOR" {
 				<-interactionEndCh
-				io.WriteString(stdinPipe, "\n")
+				_, _ = io.WriteString(stdinPipe, "\n")
 			}
 			if showStdout {
 				fmt.Println(line)

--- a/tests/e2e/utils/helpers.go
+++ b/tests/e2e/utils/helpers.go
@@ -453,29 +453,29 @@ func SetHardhatRPC(rpc string) error {
 
 func StartLedgerSim(
 	iters int,
-	secondsToWait int,
 	seed string,
 	showStdout bool,
-) chan struct{} {
+) (chan struct{}, chan struct{}) {
 	ledgerSimReadyCh := make(chan struct{})
+	interactionEndCh := make(chan struct{})
 	ledgerSimEndCh := make(chan struct{})
 	go func() {
 		defer ginkgo.GinkgoRecover()
-		err := RunLedgerSim(iters, secondsToWait, seed, ledgerSimReadyCh, ledgerSimEndCh, showStdout)
+		err := RunLedgerSim(iters, seed, ledgerSimReadyCh, interactionEndCh, ledgerSimEndCh, showStdout)
 		if err != nil {
 			fmt.Println(err)
 		}
 		gomega.Expect(err).Should(gomega.BeNil())
 	}()
 	<-ledgerSimReadyCh
-	return ledgerSimEndCh
+	return interactionEndCh, ledgerSimEndCh
 }
 
 func RunLedgerSim(
 	iters int,
-	secondsToWait int,
 	seed string,
 	ledgerSimReadyCh chan struct{},
+	interactionEndCh chan struct{},
 	ledgerSimEndCh chan struct{},
 	showStdout bool,
 ) error {
@@ -483,11 +483,14 @@ func RunLedgerSim(
 		"ts-node",
 		basicLedgerSimScript,
 		fmt.Sprintf("%d", iters),
-		fmt.Sprintf("%d", secondsToWait),
 		seed,
 	)
 	cmd.Dir = ledgerSimDir
 
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
 		return err
@@ -508,6 +511,10 @@ func RunLedgerSim(
 			line = strings.TrimSpace(line)
 			if line == "SIMULATED LEDGER DEV READY" {
 				close(ledgerSimReadyCh)
+			}
+			if line == "PRESS ENTER TO END SIMULATOR" {
+				<-interactionEndCh
+				io.WriteString(stdinPipe, "\n")
 			}
 			if showStdout {
 				fmt.Println(line)


### PR DESCRIPTION
Closes https://github.com/ava-labs/avalanche-cli/issues/955
Previously: the ts script had a wait time before finishing, to give time to the golang process to query the simulator. But in certain interleaves in low resource machines, the golang process query arrived after the script finished. This PR adds a golang channel + stdin/stdout based protocol so as the golang process tells the simulator when to start the stop process.