### PR TITLE
Add latest tag to dockerhub images, avoid rc tags to be set as latest on github

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,3 +64,4 @@ release:
   github:
     owner: ava-labs
     name: avalanche-cli
+  prerelease: auto

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,4 +64,5 @@ release:
   github:
     owner: ava-labs
     name: avalanche-cli
+  # If tag indicates rc, will mark it as prerelease
   prerelease: auto

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,6 +50,10 @@ dockers:
     - "--platform=linux/arm64"
     goarch: arm64
 docker_manifests:
+  - name_template: 'avaplatform/avalanche-cli:latest'
+    image_templates:
+    - 'avaplatform/avalanche-cli:{{ .Tag }}-amd64'
+    - 'avaplatform/avalanche-cli:{{ .Tag }}-arm64'
   - name_template: 'avaplatform/avalanche-cli:{{ .Tag }}'
     image_templates:
     - 'avaplatform/avalanche-cli:{{ .Tag }}-amd64'


### PR DESCRIPTION
Closes https://github.com/ava-labs/avalanche-cli/issues/1751 https://github.com/ava-labs/avalanche-cli/issues/1778