### PR TITLE
use new format for compatibility

### DIFF
--- a/cmd/networkcmd/start_test.go
+++ b/cmd/networkcmd/start_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testAvagoCompat = []byte("{\"19\": [\"v1.9.2\"],\"18\": [\"v1.9.1\"],\"17\": [\"v1.9.0\",\"v1.8.0\"]}")
+var testAvagoCompat = []byte("{\"19\": [{\"major\": 1, \"minor\": 9, \"patch\": 2}],\"18\": [{\"major\": 1, \"minor\": 9, \"patch\": 1}],\"17\": [{\"major\": 1, \"minor\": 9, \"patch\": 0},{\"major\": 1, \"minor\": 8, \"patch\": 0}]}")
 
 func Test_determineAvagoVersion(t *testing.T) {
 	subnetName1 := "test1"

--- a/cmd/subnetcmd/deploy_test.go
+++ b/cmd/subnetcmd/deploy_test.go
@@ -20,7 +20,7 @@ const (
 	testLatestAvagoVersion = "latest"
 )
 
-var testAvagoCompat = []byte("{\"19\": [\"v1.9.2\"],\"18\": [\"v1.9.1\"],\"17\": [\"v1.9.0\",\"v1.8.0\"]}")
+var testAvagoCompat = []byte("{\"19\": [{\"major\": 1, \"minor\": 9, \"patch\": 2}],\"18\": [{\"major\": 1, \"minor\": 9, \"patch\": 1}],\"17\": [{\"major\": 1, \"minor\": 9, \"patch\": 0},{\"major\": 1, \"minor\": 8, \"patch\": 0}]}")
 
 func TestMutuallyExclusive(t *testing.T) {
 	require := require.New(t)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -226,7 +226,7 @@ const (
 
 	AvalancheGoVersionUnknown            = "n/a"
 	AvalancheGoCompatibilityVersionAdded = "v1.9.2"
-	AvalancheGoCompatibilityURL          = "https://raw.githubusercontent.com/ava-labs/avalanchego/master/version/compatibility.json"
+	AvalancheGoCompatibilityURL          = "https://raw.githubusercontent.com/ava-labs/avalanchego/simplify-version/version/compatibility.json"
 	SubnetEVMRPCCompatibilityURL         = "https://raw.githubusercontent.com/ava-labs/subnet-evm/master/compatibility.json"
 
 	YesLabel = "Yes"

--- a/pkg/models/compatibility.go
+++ b/pkg/models/compatibility.go
@@ -3,8 +3,10 @@
 
 package models
 
+import "github.com/ava-labs/avalanchego/version"
+
 type VMCompatibility struct {
 	RPCChainVMProtocolVersion map[string]int `json:"rpcChainVMProtocolVersion"`
 }
 
-type AvagoCompatiblity map[string][]string
+type AvagoCompatiblity map[uint][]*version.Semantic

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
+	"github.com/ava-labs/avalanchego/version"
 )
 
 func SetupRealtimeCLIOutput(cmd *exec.Cmd, redirectStdout bool, redirectStderr bool) (*bytes.Buffer, *bytes.Buffer) {
@@ -184,4 +185,8 @@ func Unique(slice []string) []string {
 		}
 	}
 	return uniqueSlice
+}
+
+func SemanticSliceToStringSlice(versions []*version.Semantic) []string {
+	return Map(versions, func(v *version.Semantic) string { return v.String() })
 }

--- a/pkg/vm/compatibility.go
+++ b/pkg/vm/compatibility.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	pb "github.com/ava-labs/avalanchego/proto/pb/vm/runtime"
-	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/grpcutils"
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/gruntime"
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/runtime"
@@ -181,7 +180,7 @@ func GetAvalancheGoVersionsForRPC(app *application.Avalanche, rpcVersion int, ur
 		return nil, ErrNoAvagoVersion
 	}
 
-	eligibleVersionsStrSlice := utils.Map(eligibleVersions, func(v *version.Semantic) string { return v.String() })
+	eligibleVersionsStrSlice := utils.SemanticSliceToStringSlice(eligibleVersions)
 
 	// versions are not necessarily sorted, so we need to sort them, tho this puts them in ascending order
 	semver.Sort(eligibleVersionsStrSlice)

--- a/pkg/vm/compatibility.go
+++ b/pkg/vm/compatibility.go
@@ -10,10 +10,10 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	pb "github.com/ava-labs/avalanchego/proto/pb/vm/runtime"
+	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/grpcutils"
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/gruntime"
 	"github.com/ava-labs/avalanchego/vms/rpcchainvm/runtime"
@@ -23,6 +23,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"golang.org/x/mod/semver"
 )
 
