### PR TITLE
Arm64/graviton support

### DIFF
--- a/cmd/nodecmd/create.go
+++ b/cmd/nodecmd/create.go
@@ -307,7 +307,7 @@ func createNodes(_ *cobra.Command, args []string) error {
 			if !(authorizeAccess || authorizedAccessFromSettings()) && (requestCloudAuth(constants.AWSCloudService) != nil) {
 				return fmt.Errorf("cloud access is required")
 			}
-			ec2SvcMap, ami, numNodesMap, err := getAWSCloudConfig(awsProfile)
+			ec2SvcMap, ami, numNodesMap, err := getAWSCloudConfig(awsProfile, nodeType)
 			regions := maps.Keys(ec2SvcMap)
 			if err != nil {
 				return err

--- a/cmd/nodecmd/create_aws.go
+++ b/cmd/nodecmd/create_aws.go
@@ -95,7 +95,7 @@ func getAWSMonitoringEC2Svc(awsProfile, monitoringRegion string) (map[string]*aw
 	return ec2SvcMap, nil
 }
 
-func getAWSCloudConfig(awsProfile string) (map[string]*awsAPI.AwsCloud, map[string]string, map[string]NumNodes, error) {
+func getAWSCloudConfig(awsProfile string, instanceType string) (map[string]*awsAPI.AwsCloud, map[string]string, map[string]NumNodes, error) {
 	finalRegions := map[string]NumNodes{}
 	switch {
 	case len(numValidatorsNodes) != len(utils.Unique(cmdLineRegion)):
@@ -134,7 +134,11 @@ func getAWSCloudConfig(awsProfile string) (map[string]*awsAPI.AwsCloud, map[stri
 			}
 			return nil, nil, nil, err
 		}
-		amiMap[region], err = ec2SvcMap[region].GetUbuntuAMIID()
+		arch, err := ec2SvcMap[region].GetInstanceTypeArch(instanceType)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		amiMap[region], err = ec2SvcMap[region].GetUbuntuAMIID(arch)
 		if err != nil {
 			if isExpiredCredentialError(err) {
 				printExpiredCredentialsOutput(awsProfile)

--- a/cmd/nodecmd/create_aws.go
+++ b/cmd/nodecmd/create_aws.go
@@ -138,7 +138,7 @@ func getAWSCloudConfig(awsProfile string, instanceType string) (map[string]*awsA
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		amiMap[region], err = ec2SvcMap[region].GetUbuntuAMIID(arch)
+		amiMap[region], err = ec2SvcMap[region].GetUbuntuAMIID(arch, constants.UbuntuVersionLTS)
 		if err != nil {
 			if isExpiredCredentialError(err) {
 				printExpiredCredentialsOutput(awsProfile)

--- a/cmd/nodecmd/loadtest.go
+++ b/cmd/nodecmd/loadtest.go
@@ -167,7 +167,7 @@ func createLoadTest(_ *cobra.Command, args []string) error {
 		var ami map[string]string
 		loadTestEc2SvcMap := make(map[string]*awsAPI.AwsCloud)
 		if existingSeparateInstance == "" {
-			ec2SvcMap, ami, _, err = getAWSCloudConfig(awsProfile, true, sgRegions)
+			ec2SvcMap, ami, _, err = getAWSCloudConfig(awsProfile, true, sgRegions, nodeType)
 			if err != nil {
 				return err
 			}

--- a/pkg/cloud/aws/aws.go
+++ b/pkg/cloud/aws/aws.go
@@ -464,8 +464,11 @@ func (c *AwsCloud) CheckKeyPairExists(kpName string) (bool, error) {
 }
 
 // GetUbuntuAMIID returns the ID of the latest Ubuntu Amazon Machine Image (AMI).
-func (c *AwsCloud) GetUbuntuAMIID() (string, error) {
-	descriptionFilterValue := "Canonical, Ubuntu, 20.04 LTS, amd64*"
+func (c *AwsCloud) GetUbuntuAMIID(arch string) (string, error) {
+	if !utils.ArchSupported(arch) {
+		return "", fmt.Errorf("unsupported architecture: %s", arch)
+	}
+	descriptionFilterValue := fmt.Sprintf("Canonical, Ubuntu, 20.04 LTS, %s*", arch)
 	imageInput := &ec2.DescribeImagesInput{
 		Filters: []types.Filter{
 			{Name: aws.String("root-device-type"), Values: []string{"ebs"}},
@@ -506,4 +509,18 @@ func (c *AwsCloud) ListRegions() ([]string, error) {
 func isEIPQuotaExceededError(err error) bool {
 	// You may need to adjust this function based on the actual error messages returned by AWS
 	return err != nil && (utils.ContainsIgnoreCase(err.Error(), "limit exceeded") || utils.ContainsIgnoreCase(err.Error(), "elastic ip address limit exceeded"))
+}
+
+// GetInstanceTypeArch returns the architecture of the given instance type.
+func (c *AwsCloud) GetInstanceTypeArch(instanceType string) (string, error) {
+	archOutput, err := c.ec2Client.DescribeInstanceTypes(c.ctx, &ec2.DescribeInstanceTypesInput{
+		InstanceTypes: []types.InstanceType{types.InstanceType(instanceType)},
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(archOutput.InstanceTypes) == 0 {
+		return "", fmt.Errorf("no instance type found for %s", instanceType)
+	}
+	return string(archOutput.InstanceTypes[0].ProcessorInfo.SupportedArchitectures[0]), nil
 }

--- a/pkg/cloud/aws/aws.go
+++ b/pkg/cloud/aws/aws.go
@@ -464,15 +464,16 @@ func (c *AwsCloud) CheckKeyPairExists(kpName string) (bool, error) {
 }
 
 // GetUbuntuAMIID returns the ID of the latest Ubuntu Amazon Machine Image (AMI).
-func (c *AwsCloud) GetUbuntuAMIID(arch string) (string, error) {
+func (c *AwsCloud) GetUbuntuAMIID(arch string, ubuntuVerLTS string) (string, error) {
 	if !utils.ArchSupported(arch) {
 		return "", fmt.Errorf("unsupported architecture: %s", arch)
 	}
-	descriptionFilterValue := fmt.Sprintf("Canonical, Ubuntu, 20.04 LTS, %s*", arch)
+	descriptionFilterValue := fmt.Sprintf("Canonical, Ubuntu, %s LTS", ubuntuVerLTS)
 	imageInput := &ec2.DescribeImagesInput{
 		Filters: []types.Filter{
 			{Name: aws.String("root-device-type"), Values: []string{"ebs"}},
 			{Name: aws.String("description"), Values: []string{descriptionFilterValue}},
+			{Name: aws.String("architecture"), Values: []string{arch}},
 		},
 		Owners: []string{"self", "amazon"},
 	}

--- a/pkg/cloud/aws/aws.go
+++ b/pkg/cloud/aws/aws.go
@@ -468,7 +468,7 @@ func (c *AwsCloud) GetUbuntuAMIID(arch string, ubuntuVerLTS string) (string, err
 	if !utils.ArchSupported(arch) {
 		return "", fmt.Errorf("unsupported architecture: %s", arch)
 	}
-	descriptionFilterValue := fmt.Sprintf("Canonical, Ubuntu, %s LTS", ubuntuVerLTS)
+	descriptionFilterValue := fmt.Sprintf("Canonical, Ubuntu, %s LTS*", ubuntuVerLTS)
 	imageInput := &ec2.DescribeImagesInput{
 		Filters: []types.Filter{
 			{Name: aws.String("root-device-type"), Values: []string{"ebs"}},

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -11,6 +11,8 @@ const (
 	WriteReadReadPerms     = 0o644
 	WriteReadUserOnlyPerms = 0o600
 
+	UbuntuVersionLTS = "20.04"
+
 	BaseDirName = ".avalanche-cli"
 	LogDir      = "logs"
 

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"golang.org/x/exp/slices"
 )
 
 func SetupRealtimeCLIOutput(cmd *exec.Cmd, redirectStdout bool, redirectStderr bool) (*bytes.Buffer, *bytes.Buffer) {
@@ -292,4 +294,12 @@ func ReadLongString(msg string, args ...interface{}) (string, error) {
 	// Remove newline character at the end
 	longString = strings.TrimSuffix(longString, "\n")
 	return longString, nil
+}
+
+func SupportedAvagoArch() []string {
+	return []string{string(types.ArchitectureTypeArm64), string(types.ArchitectureTypeX8664)}
+}
+
+func ArchSupported(arch string) bool {
+	return slices.Contains(SupportedAvagoArch(), arch)
 }


### PR DESCRIPTION
resolves: https://github.com/ava-labs/avalanche-cli/issues/1561
![image](https://github.com/ava-labs/avalanche-cli/assets/56270896/479b26a3-0e26-486d-be9b-1cd6260a8d1d)

note: AMI used  :) 

```
ubuntu@ip-172-31-9-92:~$ sudo lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 20.04.6 LTS
Release:        20.04
Codename:       focal
```
```
ubuntu@ip-172-31-9-92:~$ cat /proc/cpuinfo 
processor       : 0
BogoMIPS        : 2100.00
Features        : fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm dit uscat ilrcpc flagm ssbs paca pacg dcpodp svei8mm svebf16 i8mm bf16 dgh rng
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x1
CPU part        : 0xd40
CPU revision    : 1

...
```

```
ubuntu@ip-172-31-9-92:~$ uname -a
Linux ip-172-31-9-92 5.15.0-1055-aws #60~20.04.1-Ubuntu SMP Thu Feb 22 15:54:21 UTC 2024 aarch64 aarch64 aarch64 GNU/Linux
[VS]
ubuntu@ip-172-31-47-69:~$ uname -a
Linux ip-172-31-47-69 5.15.0-1055-aws #60~20.04.1-Ubuntu SMP Thu Feb 22 15:49:52 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
```
`aarch64 aarch64 aarch64` VS `x86_64 x86_64 x86_64` 😹 