### PR TITLE
Add Node Info SSH

### DIFF
--- a/cmd/nodecmd/ssh.go
+++ b/cmd/nodecmd/ssh.go
@@ -137,9 +137,9 @@ func printNodeInfo(host *models.Host, clusterConf models.ClusterConfig, result s
 		rolesStr = " [" + rolesStr + "]"
 	}
 	if result != "" {
-		ux.Logger.PrintToUser(fmt.Sprintf("  [Node %s (%s) %s%s] %s", host.GetCloudID(), nodeIDStr, nodeConfig.ElasticIP, rolesStr, result))
+		ux.Logger.PrintToUser("  [Node %s (%s) %s%s] %s", host.GetCloudID(), nodeIDStr, nodeConfig.ElasticIP, rolesStr, result)
 	} else {
-		ux.Logger.PrintToUser(fmt.Sprintf("  Node %s (%s) %s%s", host.GetCloudID(), nodeIDStr, nodeConfig.ElasticIP, rolesStr))
+		ux.Logger.PrintToUser("  Node %s (%s) %s%s", host.GetCloudID(), nodeIDStr, nodeConfig.ElasticIP, rolesStr)
 	}
 	return nil
 }


### PR DESCRIPTION
AVL-7H2W7V:avalanche-cli raymondsukanto$ ./bin/avalanche node ssh i-0e062ea96ce54a8dd pgrep avalanchego
```
  Node i-0e062ea96ce54a8dd (NodeID-DE8skjJuc2XEHwfYnUWiY9Lb47RJHAeJh) 54.225.179.150 [Validator]
6571
```
AVL-7H2W7V:avalanche-cli raymondsukanto$ ./bin/avalanche node ssh wizNodes6 pgrep avalanchego
```
  Node i-0eca94a11bd7daff7 (----------------------------------------) 23.23.228.80 [Monitor]
  Node i-00ee58a4f7add26ae (NodeID-5jG5CCQjygp4yd24gTvikVaSVe727kAHp) 44.195.111.152 [Validator]
6574
  Node i-0e062ea96ce54a8dd (NodeID-DE8skjJuc2XEHwfYnUWiY9Lb47RJHAeJh) 54.225.179.150 [Validator]
6571
Error: failed to ssh node(s) map[aws_node_i-0eca94a11bd7daff7:exit status 1]
```
