### PR TITLE
adds aws-profile flag to node destroy cmd

### DIFF
--- a/cmd/nodecmd/destroy.go
+++ b/cmd/nodecmd/destroy.go
@@ -42,6 +42,7 @@ If there is a static IP address attached, it will be released.`,
 	cmd.Flags().BoolVar(&authorizeAccess, "authorize-access", false, "authorize CLI to release cloud resources")
 	cmd.Flags().BoolVar(&authorizeRemove, "authorize-remove", false, "authorize CLI to remove all local files related to cloud nodes")
 	cmd.Flags().BoolVarP(&authorizeAll, "authorize-all", "y", false, "authorize all CLI requests")
+	cmd.Flags().StringVar(&awsProfile, "aws-profile", constants.AWSDefaultCredential, "aws profile to use")
 
 	return cmd
 }


### PR DESCRIPTION
Seems this should be controllable, similar to the creation commands.