### PR TITLE
Don't ask about metrics for completion command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,7 +122,7 @@ func createApp(cmd *cobra.Command, _ []string) error {
 	if err := migrations.RunMigrations(app); err != nil {
 		return err
 	}
-	if os.Getenv("RUN_E2E") == "" && !app.Conf.ConfigFileExists() && !utils.FileExists(utils.UserHomePath(constants.OldMetricsConfigFileName)) {
+	if os.Getenv("RUN_E2E") == "" && !app.Conf.ConfigFileExists() && !utils.FileExists(utils.UserHomePath(constants.OldMetricsConfigFileName)) && metrics.CheckCommandIsNotCompletion(cmd) {
 		err = metrics.HandleUserMetricsPreference(app)
 		if err != nil {
 			return err

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -81,13 +81,13 @@ func userIsOptedIn(app *application.Avalanche) bool {
 
 func HandleTracking(cmd *cobra.Command, app *application.Avalanche, flags map[string]string) {
 	if userIsOptedIn(app) {
-		if !cmd.HasSubCommands() && checkCommandIsNotCompletion(cmd) {
+		if !cmd.HasSubCommands() && CheckCommandIsNotCompletion(cmd) {
 			TrackMetrics(cmd, flags)
 		}
 	}
 }
 
-func checkCommandIsNotCompletion(cmd *cobra.Command) bool {
+func CheckCommandIsNotCompletion(cmd *cobra.Command) bool {
 	result := strings.Fields(cmd.CommandPath())
 	if len(result) >= 2 && result[1] == "completion" {
 		return false


### PR DESCRIPTION
Fix #1206

The undocumented `completion` command is used in the installation script in order to output shell completion for the current shell. At that stage, in general, we're in a fresh installation and the user hasn't decided yet about metrics opt-in. In the current version, the command will ask about metrics opt-in making the step `completions()` of the installation process always fail.

This PR fixes this by adding a check using the existing `CheckCommandIsNotCompletion` function (made public) before deciding that it's time to ask the user about metrics opt-in