### PR TITLE
add script execution time to logs

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ava-labs/avalanche-cli/pkg/monitoring"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
+	"github.com/ava-labs/avalanche-cli/pkg/ux"
 
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
@@ -55,6 +56,7 @@ func RunOverSSH(
 	scriptPath string,
 	templateVars scriptInputs,
 ) error {
+	startTime := time.Now()
 	shellScript, err := script.ReadFile(scriptPath)
 	if err != nil {
 		return err
@@ -72,6 +74,8 @@ func RunOverSSH(
 	if output, err := host.Command(script.String(), nil, timeout); err != nil {
 		return fmt.Errorf("%w: %s", err, string(output))
 	}
+	executionTime := time.Since(startTime)
+	ux.Logger.Info("RunOverSSH[%s]%s took %s with err: %v", host.NodeID, scriptDesc, executionTime, err)
 	return nil
 }
 

--- a/pkg/ux/output.go
+++ b/pkg/ux/output.go
@@ -42,6 +42,12 @@ func (ul *UserLog) PrintToUser(msg string, args ...interface{}) {
 	ul.log.Info(formattedMsg)
 }
 
+// Info prints to the log file
+func (ul *UserLog) Info(msg string, args ...interface{}) {
+	formattedMsg := fmt.Sprintf(msg, args...)
+	ul.log.Info(formattedMsg)
+}
+
 // GreenCheckmarkToUser prints a green checkmark to the user before the message
 func (ul *UserLog) GreenCheckmarkToUser(msg string, args ...interface{}) {
 	checkmark := "\u2713" // Unicode for checkmark symbol


### PR DESCRIPTION
related to 
https://github.com/ava-labs/avalanche-cli/issues/1641
https://github.com/ava-labs/avalanche-cli/issues/1640

`[03-21|08:10:04.419] INFO ux/output.go:48 RunOverSSH[aws_node_i-0a4c86be5df80c7d7]Setup Build Env took 20.205737166s with err: <nil>`

```
[03-21|08:09:22.201] INFO ux/output.go:48 RunOverSSH[aws_node_i-0a4c86be5df80c7d7]Setup Node took 13.737820834s with err: <nil>
[03-21|08:09:22.726] INFO ux/spinner.go:69 [aws_node_i-0a4c86be5df80c7d7] Setup node [Spinner Complete]
[03-21|08:09:22.727] INFO ux/spinner.go:46 [aws_node_i-0a4c86be5df80c7d7] Setup Machine Metrics [Spinner Start]
[03-21|08:09:44.211] INFO ux/output.go:48 RunOverSSH[aws_node_i-0a4c86be5df80c7d7]Setup Machine Metrics took 21.481203458s with err: <nil>
[03-21|08:09:44.212] INFO ux/spinner.go:69 [aws_node_i-0a4c86be5df80c7d7] Setup Machine Metrics [Spinner Complete]
[03-21|08:09:44.212] INFO ux/spinner.go:46 [aws_node_i-0a4c86be5df80c7d7] Setup Build Env [Spinner Start]
[03-21|08:10:04.419] INFO ux/output.go:48 RunOverSSH[aws_node_i-0a4c86be5df80c7d7]Setup Build Env took 20.205737166s with err: <nil>
[03-21|08:10:04.420] INFO ux/spinner.go:69 [aws_node_i-0a4c86be5df80c7d7] Setup Build Env [Spinner Complete]
[03-21|08:10:04.420] INFO ux/spinner.go:46 [aws_node_i-0a4c86be5df80c7d7] Setup Avalanche-CLI [Spinner Start]
[03-21|08:10:04.420] INFO ux/spinner.go:69 [aws_node_i-0a4c86be5df80c7d7] Setup Avalanche-CLI [Spinner Complete]
[03-21|08:10:04.420] INFO ux/spinner.go:46 [aws_node_i-0eed9d8e2e49947de] Update Monitoring Targets [Spinner Start]
[03-21|08:10:19.429] INFO ux/spinner.go:64 [aws_node_i-0eed9d8e2e49947de] Update Monitoring Targets err:failed to connect to host 3.82.155.104: dial tcp 3.82.155.104:22: i/o timeout [Spinner Err
```