@@ -175,14 +176,16 @@ func GetAvalancheGoVersionsForRPC(app *application.Avalanche, rpcVersion int, ur
 		return nil, err
 	}
 
-	eligibleVersions, ok := parsedCompat[strconv.Itoa(rpcVersion)]
+	eligibleVersions, ok := parsedCompat[uint(rpcVersion)]
 	if !ok {
 		return nil, ErrNoAvagoVersion
 	}
 
+	eligibleVersionsStrSlice := utils.Map(eligibleVersions, func(v *version.Semantic) string { return v.String() })
+
 	// versions are not necessarily sorted, so we need to sort them, tho this puts them in ascending order
-	semver.Sort(eligibleVersions)
-	return eligibleVersions, nil
+	semver.Sort(eligibleVersionsStrSlice)
+	return eligibleVersionsStrSlice, nil
 }
 
 // GetAvailableAvalancheGoVersions returns list of only available for download avalanche go versions,

--- a/pkg/vm/compatibility_test.go
+++ b/pkg/vm/compatibility_test.go
@@ -21,10 +21,10 @@ const (
 
 var (
 	testSubnetEVMCompat = []byte("{\"rpcChainVMProtocolVersion\": {\"v0.4.2\": 18,\"v0.4.1\": 18,\"v0.4.0\": 17}}")
-	testAvagoCompat     = []byte("{\"19\": [\"v1.9.2\"],\"18\": [\"v1.9.1\"],\"17\": [\"v1.9.0\",\"v1.8.0\"]}")
-	testAvagoCompat2    = []byte("{\"19\": [\"v1.9.2\", \"v1.9.1\"],\"18\": [\"v1.9.0\"]}")
-	testAvagoCompat3    = []byte("{\"19\": [\"v1.9.1\", \"v1.9.2\"],\"18\": [\"v1.9.0\"]}")
-	testAvagoCompat4    = []byte("{\"19\": [\"v1.9.1\", \"v1.9.2\", \"v1.9.11\"],\"18\": [\"v1.9.0\"]}")
+	testAvagoCompat     = []byte("{\"19\": [{\"major\": 1, \"minor\": 9, \"patch\": 2}], \"18\": [{\"major\": 1, \"minor\": 9, \"patch\": 1}], \"17\": [{\"major\": 1, \"minor\": 9, \"patch\": 0},{\"major\": 1, \"minor\": 8, \"patch\": 0}]}")
+	testAvagoCompat2    = []byte("{\"19\": [{\"major\": 1, \"minor\": 9, \"patch\": 2}, {\"major\": 1, \"minor\": 9, \"patch\": 1}], \"18\": [{\"major\": 1, \"minor\": 9, \"patch\": 0}]}")
+	testAvagoCompat3    = []byte("{\"19\": [{\"major\": 1, \"minor\": 9, \"patch\": 1}, {\"major\": 1, \"minor\": 9, \"patch\": 2}], \"18\": [{\"major\": 1, \"minor\": 9, \"patch\": 0}]}")
+	testAvagoCompat4    = []byte("{\"19\": [{\"major\": 1, \"minor\": 9, \"patch\": 1}, {\"major\": 1, \"minor\": 9, \"patch\": 2}, {\"major\": 1, \"minor\": 9, \"patch\": 11}], \"18\": [{\"major\": 1, \"minor\": 9, \"patch\": 0}]}")
 )
 
 func TestGetRPCProtocolVersionSubnetEVM(t *testing.T) {

--- a/tests/e2e/utils/versions_test.go
+++ b/tests/e2e/utils/versions_test.go
@@ -9,11 +9,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/ava-labs/avalanche-cli/pkg/application"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/mod/semver"
@@ -79,7 +79,7 @@ func (m *testMapper) GetLatestAvagoByProtoVersion(_ *application.Avalanche, rpcV
 	if err := json.Unmarshal(cBytes, &compat); err != nil {
 		return "", err
 	}
-	vers := compat[strconv.Itoa(rpcVersion)]
+	vers := utils.SemanticSliceToStringSlice(compat[uint(rpcVersion)])
 	if len(vers) == 0 {
 		return "", errors.New("test zero length versions")
 	}
@@ -198,14 +198,14 @@ func TestGetVersionMapping(t *testing.T) {
 				  }`,
 			sourceAvago: `{
 						"19": [
-							"v1.9.2",
-							"v1.9.3"
+							{"major": 1, "minor": 9, "patch": 2},
+							{"major": 1, "minor": 9, "patch": 3}
 						],
 						"18": [
-							"v1.9.1"
+							{"major": 1, "minor": 9, "patch": 1}
 						],
 						"17": [
-							"v1.9.0"
+							{"major": 1, "minor": 9, "patch": 0}
 						]
 				  }`,
 		},
@@ -237,14 +237,14 @@ func TestGetVersionMapping(t *testing.T) {
 			  }`,
 			sourceAvago: `{
 					"99": [
-						"v2.3.4",
-						"v2.3.3"
+						{"major": 2, "minor": 3, "patch": 4},
+						{"major": 2, "minor": 3, "patch": 3}
 					],
 					"18": [
-						"v1.9.1"
+						{"major": 1, "minor": 9, "patch": 1}
 					],
 					"17": [
-						"v1.9.0"
+						{"major": 1, "minor": 9, "patch": 0}
 					]
 			  }`,
 		},
@@ -278,26 +278,26 @@ func TestGetVersionMapping(t *testing.T) {
 			  }`,
 			sourceAvago: `{
 					"99": [
-						"v4.3.2"
+						{"major": 4, "minor": 3, "patch": 2}
 					],
 					"88": [
-						"v2.3.4"
+						{"major": 2, "minor": 3, "patch": 4}
 					],
 					"87": [
-						"v2.2.2"
+						{"major": 2, "minor": 2, "patch": 2}
 					],
 					"86": [
-						"v2.2.1"
+						{"major": 2, "minor": 2, "patch": 1}
 					],
 					"77": [
-						"v2.1.1",
-						"v2.1.0"
+						{"major": 2, "minor": 1, "patch": 1},
+						{"major": 2, "minor": 1, "patch": 0}
 					],
 					"18": [
-						"v1.9.1"
+						{"major": 1, "minor": 9, "patch": 1}
 					],
 					"17": [
-						"v1.9.0"
+						{"major": 1, "minor": 9, "patch": 0}
 					]
 			  }`,
 		},
@@ -339,14 +339,14 @@ func TestGetVersionMapping(t *testing.T) {
 			sourceEVM:  `{}`,
 			sourceAvago: `{
 					"99": [
-						"v2.3.4",
-						"v2.3.3"
+						{"major": 2, "minor": 3, "patch": 4},
+						{"major": 2, "minor": 3, "patch": 3}
 					],
 					"18": [
-						"v1.9.1"
+						{"major": 1, "minor": 9, "patch": 1}
 					],
 					"17": [
-						"v1.9.0"
+						{"major": 1, "minor": 9, "patch": 0}
 					]
 			  }`,
 		},


### PR DESCRIPTION
Closes https://github.com/ava-labs/avalanche-cli/issues/1294
Depends on https://github.com/ava-labs/avalanchego/pull/2474 , with a probably filename change
Do not merge yet, a change in AvalancheGoCompatibilityURL is needed after previous PR is merged