### PR TITLE
Custom dashboard

### DIFF
--- a/cmd/nodecmd/addDashboard.go
+++ b/cmd/nodecmd/addDashboard.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+package nodecmd
+
+import (
+	"github.com/ava-labs/avalanche-cli/pkg/ansible"
+	"github.com/ava-labs/avalanche-cli/pkg/ssh"
+	"github.com/spf13/cobra"
+)
+
+func newAddDashboardCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "addDashboard [clusterName]",
+		Short: "(ALPHA Warning) Adds custom dashboard for existing devnet cluster",
+		Long: `(ALPHA Warning) This command is currently in experimental mode. 
+
+The node addDashboard command adds custom dashboard to the Grafana monitoring dashboard for the 
+cluster.`,
+
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE:         addDashboard,
+	}
+	cmd.Flags().StringVar(&customGrafanaDashboardPath, "add-grafana-dashboard", "", "path to additional grafana dashboard json file")
+	cmd.Flags().StringVar(&subnetName, "subnet", "", "subnet that the dasbhoard is intended for (if any)")
+	return cmd
+}
+
+func addDashboard(_ *cobra.Command, args []string) error {
+	clusterName := args[0]
+	if customGrafanaDashboardPath != "" {
+		if err := addCustomDashboard(clusterName, subnetName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func addCustomDashboard(clusterName, subnetName string) error {
+	monitoringInventoryPath := app.GetMonitoringInventoryDir(clusterName)
+	monitoringHosts, err := ansible.GetInventoryFromAnsibleInventoryFile(monitoringInventoryPath)
+	if err != nil {
+		return err
+	}
+	_, chainID, err := getDeployedSubnetInfo(clusterName, subnetName)
+	if err != nil {
+		return err
+	}
+	return ssh.RunSSHUpdateMonitoringDashboards(monitoringHosts[0], app.GetMonitoringDashboardDir()+"/", customGrafanaDashboardPath, chainID)
+}

--- a/cmd/nodecmd/create.go
+++ b/cmd/nodecmd/create.go
@@ -563,7 +563,7 @@ func createNodes(cmd *cobra.Command, args []string) error {
 					ux.SpinFailWithError(spinner, "", err)
 					return
 				}
-				if err := ssh.RunSSHCopyMonitoringDashboards(monitoringHost, app.GetMonitoringDashboardDir()+"/", customGrafanaDashboardPath); err != nil {
+				if err := ssh.RunSSHCopyMonitoringDashboards(monitoringHost, app.GetMonitoringDashboardDir()+"/"); err != nil {
 					nodeResults.AddResult(monitoringHost.NodeID, nil, err)
 					ux.SpinFailWithError(spinner, "", err)
 					return

--- a/cmd/nodecmd/node.go
+++ b/cmd/nodecmd/node.go
@@ -54,5 +54,7 @@ rest of the commands to maintain your node and make your node a Subnet Validator
 	cmd.AddCommand(newRefreshIPsCmd())
 	// node loadtest
 	cmd.AddCommand(NewLoadTestCmd())
+	// node addDashboard
+	cmd.AddCommand(newAddDashboardCmd())
 	return cmd
 }

--- a/cmd/nodecmd/wiz.go
+++ b/cmd/nodecmd/wiz.go
@@ -343,6 +343,11 @@ func wiz(cmd *cobra.Command, args []string) error {
 	ux.Logger.PrintToUser("")
 
 	if addMonitoring {
+		if customGrafanaDashboardPath != "" {
+			if err = addCustomDashboard(clusterName, subnetName); err != nil {
+				return err
+			}
+		}
 		// no need to check for error, as it's ok not to have monitoring host
 		monitoringHosts, _ := ansible.GetInventoryFromAnsibleInventoryFile(app.GetMonitoringInventoryDir(clusterName))
 		if len(monitoringHosts) > 0 {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -114,17 +114,17 @@ const (
 	ExtraLocalNetworkDataFilename     = "extra-local-network-data.json"
 	ExtraLocalNetworkDataSnapshotsDir = "extra-local-network-data"
 
-	CliInstallationURL      = "https://raw.githubusercontent.com/ava-labs/avalanche-cli/main/scripts/install.sh"
-	ExpectedCliInstallErr   = "resource temporarily unavailable"
-	EIPLimitErr             = "AddressLimitExceeded"
-	ErrCreatingAWSNode      = "failed to create AWS Node"
-	ErrCreatingGCPNode      = "failed to create GCP Node"
-	ErrReleasingGCPStaticIP = "failed to release gcp static ip"
-	KeyDir                  = "key"
-	KeySuffix               = ".pk"
-	YAMLSuffix              = ".yml"
-
-	Enable = "enable"
+	CliInstallationURL         = "https://raw.githubusercontent.com/ava-labs/avalanche-cli/main/scripts/install.sh"
+	ExpectedCliInstallErr      = "resource temporarily unavailable"
+	EIPLimitErr                = "AddressLimitExceeded"
+	ErrCreatingAWSNode         = "failed to create AWS Node"
+	ErrCreatingGCPNode         = "failed to create GCP Node"
+	ErrReleasingGCPStaticIP    = "failed to release gcp static ip"
+	KeyDir                     = "key"
+	KeySuffix                  = ".pk"
+	YAMLSuffix                 = ".yml"
+	CustomGrafanaDashboardJSON = "custom.json"
+	Enable                     = "enable"
 
 	Disable = "disable"
 


### PR DESCRIPTION
Included in wiz: 
`./bin/avalanche node devnet wiz CLUSTERNAME SUBNETNAME --remote-cli-version v1.4.3-rc.2 --num-apis 1,1 --num-validators 2,2 --region us-east-1,us-east-2 --aws --node-type default --enable-monitoring --default-validator-params --use-static-ip=false --add-grafana-dashboard=DASHBOARD_PATH`

or standalone command
`./bin/avalanche node addDashboard CLUSTERNAME --add-grafana-dashboard=DASHBOARD_PATH --subnet=SUBNETNAME`