### PR TITLE
add colored table to node status output

### DIFF
--- a/cmd/nodecmd/status.go
+++ b/cmd/nodecmd/status.go
@@ -4,6 +4,8 @@ package nodecmd
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/ava-labs/avalanche-cli/cmd/subnetcmd"
 	"github.com/ava-labs/avalanche-cli/pkg/ansible"
@@ -11,7 +13,9 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
+	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 )
@@ -47,7 +51,16 @@ func statusSubnet(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	ux.Logger.PrintToUser(fmt.Sprintf("Collecting data for node(s) in cluster %s ...", clusterName))
+	if subnetName != "" {
+		// check subnet first
+		if _, err := subnetcmd.ValidateSubnetNameAndGetChains([]string{subnetName}); err != nil {
+			return err
+		}
+	}
+	notBootstrappedNodes, err := checkClusterIsBootstrapped(clusterName)
+	if err != nil {
+		return err
+	}
 	avalanchegoVersionForNode := map[string]string{}
 	if err := app.CreateAnsibleStatusDir(); err != nil {
 		return err
@@ -65,10 +78,10 @@ func statusSubnet(_ *cobra.Command, args []string) error {
 		}
 		avalanchegoVersionForNode[host] = avalancheGoVersion
 	}
+	notSyncedNodes := []string{}
+	subnetSyncedNodes := []string{}
+	subnetValidatingNodes := []string{}
 	if subnetName != "" {
-		if _, err := subnetcmd.ValidateSubnetNameAndGetChains([]string{subnetName}); err != nil {
-			return err
-		}
 		sc, err := app.LoadSidecar(subnetName)
 		if err != nil {
 			return err
@@ -77,9 +90,6 @@ func statusSubnet(_ *cobra.Command, args []string) error {
 		if blockchainID == ids.Empty {
 			return ErrNoBlockchainID
 		}
-		notSyncedNodes := []string{}
-		subnetSyncedNodes := []string{}
-		subnetValidatingNodes := []string{}
 		if err := ansible.RunAnsiblePlaybookSubnetSyncStatus(app.GetAnsibleDir(), app.GetSubnetSyncJSONFile(), blockchainID.String(), app.GetAnsibleInventoryDirPath(clusterName), "all"); err != nil {
 			return err
 		}
@@ -97,55 +107,57 @@ func statusSubnet(_ *cobra.Command, args []string) error {
 				notSyncedNodes = append(notSyncedNodes, host)
 			}
 		}
-		printOutput(avalanchegoVersionForNode, ansibleHostIDs, notSyncedNodes, subnetSyncedNodes, subnetValidatingNodes, clusterName, subnetName)
-		return nil
 	}
-	notBootstrappedNodes, err := checkClusterIsBootstrapped(clusterName)
-	if err != nil {
-		return err
-	}
-	printOutput(avalanchegoVersionForNode, ansibleHostIDs, notBootstrappedNodes, nil, nil, clusterName, subnetName)
+	printOutput(ansibleHostIDs, avalanchegoVersionForNode, notBootstrappedNodes, notSyncedNodes, subnetSyncedNodes, subnetValidatingNodes, clusterName, subnetName)
 	return nil
 }
 
-func printOutput(hostAvalanchegoVersions map[string]string, hostAliases, notBootstrappedHosts, subnetSyncedHosts, subnetValidatingHosts []string, clusterName, subnetName string) {
-	if len(notBootstrappedHosts) == 0 {
-		if subnetName == "" {
-			ux.Logger.PrintToUser("All nodes in cluster %s are bootstrapped to Primary Network!", clusterName)
-		} else {
-			// all nodes are either synced to or validating subnet
-			status := "synced to"
-			if len(subnetSyncedHosts) == 0 {
-				status = "validators of"
-			}
-			ux.Logger.PrintToUser("All nodes in cluster %s are %s Subnet %s", clusterName, status, subnetName)
-		}
-		return
+func printOutput(hostAliases []string, avagoVersions map[string]string, notBootstrappedHosts, notSyncedHosts, subnetSyncedHosts, subnetValidatingHosts []string, clusterName, subnetName string) {
+	if subnetName == "" && len(notBootstrappedHosts) == 0 {
+		ux.Logger.PrintToUser("All nodes in cluster %s are bootstrapped to Primary Network!", clusterName)
 	}
-	ux.Logger.PrintToUser("Node(s) Status For Cluster %s", clusterName)
-	ux.Logger.PrintToUser("======================================")
+	if subnetName != "" && len(notSyncedHosts) == 0 {
+		// all nodes are either synced to or validating subnet
+		status := "synced to"
+		if len(subnetSyncedHosts) == 0 {
+			status = "validators of"
+		}
+		ux.Logger.PrintToUser("All nodes in cluster %s are %s Subnet %s", clusterName, status, subnetName)
+	}
+
+	ux.Logger.PrintToUser("")
+	tit := fmt.Sprintf("STATUS FOR CLUSTER: %s", clusterName)
+	ux.Logger.PrintToUser(tit)
+	ux.Logger.PrintToUser(strings.Repeat("=", len(tit)))
+	ux.Logger.PrintToUser("")
+	header := []string{"Node", "Avago Version", "Primary Network"}
+	if subnetName != "" {
+		header = append(header, "Subnet "+subnetName)
+	}
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader(header)
+	table.SetRowLine(true)
 	for _, host := range hostAliases {
-		hostWithVersion := fmt.Sprintf("%s (%s)", host, hostAvalanchegoVersions[host])
-		hostIsBootstrapped := true
+		boostrappedStatus := logging.Green.Wrap("OK")
 		if slices.Contains(notBootstrappedHosts, host) {
-			hostIsBootstrapped = false
+			boostrappedStatus = logging.Red.Wrap("ERR")
 		}
-		hostStatus := "synced to"
-		if slices.Contains(subnetValidatingHosts, host) {
-			hostStatus = "validator of"
+		row := []string{
+			host,
+			avagoVersions[host],
+			boostrappedStatus,
 		}
-		if subnetName == "" {
-			isBootstrappedStr := "is not"
-			if hostIsBootstrapped {
-				isBootstrappedStr = "is"
+		if subnetName != "" {
+			syncedStatus := logging.Red.Wrap("ERR")
+			if slices.Contains(subnetSyncedHosts, host) {
+				syncedStatus = logging.Green.Wrap("Synced")
 			}
-			ux.Logger.PrintToUser("Node %s %s bootstrapped to Primary Network", hostWithVersion, isBootstrappedStr)
-		} else {
-			if !hostIsBootstrapped {
-				ux.Logger.PrintToUser("Node %s is not synced to Subnet %s", hostWithVersion, subnetName)
-			} else {
-				ux.Logger.PrintToUser("Node %s is %s Subnet %s", hostWithVersion, hostStatus, subnetName)
+			if slices.Contains(subnetValidatingHosts, host) {
+				syncedStatus = logging.Green.Wrap("Validating")
 			}
+			row = append(row, syncedStatus)
 		}
+		table.Append(row)
 	}
+	table.Render()
 }


### PR DESCRIPTION
avalanche node status newCluster --subnet custom

![Screenshot from 2023-10-24 16-24-51](https://github.com/ava-labs/avalanche-cli/assets/12205242/234a2b35-6d1d-4c64-863f-bc71591af378)

avalanche node status cluster2 

![Screenshot from 2023-10-24 16-25-04](https://github.com/ava-labs/avalanche-cli/assets/12205242/656291db-e683-4f97-a723-ffc547022c9f)

avalanche node status cluster2 --subnet custom

![Screenshot from 2023-10-24 16-25-12](https://github.com/ava-labs/avalanche-cli/assets/12205242/1da5ed89-5587-41b2-8fd0-86fc2050f6cd)

