### PR TITLE
Instance type interactive input for user

### DIFF
--- a/cmd/nodecmd/create.go
+++ b/cmd/nodecmd/create.go
@@ -635,7 +635,7 @@ func setCloudInstanceType(cloudService string) (string, error) {
 		}
 		nodeTypeStr = strings.ReplaceAll(nodeTypeStr, defaultStr, "") // remove (default) if any
 		if nodeTypeStr == customNodeType {
-			nodeTypeStr, err = app.Prompt.CaptureString("What instance type would you like to use? Please refer to https://docs.avax.network/nodes/run/node-manually#hardware-and-os-requirements for minimum hardware requirements.")
+			nodeTypeStr, err = app.Prompt.CaptureString("What instance type would you like to use? Please refer to https://docs.avax.network/nodes/run/node-manually#hardware-and-os-requirements for minimum hardware requirements")
 			if err != nil {
 				ux.Logger.PrintToUser("Failed to capture custom node type with error: %s", err.Error())
 				return "", err


### PR DESCRIPTION
```
❯ ./bin/avalanche node create cloudWOTF
✔ Fuji
✔ Amazon Web Services
Use the arrow keys to navigate: ↓ ↑ → ←
? Instance type to use:
  ▸ c5.2xlarge
    t3a.2xlarge
    c5n.2xlarge
    Choose custom instance type
  ```
`✗ What instance type would you like to use? Please refer to https://docs.avax.network/nodes/run/node-manually#hardware-and-os-requirements for minimum hardware requirements.: █`
 
and 
```
❯ ./bin/avalanche node create cloudWOTF
✔ Fuji
✔ Google Cloud Platform
Use the arrow keys to navigate: ↓ ↑ → ←
? Instance type to use:
  ▸ e2-standard-8
    c3-highcpu-8
    n2-standard-8
    Choose custom instance type
```

