### PR TITLE
fix strings.Contains

### DIFF
--- a/pkg/cloud/aws/aws.go
+++ b/pkg/cloud/aws/aws.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"sort"
 	"strings"
@@ -498,11 +499,18 @@ func (c *AwsCloud) SetupSecurityGroup(ipAddress, securityGroupName string) (stri
 // CheckIPInSg checks if the IP is present in the SecurityGroup.
 func CheckIPInSg(sg *types.SecurityGroup, currentIP string, port int32) bool {
 	for _, ipPermission := range sg.IpPermissions {
-		for _, ip := range ipPermission.IpRanges {
-			if strings.Contains(*ip.CidrIp, currentIP) {
-				if *ipPermission.FromPort == port {
-					return true
-				}
+		for _, ipRange := range ipPermission.IpRanges {
+			_, ipNet, err := net.ParseCIDR(*ipRange.CidrIp)
+			if err != nil {
+				continue
+			}
+			ip := net.ParseIP(currentIP)
+			if ip == nil {
+				continue
+			}
+
+			if ipNet.Contains(ip) && ipPermission.FromPort != nil && *ipPermission.FromPort == port {
+				return true
 			}
 		}
 	}

--- a/pkg/cloud/aws/aws_test.go
+++ b/pkg/cloud/aws/aws_test.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
 package aws
 
 import (

--- a/pkg/cloud/aws/aws_test.go
+++ b/pkg/cloud/aws/aws_test.go
@@ -1,0 +1,61 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestCheckIPInSg tests the CheckIPInSg function
+func TestCheckIPInSg(t *testing.T) {
+	port80 := int32(80)
+	port443 := int32(443)
+	sg := &types.SecurityGroup{
+		IpPermissions: []types.IpPermission{
+			{
+				FromPort: &port80,
+				IpRanges: []types.IpRange{
+					{CidrIp: aws.String("192.168.1.0/24")},
+					{CidrIp: aws.String("10.0.0.0/16")},
+				},
+			},
+			{
+				FromPort: &port443,
+				IpRanges: []types.IpRange{
+					{CidrIp: aws.String("172.16.0.0/16")},
+				},
+			},
+		},
+	}
+
+	// ip is present in SG
+	present := CheckIPInSg(sg, "192.168.1.5", 80)
+	if !present {
+		t.Errorf("Expected IP to be present in SecurityGroup")
+	}
+
+	// ip is not present in SG
+	notPresent := CheckIPInSg(sg, "192.168.2.5", 80)
+	if notPresent {
+		t.Errorf("Expected IP not to be present in SecurityGroup")
+	}
+
+	// invalid IP
+	invalidIP := CheckIPInSg(sg, "invalid_ip", 80)
+	if invalidIP {
+		t.Errorf("Expected invalid IP not to be present in SecurityGroup")
+	}
+
+	// ip present in SG but with wrong port
+	wrongPort := CheckIPInSg(sg, "10.0.1.5", 443)
+	if wrongPort {
+		t.Errorf("Expected IP to be present in SecurityGroup but with wrong port")
+	}
+
+	// ip is not present in any CIDR range in SG
+	outsideRange := CheckIPInSg(sg, "172.17.0.5", 443)
+	if outsideRange {
+		t.Errorf("Expected IP not to be present in any CIDR range in SecurityGroup")
+	}
+}


### PR DESCRIPTION
`strings.Contains` logic is not correct for verifying if IP is whitelisted for access in SG 
- fix for this and unittest 