### PR TITLE
Cleanup of cmd usage msgs, error messages, logs

### DIFF
--- a/cmd/backendcmd/spawnServer.go
+++ b/cmd/backendcmd/spawnServer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ava-labs/avalanche-cli/pkg/application"
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/spf13/cobra"
 )
@@ -22,7 +23,7 @@ func NewCmd(injectedApp *application.Avalanche) *cobra.Command {
 		Short:  "Run the backend server",
 		Long:   "This tool requires a backend process to run; this command starts it",
 		RunE:   startBackend,
-		Args:   cobra.ExactArgs(0),
+		Args:   cobrautils.ExactArgs(0),
 		Hidden: true,
 	}
 }

--- a/cmd/configcmd/authorize.go
+++ b/cmd/configcmd/authorize.go
@@ -5,6 +5,7 @@ package configcmd
 import (
 	"errors"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/spf13/cobra"
@@ -13,12 +14,11 @@ import (
 // avalanche config metrics command
 func newAuthorizeCloudAccessCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "authorize-cloud-access [enable | disable]",
-		Short:        "authorize access to cloud resources",
-		Long:         "set preferences to authorize access to cloud resources",
-		RunE:         handleAuthorizeCloudAccess,
-		Args:         cobra.ExactArgs(1),
-		SilenceUsage: true,
+		Use:   "authorize-cloud-access [enable | disable]",
+		Short: "authorize access to cloud resources",
+		Long:  "set preferences to authorize access to cloud resources",
+		RunE:  handleAuthorizeCloudAccess,
+		Args:  cobrautils.ExactArgs(1),
 	}
 
 	return cmd

--- a/cmd/configcmd/config.go
+++ b/cmd/configcmd/config.go
@@ -15,9 +15,7 @@ func NewCmd(injectedApp *application.Avalanche) *cobra.Command {
 		Use:   "config",
 		Short: "Modify configuration for Avalanche-CLI",
 		Long:  `Customize configuration for Avalanche-CLI`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cobrautils.CommandSuiteUsage(cmd, args)
-		},
+		RunE:  cobrautils.CommandSuiteUsage,
 	}
 	app = injectedApp
 	// set user metrics collection preferences cmd

--- a/cmd/configcmd/config.go
+++ b/cmd/configcmd/config.go
@@ -3,10 +3,8 @@
 package configcmd
 
 import (
-	"fmt"
-
 	"github.com/ava-labs/avalanche-cli/pkg/application"
-
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/spf13/cobra"
 )
 
@@ -17,11 +15,8 @@ func NewCmd(injectedApp *application.Avalanche) *cobra.Command {
 		Use:   "config",
 		Short: "Modify configuration for Avalanche-CLI",
 		Long:  `Customize configuration for Avalanche-CLI`,
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				fmt.Println(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cobrautils.CommandSuiteUsage(cmd, args)
 		},
 	}
 	app = injectedApp

--- a/cmd/configcmd/metrics.go
+++ b/cmd/configcmd/metrics.go
@@ -5,6 +5,7 @@ package configcmd
 import (
 	"errors"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/spf13/cobra"
@@ -13,12 +14,11 @@ import (
 // avalanche config metrics command
 func newMetricsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "metrics [enable | disable]",
-		Short:        "opt in or out of metrics collection",
-		Long:         "set user metrics collection preferences",
-		RunE:         handleMetricsSettings,
-		Args:         cobra.ExactArgs(1),
-		SilenceUsage: true,
+		Use:   "metrics [enable | disable]",
+		Short: "opt in or out of metrics collection",
+		Long:  "set user metrics collection preferences",
+		RunE:  handleMetricsSettings,
+		Args:  cobrautils.ExactArgs(1),
 	}
 
 	return cmd

--- a/cmd/configcmd/migrate.go
+++ b/cmd/configcmd/migrate.go
@@ -18,11 +18,10 @@ var MigrateOutput string
 // avalanche config metrics migrate
 func newMigrateCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "migrate",
-		Short:        "migrate ~/.avalanche-cli.json and ~/.avalanche-cli/config to new configuration location ~/.avalanche-cli/config.json",
-		Long:         `migrate command migrates old ~/.avalanche-cli.json and ~/.avalanche-cli/config to /.avalanche-cli/config.json..`,
-		RunE:         migrateConfig,
-		SilenceUsage: true,
+		Use:   "migrate",
+		Short: "migrate ~/.avalanche-cli.json and ~/.avalanche-cli/config to new configuration location ~/.avalanche-cli/config.json",
+		Long:  `migrate command migrates old ~/.avalanche-cli.json and ~/.avalanche-cli/config to /.avalanche-cli/config.json..`,
+		RunE:  migrateConfig,
 	}
 	return cmd
 }

--- a/cmd/configcmd/singleNode.go
+++ b/cmd/configcmd/singleNode.go
@@ -5,6 +5,7 @@ package configcmd
 import (
 	"errors"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/spf13/cobra"
 )
@@ -12,12 +13,11 @@ import (
 // avalanche config singlenode command
 func newSingleNodeCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "singleNode [enable | disable]",
-		Short:        "opt in or out of single node local network",
-		Long:         "set user preference between single node and five nodes local network",
-		RunE:         handleSingleNodeSettings,
-		Args:         cobra.ExactArgs(1),
-		SilenceUsage: true,
+		Use:   "singleNode [enable | disable]",
+		Short: "opt in or out of single node local network",
+		Long:  "set user preference between single node and five nodes local network",
+		RunE:  handleSingleNodeSettings,
+		Args:  cobrautils.ExactArgs(1),
 	}
 
 	return cmd

--- a/cmd/keycmd/create.go
+++ b/cmd/keycmd/create.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"regexp"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/key"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
@@ -84,9 +85,8 @@ can use this key in other commands by providing this keyName.
 
 If you'd like to import an existing key instead of generating one from scratch, provide the
 --file flag.`,
-		Args:         cobra.ExactArgs(1),
-		RunE:         createKey,
-		SilenceUsage: true,
+		Args: cobrautils.ExactArgs(1),
+		RunE: createKey,
 	}
 
 	cmd.Flags().StringVar(

--- a/cmd/keycmd/delete.go
+++ b/cmd/keycmd/delete.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/spf13/cobra"
 )
@@ -21,9 +22,8 @@ func newDeleteCmd() *cobra.Command {
 
 To delete a key, provide the keyName. The command prompts for confirmation
 before deleting the key. To skip the confirmation, provide the --force flag.`,
-		RunE:         deleteKey,
-		Args:         cobra.ExactArgs(1),
-		SilenceUsage: true,
+		RunE: deleteKey,
+		Args: cobrautils.ExactArgs(1),
 	}
 	cmd.Flags().BoolVarP(
 		&forceDelete,

--- a/cmd/keycmd/export.go
+++ b/cmd/keycmd/export.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 
 	"github.com/spf13/cobra"
@@ -20,9 +21,8 @@ applications or import it into another instance of Avalanche-CLI.
 
 By default, the tool writes the hex encoded key to stdout. If you provide the --output
 flag, the command writes the key to a file of your choosing.`,
-		Args:         cobra.ExactArgs(1),
-		RunE:         exportKey,
-		SilenceUsage: true,
+		Args: cobrautils.ExactArgs(1),
+		RunE: exportKey,
 	}
 
 	cmd.Flags().StringVarP(

--- a/cmd/keycmd/key.go
+++ b/cmd/keycmd/key.go
@@ -3,9 +3,8 @@
 package keycmd
 
 import (
-	"fmt"
-
 	"github.com/ava-labs/avalanche-cli/pkg/application"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/spf13/cobra"
 )
 
@@ -23,11 +22,8 @@ but these keys are NOT suitable to use in production environments. DO NOT use
 these keys on Mainnet.
 
 To get started, use the key create command.`,
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				fmt.Println(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cobrautils.CommandSuiteUsage(cmd, args)
 		},
 	}
 

--- a/cmd/keycmd/key.go
+++ b/cmd/keycmd/key.go
@@ -22,9 +22,7 @@ but these keys are NOT suitable to use in production environments. DO NOT use
 these keys on Mainnet.
 
 To get started, use the key create command.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cobrautils.CommandSuiteUsage(cmd, args)
-		},
+		RunE: cobrautils.CommandSuiteUsage,
 	}
 
 	// avalanche key create

--- a/cmd/keycmd/list.go
+++ b/cmd/keycmd/list.go
@@ -57,8 +57,7 @@ func newListCmd() *cobra.Command {
 		Short: "List stored signing keys or ledger addresses",
 		Long: `The key list command prints information for all stored signing
 keys or for the ledger addresses associated to certain indices.`,
-		RunE:         listKeys,
-		SilenceUsage: true,
+		RunE: listKeys,
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, false, listSupportedNetworkOptions)
 	cmd.Flags().BoolVarP(

--- a/cmd/keycmd/transfer.go
+++ b/cmd/keycmd/transfer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/key"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
 	"github.com/ava-labs/avalanche-cli/pkg/prompts"
@@ -56,12 +57,11 @@ var (
 
 func newTransferCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "transfer [options]",
-		Short:        "Fund a ledger address or stored key from another one",
-		Long:         `The key transfer command allows to transfer funds between stored keys or ledger addresses.`,
-		RunE:         transferF,
-		Args:         cobra.ExactArgs(0),
-		SilenceUsage: true,
+		Use:   "transfer [options]",
+		Short: "Fund a ledger address or stored key from another one",
+		Long:  `The key transfer command allows to transfer funds between stored keys or ledger addresses.`,
+		RunE:  transferF,
+		Args:  cobrautils.ExactArgs(0),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, false, transferSupportedNetworkOptions)
 	cmd.Flags().BoolVar(

--- a/cmd/networkcmd/clean.go
+++ b/cmd/networkcmd/clean.go
@@ -7,10 +7,10 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/ava-labs/avalanche-cli/pkg/elasticsubnet"
-
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
+	"github.com/ava-labs/avalanche-cli/pkg/elasticsubnet"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
 	"github.com/ava-labs/avalanche-cli/pkg/teleporter"
@@ -29,9 +29,8 @@ func newCleanCmd() *cobra.Command {
 		Long: `The network clean command shuts down your local, multi-node network. All deployed Subnets
 shutdown and delete their state. You can restart the network by deploying a new Subnet
 configuration.`,
-		RunE:         clean,
-		Args:         cobra.ExactArgs(0),
-		SilenceUsage: true,
+		RunE: clean,
+		Args: cobrautils.ExactArgs(0),
 	}
 
 	cmd.Flags().BoolVar(

--- a/cmd/networkcmd/network.go
+++ b/cmd/networkcmd/network.go
@@ -3,9 +3,8 @@
 package networkcmd
 
 import (
-	"fmt"
-
 	"github.com/ava-labs/avalanche-cli/pkg/application"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/spf13/cobra"
 )
 
@@ -24,13 +23,10 @@ subnet deploy command starts this network in the background. This command suite 
 to shutdown, restart, and clear that network.
 
 This network currently supports multiple, concurrently deployed Subnets.`,
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				fmt.Println(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cobrautils.CommandSuiteUsage(cmd, args)
 		},
-		Args: cobra.ExactArgs(0),
+		Args: cobrautils.ExactArgs(0),
 	}
 	// network start
 	cmd.AddCommand(newStartCmd())

--- a/cmd/networkcmd/network.go
+++ b/cmd/networkcmd/network.go
@@ -23,9 +23,7 @@ subnet deploy command starts this network in the background. This command suite 
 to shutdown, restart, and clear that network.
 
 This network currently supports multiple, concurrently deployed Subnets.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cobrautils.CommandSuiteUsage(cmd, args)
-		},
+		RunE: cobrautils.CommandSuiteUsage,
 		Args: cobrautils.ExactArgs(0),
 	}
 	// network start

--- a/cmd/networkcmd/start.go
+++ b/cmd/networkcmd/start.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
@@ -42,9 +43,8 @@ By default, the command loads the default snapshot. If you provide the --snapsho
 flag, the network loads that snapshot instead. The command fails if the local network is
 already running.`,
 
-		RunE:         StartNetwork,
-		Args:         cobra.ExactArgs(0),
-		SilenceUsage: true,
+		RunE: StartNetwork,
+		Args: cobrautils.ExactArgs(0),
 	}
 
 	cmd.Flags().StringVar(&userProvidedAvagoVersion, "avalanchego-version", latest, "use this version of avalanchego (ex: v1.17.12)")

--- a/cmd/networkcmd/status.go
+++ b/cmd/networkcmd/status.go
@@ -4,6 +4,7 @@ package networkcmd
 
 import (
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
@@ -18,9 +19,8 @@ func newStatusCmd() *cobra.Command {
 		Long: `The network status command prints whether or not a local Avalanche
 network is running and some basic stats about the network.`,
 
-		RunE:         networkStatus,
-		Args:         cobra.ExactArgs(0),
-		SilenceUsage: true,
+		RunE: networkStatus,
+		Args: cobrautils.ExactArgs(0),
 	}
 }
 

--- a/cmd/networkcmd/stop.go
+++ b/cmd/networkcmd/stop.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/teleporter"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
@@ -31,9 +32,8 @@ reload this snapshot with network start --snapshot-name <snapshotName>. Otherwis
 network saves to the default snapshot, overwriting any existing state. You can reload the
 default snapshot with network start.`,
 
-		RunE:         StopNetwork,
-		Args:         cobra.ExactArgs(0),
-		SilenceUsage: true,
+		RunE: StopNetwork,
+		Args: cobrautils.ExactArgs(0),
 	}
 	cmd.Flags().StringVar(&snapshotName, "snapshot-name", constants.DefaultSnapshotName, "name of snapshot to use to save network state into")
 	return cmd

--- a/cmd/nodecmd/addDashboard.go
+++ b/cmd/nodecmd/addDashboard.go
@@ -4,6 +4,7 @@ package nodecmd
 
 import (
 	"github.com/ava-labs/avalanche-cli/pkg/ansible"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/ssh"
 	"github.com/spf13/cobra"
 )
@@ -17,9 +18,8 @@ func newAddDashboardCmd() *cobra.Command {
 The node addDashboard command adds custom dashboard to the Grafana monitoring dashboard for the 
 cluster.`,
 
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
-		RunE:         addDashboard,
+		Args: cobrautils.ExactArgs(1),
+		RunE: addDashboard,
 	}
 	cmd.Flags().StringVar(&customGrafanaDashboardPath, "add-grafana-dashboard", "", "path to additional grafana dashboard json file")
 	cmd.Flags().StringVar(&subnetName, "subnet", "", "subnet that the dasbhoard is intended for (if any)")

--- a/cmd/nodecmd/create.go
+++ b/cmd/nodecmd/create.go
@@ -15,29 +15,26 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-
-	awsAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/aws"
-
 	"github.com/ava-labs/avalanche-cli/cmd/flags"
 	"github.com/ava-labs/avalanche-cli/cmd/subnetcmd"
 	"github.com/ava-labs/avalanche-cli/pkg/ansible"
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
+	awsAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/aws"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
+	"github.com/ava-labs/avalanche-cli/pkg/constants"
+	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
 	"github.com/ava-labs/avalanche-cli/pkg/ssh"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
+	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanche-cli/pkg/vm"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/staking"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
-
-	"github.com/ava-labs/avalanche-cli/pkg/constants"
-	"github.com/ava-labs/avalanche-cli/pkg/models"
-
-	"github.com/ava-labs/avalanche-cli/pkg/ux"
-	"github.com/spf13/cobra"
 	"golang.org/x/mod/semver"
 )
 
@@ -96,9 +93,8 @@ status by running avalanche node status
 The created node will be part of group of validators called <clusterName> 
 and users can call node commands with <clusterName> so that the command
 will apply to all nodes in the cluster`,
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
-		RunE:         createNodes,
+		Args: cobrautils.ExactArgs(1),
+		RunE: createNodes,
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, false, createSupportedNetworkOptions)
 	cmd.Flags().BoolVar(&useStaticIP, "use-static-ip", true, "attach static Public IP on cloud servers")

--- a/cmd/nodecmd/deploy.go
+++ b/cmd/nodecmd/deploy.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ava-labs/avalanche-cli/cmd/subnetcmd"
 	"github.com/ava-labs/avalanche-cli/pkg/ansible"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
@@ -27,9 +28,8 @@ func newDeployCmd() *cobra.Command {
 The node devnet deploy command deploys a subnet into a devnet cluster, creating subnet and blockchain txs for it.
 It saves the deploy info both locally and remotely.
 `,
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(2),
-		RunE:         deploySubnet,
+		Args: cobrautils.ExactArgs(2),
+		RunE: deploySubnet,
 	}
 	cmd.Flags().BoolVar(&subnetOnly, "subnet-only", false, "only create a subnet")
 	cmd.Flags().BoolVar(&avoidChecks, "no-checks", false, "do not check for healthy status or rpc compatibility of nodes against subnet")

--- a/cmd/nodecmd/destroy.go
+++ b/cmd/nodecmd/destroy.go
@@ -8,12 +8,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ava-labs/avalanche-cli/pkg/utils"
-
 	awsAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/aws"
 	gcpAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/gcp"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"golang.org/x/exp/maps"
 	"golang.org/x/net/context"
@@ -35,9 +35,8 @@ func newDestroyCmd() *cobra.Command {
 The node destroy command terminates all running nodes in cloud server and deletes all storage disks.
 
 If there is a static IP address attached, it will be released.`,
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
-		RunE:         destroyNodes,
+		Args: cobrautils.ExactArgs(1),
+		RunE: destroyNodes,
 	}
 	cmd.Flags().BoolVar(&authorizeAccess, "authorize-access", false, "authorize CLI to release cloud resources")
 	cmd.Flags().BoolVar(&authorizeRemove, "authorize-remove", false, "authorize CLI to remove all local files related to cloud nodes")

--- a/cmd/nodecmd/devnet.go
+++ b/cmd/nodecmd/devnet.go
@@ -3,7 +3,7 @@
 package nodecmd
 
 import (
-	"fmt"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 
 	"github.com/spf13/cobra"
 )
@@ -16,11 +16,8 @@ func newDevnetCmd() *cobra.Command {
 
 The node devnet command suite provides a collection of commands related to devnets.
 You can check the updated status by calling avalanche node status <clusterName>`,
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				fmt.Println(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cobrautils.CommandSuiteUsage(cmd, args)
 		},
 	}
 	// node devnet deploy

--- a/cmd/nodecmd/devnet.go
+++ b/cmd/nodecmd/devnet.go
@@ -16,9 +16,7 @@ func newDevnetCmd() *cobra.Command {
 
 The node devnet command suite provides a collection of commands related to devnets.
 You can check the updated status by calling avalanche node status <clusterName>`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cobrautils.CommandSuiteUsage(cmd, args)
-		},
+		RunE: cobrautils.CommandSuiteUsage,
 	}
 	// node devnet deploy
 	cmd.AddCommand(newDeployCmd())

--- a/cmd/nodecmd/export.go
+++ b/cmd/nodecmd/export.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
@@ -31,9 +32,8 @@ func newExportCmd() *cobra.Command {
 The node export command exports cluster configuration including their nodes to a text file.
 If no file is specified, the configuration is printed to the stdout.
 Use --include-secrets to include keys in the export. In this case please keep the file secure as it contains sensitive information.`,
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
-		RunE:         exportFile,
+		Args: cobrautils.ExactArgs(1),
+		RunE: exportFile,
 	}
 	cmd.Flags().StringVar(&clusterFileName, "file", "", "specify the file to export the cluster configuration to")
 	cmd.Flags().BoolVar(&force, "force", false, "overwrite the file if it exists")

--- a/cmd/nodecmd/import.go
+++ b/cmd/nodecmd/import.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/ava-labs/avalanche-cli/pkg/ansible"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
@@ -27,9 +28,8 @@ func newImportCmd() *cobra.Command {
 The node import command imports cluster configuration and nodes from a text file.
 This file should be created using the export command.
 Please make sure thatyour ssh public key and IP address are whitelisted by the cluster owner.`,
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
-		RunE:         importFile,
+		Args: cobrautils.ExactArgs(1),
+		RunE: importFile,
 	}
 	cmd.Flags().StringVar(&clusterFileName, "file", "", "specify the file to export the cluster configuration to")
 	return cmd

--- a/cmd/nodecmd/list.go
+++ b/cmd/nodecmd/list.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 
@@ -20,9 +21,8 @@ func newListCmd() *cobra.Command {
 		Long: `(ALPHA Warning) This command is currently in experimental mode.
 
 The node list command lists all clusters together with their nodes.`,
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(0),
-		RunE:         list,
+		Args: cobrautils.ExactArgs(0),
+		RunE: list,
 	}
 
 	return cmd

--- a/cmd/nodecmd/loadtest.go
+++ b/cmd/nodecmd/loadtest.go
@@ -14,9 +14,7 @@ func NewLoadTestCmd() *cobra.Command {
 		Long: `(ALPHA Warning) This command is currently in experimental mode. 
 
 The node loadtest command suite starts and stops a load test for an existing devnet cluster.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cobrautils.CommandSuiteUsage(cmd, args)
-		},
+		RunE: cobrautils.CommandSuiteUsage,
 	}
 	// node loadtest start cluster subnetName
 	cmd.AddCommand(newLoadTestStartCmd())

--- a/cmd/nodecmd/loadtest.go
+++ b/cmd/nodecmd/loadtest.go
@@ -3,8 +3,7 @@
 package nodecmd
 
 import (
-	"fmt"
-
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/spf13/cobra"
 )
 
@@ -15,11 +14,8 @@ func NewLoadTestCmd() *cobra.Command {
 		Long: `(ALPHA Warning) This command is currently in experimental mode. 
 
 The node loadtest command suite starts and stops a load test for an existing devnet cluster.`,
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				fmt.Println(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cobrautils.CommandSuiteUsage(cmd, args)
 		},
 	}
 	// node loadtest start cluster subnetName

--- a/cmd/nodecmd/loadtestStart.go
+++ b/cmd/nodecmd/loadtestStart.go
@@ -7,23 +7,22 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ava-labs/avalanche-cli/pkg/ssh"
-	"github.com/ava-labs/avalanchego/utils/logging"
-
-	"golang.org/x/exp/slices"
-
 	"github.com/ava-labs/avalanche-cli/pkg/ansible"
 	"github.com/ava-labs/avalanche-cli/pkg/application"
 	awsAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/aws"
 	gcpAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/gcp"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/prompts"
+	"github.com/ava-labs/avalanche-cli/pkg/ssh"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
 
@@ -64,9 +63,8 @@ test binary based on the provided load test Git Repo URL and load test binary bu
 
 The command will then run the load test binary based on the provided load test run command.`,
 
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(3),
-		RunE:         startLoadTest,
+		Args: cobrautils.ExactArgs(3),
+		RunE: startLoadTest,
 	}
 	cmd.Flags().BoolVar(&useAWS, "aws", false, "create loadtest node in AWS cloud")
 	cmd.Flags().BoolVar(&useGCP, "gcp", false, "create loadtest in GCP cloud")

--- a/cmd/nodecmd/loadtestStop.go
+++ b/cmd/nodecmd/loadtestStop.go
@@ -8,19 +8,17 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ava-labs/avalanche-cli/pkg/utils"
-
-	"golang.org/x/exp/maps"
-
 	"github.com/ava-labs/avalanche-cli/pkg/ansible"
-	"github.com/ava-labs/avalanche-cli/pkg/ssh"
-
 	awsAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/aws"
 	gcpAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/gcp"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanche-cli/pkg/ssh"
+	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/maps"
 )
 
 var loadTestsToStop []string
@@ -34,9 +32,8 @@ func newLoadTestStopCmd() *cobra.Command {
 The node loadtest stop command stops load testing for an existing devnet cluster and terminates the 
 separate cloud server created to host the load test.`,
 
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
-		RunE:         stopLoadTest,
+		Args: cobrautils.ExactArgs(1),
+		RunE: stopLoadTest,
 	}
 	cmd.Flags().StringSliceVar(&loadTestsToStop, "load-test", []string{}, "stop specified load test node(s). Use comma to separate multiple load test instance names")
 	return cmd

--- a/cmd/nodecmd/node.go
+++ b/cmd/nodecmd/node.go
@@ -19,9 +19,7 @@ validators on Avalanche Network.
 To get started, use the node create command wizard to walk through the
 configuration to make your node a primary validator on Avalanche public network. You can use the 
 rest of the commands to maintain your node and make your node a Subnet Validator.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cobrautils.CommandSuiteUsage(cmd, args)
-		},
+		RunE: cobrautils.CommandSuiteUsage,
 	}
 	app = injectedApp
 	// node create

--- a/cmd/nodecmd/node.go
+++ b/cmd/nodecmd/node.go
@@ -3,9 +3,8 @@
 package nodecmd
 
 import (
-	"fmt"
-
 	"github.com/ava-labs/avalanche-cli/pkg/application"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/spf13/cobra"
 )
 
@@ -20,11 +19,8 @@ validators on Avalanche Network.
 To get started, use the node create command wizard to walk through the
 configuration to make your node a primary validator on Avalanche public network. You can use the 
 rest of the commands to maintain your node and make your node a Subnet Validator.`,
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				fmt.Println(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cobrautils.CommandSuiteUsage(cmd, args)
 		},
 	}
 	app = injectedApp

--- a/cmd/nodecmd/refreshIPs.go
+++ b/cmd/nodecmd/refreshIPs.go
@@ -5,6 +5,7 @@ package nodecmd
 import (
 	"fmt"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/spf13/cobra"
 )
@@ -17,9 +18,8 @@ func newRefreshIPsCmd() *cobra.Command {
 
 The node refresh-ips command obtains the current IP for all nodes with dynamic IPs in the cluster,
 and updates the local node information used by CLI commands.`,
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
-		RunE:         refreshIPs,
+		Args: cobrautils.ExactArgs(1),
+		RunE: refreshIPs,
 	}
 
 	cmd.Flags().StringVar(&awsProfile, "aws-profile", constants.AWSDefaultCredential, "aws profile to use")

--- a/cmd/nodecmd/resize.go
+++ b/cmd/nodecmd/resize.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/ansible"
 	awsAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/aws"
 	gcpAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/gcp"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/ssh"
@@ -32,9 +33,8 @@ The node resize command can be used to resize cluster instance size
 and/or size of the permanent storage attached to the instance. In another words, it can 
 change amount of CPU, memory and disk space available for the cluster nodes.
 `,
-		SilenceUsage: true,
-		Args:         cobra.MinimumNArgs(1),
-		RunE:         resize,
+		Args: cobrautils.MinimumNArgs(1),
+		RunE: resize,
 	}
 	cmd.Flags().StringVar(&nodeType, "node-type", "", "Node type to resize (e.g. t3.2xlarge)")
 	cmd.Flags().StringVar(&diskSize, "disk-size", "", "Disk size to resize in Gb (e.g. 1000Gb)")

--- a/cmd/nodecmd/ssh.go
+++ b/cmd/nodecmd/ssh.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/ava-labs/avalanche-cli/pkg/ansible"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
@@ -32,9 +33,8 @@ If no command is given, just prints the ssh command to be used to connect to eac
 For provided NodeID or InstanceID or IP, the command [cmd] will be executed on that node.
 If no [cmd] is provided for the node, it will open ssh shell there.
 `,
-		SilenceUsage: true,
-		Args:         cobra.MinimumNArgs(0),
-		RunE:         sshNode,
+		Args: cobrautils.MinimumNArgs(0),
+		RunE: sshNode,
 	}
 	cmd.Flags().BoolVar(&isParallel, "parallel", false, "run ssh command on all nodes in parallel")
 	return cmd

--- a/cmd/nodecmd/status.go
+++ b/cmd/nodecmd/status.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ava-labs/avalanche-cli/cmd/subnetcmd"
 	"github.com/ava-labs/avalanche-cli/pkg/ansible"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/ssh"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
@@ -35,9 +36,8 @@ The node status command gets the bootstrap status of all nodes in a cluster with
 If no cluster is given, defaults to node list behaviour.
 
 To get the bootstrap status of a node with a Subnet, use --subnet flag`,
-		SilenceUsage: true,
-		Args:         cobra.MinimumNArgs(0),
-		RunE:         statusNode,
+		Args: cobrautils.MinimumNArgs(0),
+		RunE: statusNode,
 	}
 	cmd.Flags().StringVar(&subnetName, "subnet", "", "specify the subnet the node is syncing with")
 

--- a/cmd/nodecmd/sync.go
+++ b/cmd/nodecmd/sync.go
@@ -7,14 +7,12 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/ava-labs/avalanche-cli/pkg/ssh"
-
-	"github.com/ava-labs/avalanche-cli/pkg/constants"
-
-	"github.com/ava-labs/avalanche-cli/pkg/ansible"
-
 	"github.com/ava-labs/avalanche-cli/cmd/subnetcmd"
+	"github.com/ava-labs/avalanche-cli/pkg/ansible"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
+	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanche-cli/pkg/ssh"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/spf13/cobra"
 )
@@ -27,9 +25,8 @@ func newSyncCmd() *cobra.Command {
 
 The node sync command enables all nodes in a cluster to be bootstrapped to a Subnet. 
 You can check the subnet bootstrap status by calling avalanche node status <clusterName> --subnet <subnetName>`,
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(2),
-		RunE:         syncSubnet,
+		Args: cobrautils.ExactArgs(2),
+		RunE: syncSubnet,
 	}
 
 	cmd.Flags().StringSliceVar(&validators, "validators", []string{}, "sync subnet into given comma separated list of validators. defaults to all cluster nodes")

--- a/cmd/nodecmd/update.go
+++ b/cmd/nodecmd/update.go
@@ -17,9 +17,7 @@ The node update command suite provides a collection of commands for nodes to upd
 their avalanchego or VM config.
 
 You can check the status after update by calling avalanche node status`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cobrautils.CommandSuiteUsage(cmd, args)
-		},
+		RunE: cobrautils.CommandSuiteUsage,
 	}
 	// node update subnet
 	cmd.AddCommand(newUpdateSubnetCmd())

--- a/cmd/nodecmd/update.go
+++ b/cmd/nodecmd/update.go
@@ -3,8 +3,7 @@
 package nodecmd
 
 import (
-	"fmt"
-
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +17,8 @@ The node update command suite provides a collection of commands for nodes to upd
 their avalanchego or VM config.
 
 You can check the status after update by calling avalanche node status`,
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				fmt.Println(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cobrautils.CommandSuiteUsage(cmd, args)
 		},
 	}
 	// node update subnet

--- a/cmd/nodecmd/updateSubnet.go
+++ b/cmd/nodecmd/updateSubnet.go
@@ -7,13 +7,12 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/ava-labs/avalanche-cli/pkg/constants"
-	"github.com/ava-labs/avalanche-cli/pkg/ssh"
-
-	"github.com/ava-labs/avalanche-cli/pkg/ansible"
-
 	"github.com/ava-labs/avalanche-cli/cmd/subnetcmd"
+	"github.com/ava-labs/avalanche-cli/pkg/ansible"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
+	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanche-cli/pkg/ssh"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/spf13/cobra"
 )
@@ -26,9 +25,8 @@ func newUpdateSubnetCmd() *cobra.Command {
 
 The node update subnet command updates all nodes in a cluster with latest Subnet configuration and VM for custom VM.
 You can check the updated subnet bootstrap status by calling avalanche node status <clusterName> --subnet <subnetName>`,
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(2),
-		RunE:         updateSubnet,
+		Args: cobrautils.ExactArgs(2),
+		RunE: updateSubnet,
 	}
 
 	return cmd

--- a/cmd/nodecmd/upgrade.go
+++ b/cmd/nodecmd/upgrade.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ava-labs/avalanche-cli/pkg/ansible"
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/ssh"
@@ -37,9 +38,8 @@ The node update command suite provides a collection of commands for nodes to upd
 their avalanchego or VM version.
 
 You can check the status after upgrade by calling avalanche node status`,
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
-		RunE:         upgrade,
+		Args: cobrautils.ExactArgs(1),
+		RunE: upgrade,
 	}
 
 	return cmd

--- a/cmd/nodecmd/validate.go
+++ b/cmd/nodecmd/validate.go
@@ -17,9 +17,7 @@ The node validate command suite provides a collection of commands for nodes to j
 the Primary Network and Subnets as validators.
 If any of the commands is run before the nodes are bootstrapped on the Primary Network, the command 
 will fail. You can check the bootstrap status by calling avalanche node status <clusterName>`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cobrautils.CommandSuiteUsage(cmd, args)
-		},
+		RunE: cobrautils.CommandSuiteUsage,
 	}
 	// node validate primary cluster
 	cmd.AddCommand(newValidatePrimaryCmd())

--- a/cmd/nodecmd/validate.go
+++ b/cmd/nodecmd/validate.go
@@ -3,8 +3,7 @@
 package nodecmd
 
 import (
-	"fmt"
-
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +17,8 @@ The node validate command suite provides a collection of commands for nodes to j
 the Primary Network and Subnets as validators.
 If any of the commands is run before the nodes are bootstrapped on the Primary Network, the command 
 will fail. You can check the bootstrap status by calling avalanche node status <clusterName>`,
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				fmt.Println(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cobrautils.CommandSuiteUsage(cmd, args)
 		},
 	}
 	// node validate primary cluster

--- a/cmd/nodecmd/validatePrimary.go
+++ b/cmd/nodecmd/validatePrimary.go
@@ -9,25 +9,22 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/ava-labs/avalanchego/utils/crypto/bls"
-	"github.com/ava-labs/avalanchego/vms/platformvm/signer"
-	"golang.org/x/exp/maps"
-
-	"github.com/ava-labs/avalanchego/utils/units"
-
-	"github.com/ava-labs/avalanche-cli/pkg/ansible"
-	"github.com/ava-labs/avalanche-cli/pkg/keychain"
-
-	"github.com/ava-labs/avalanchego/vms/platformvm"
-
 	subnetcmd "github.com/ava-labs/avalanche-cli/cmd/subnetcmd"
+	"github.com/ava-labs/avalanche-cli/pkg/ansible"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
+	"github.com/ava-labs/avalanche-cli/pkg/keychain"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/crypto/bls"
+	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/vms/platformvm"
+	"github.com/ava-labs/avalanchego/vms/platformvm/signer"
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/maps"
 )
 
 var (
@@ -56,9 +53,8 @@ func newValidatePrimaryCmd() *cobra.Command {
 
 The node validate primary command enables all nodes in a cluster to be validators of Primary
 Network.`,
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
-		RunE:         validatePrimaryNetwork,
+		Args: cobrautils.ExactArgs(1),
+		RunE: validatePrimaryNetwork,
 	}
 
 	cmd.Flags().StringVarP(&keyName, "key", "k", "", "select the key to use [fuji only]")

--- a/cmd/nodecmd/validateSubnet.go
+++ b/cmd/nodecmd/validateSubnet.go
@@ -8,18 +8,17 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ava-labs/avalanchego/vms/platformvm/status"
-
-	"github.com/ava-labs/avalanche-cli/pkg/ansible"
-	"github.com/ava-labs/avalanche-cli/pkg/ssh"
-
 	subnetcmd "github.com/ava-labs/avalanche-cli/cmd/subnetcmd"
+	"github.com/ava-labs/avalanche-cli/pkg/ansible"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/keychain"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanche-cli/pkg/ssh"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/platformvm/status"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
 )
@@ -42,9 +41,8 @@ If The command is run before the nodes are bootstrapped on the Primary Network, 
 You can check the bootstrap status by calling avalanche node status <clusterName>
 If The command is run before the nodes are synced to the subnet, the command will fail.
 You can check the subnet sync status by calling avalanche node status <clusterName> --subnet <subnetName>`,
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(2),
-		RunE:         validateSubnet,
+		Args: cobrautils.ExactArgs(2),
+		RunE: validateSubnet,
 	}
 
 	cmd.Flags().StringVarP(&keyName, "key", "k", "", "select the key to use [fuji/devnet only]")

--- a/cmd/nodecmd/whitelist.go
+++ b/cmd/nodecmd/whitelist.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/application"
 	awsAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/aws"
 	gcpAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/gcp"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/ssh"
@@ -40,9 +41,8 @@ func newWhitelistCmd() *cobra.Command {
 	Command adds IP if --ip params provided to cloud security access rules allowing it to access all nodes in the cluster via ssh or http.
 	It also command adds SSH public key to all nodes in the cluster if --ssh params is there.
 	If no params provided it detects current user IP automaticaly and whitelists it`,
-		SilenceUsage: true,
-		Args:         cobra.MinimumNArgs(1),
-		RunE:         whitelist,
+		Args: cobrautils.MinimumNArgs(1),
+		RunE: whitelist,
 	}
 	cmd.Flags().StringVar(&userIPAddress, "ip", "", "ip address to whitelist")
 	cmd.Flags().StringVar(&userPubKey, "ssh", "", "ssh public key to whitelist")

--- a/cmd/nodecmd/wiz.go
+++ b/cmd/nodecmd/wiz.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/cmd/teleportercmd"
 	"github.com/ava-labs/avalanche-cli/pkg/ansible"
 	awsAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/aws"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
@@ -21,9 +22,8 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/teleporter"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
-	"github.com/ava-labs/avalanchego/utils/logging"
-
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
 	"github.com/spf13/cobra"
@@ -70,9 +70,8 @@ func newWizCmd() *cobra.Command {
 
 The node wiz command creates a devnet and deploys, sync and validate a subnet into it. It creates the subnet if so needed.
 `,
-		SilenceUsage: true,
-		Args:         cobra.RangeArgs(1, 2),
-		RunE:         wiz,
+		Args: cobrautils.RangeArgs(1, 2),
+		RunE: wiz,
 	}
 	cmd.Flags().BoolVar(&useStaticIP, "use-static-ip", true, "attach static Public IP on cloud servers")
 	cmd.Flags().BoolVar(&useAWS, "aws", false, "create node/s in AWS cloud")

--- a/cmd/primarycmd/addValidator.go
+++ b/cmd/primarycmd/addValidator.go
@@ -9,19 +9,18 @@ import (
 	"math"
 	"time"
 
-	"github.com/ava-labs/avalanche-cli/cmd/subnetcmd"
-	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
-	"github.com/ava-labs/avalanche-cli/pkg/subnet"
-	"github.com/ava-labs/avalanchego/ids"
-
-	"github.com/ava-labs/avalanche-cli/pkg/application"
-
 	"github.com/ava-labs/avalanche-cli/cmd/nodecmd"
+	"github.com/ava-labs/avalanche-cli/cmd/subnetcmd"
+	"github.com/ava-labs/avalanche-cli/pkg/application"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/keychain"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
 	"github.com/ava-labs/avalanche-cli/pkg/prompts"
+	"github.com/ava-labs/avalanche-cli/pkg/subnet"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/spf13/cobra"
 )
 
@@ -54,9 +53,8 @@ func newAddValidatorCmd() *cobra.Command {
 		Short: "Add a validator to Primary Network",
 		Long: `The primary addValidator command adds a node as a validator 
 in the Primary Network`,
-		SilenceUsage: true,
-		RunE:         addValidator,
-		Args:         cobra.ExactArgs(0),
+		RunE: addValidator,
+		Args: cobrautils.ExactArgs(0),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, false, addValidatorSupportedNetworkOptions)
 	cmd.Flags().StringVarP(&keyName, "key", "k", "", "select the key to use [fuji only]")

--- a/cmd/primarycmd/describe.go
+++ b/cmd/primarycmd/describe.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"os"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/evm"
 	"github.com/ava-labs/avalanche-cli/pkg/key"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
@@ -35,12 +36,11 @@ var describeSupportedNetworkOptions = []networkoptions.NetworkOption{networkopti
 // avalanche primary describe
 func newDescribeCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "describe",
-		Short:        "Print details of the primary network configuration",
-		Long:         `The subnet describe command prints details of the primary network configuration to the console.`,
-		SilenceUsage: true,
-		RunE:         describe,
-		Args:         cobra.ExactArgs(0),
+		Use:   "describe",
+		Short: "Print details of the primary network configuration",
+		Long:  `The subnet describe command prints details of the primary network configuration to the console.`,
+		RunE:  describe,
+		Args:  cobrautils.ExactArgs(0),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, false, describeSupportedNetworkOptions)
 	return cmd

--- a/cmd/primarycmd/primary.go
+++ b/cmd/primarycmd/primary.go
@@ -3,9 +3,8 @@
 package primarycmd
 
 import (
-	"fmt"
-
 	"github.com/ava-labs/avalanche-cli/pkg/application"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +17,8 @@ func NewCmd(injectedApp *application.Avalanche) *cobra.Command {
 		Short: "Interact with the Primary Network",
 		Long: `The primary command suite provides a collection of tools for interacting with the
 Primary Network`,
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				fmt.Println(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cobrautils.CommandSuiteUsage(cmd, args)
 		},
 	}
 	app = injectedApp

--- a/cmd/primarycmd/primary.go
+++ b/cmd/primarycmd/primary.go
@@ -17,9 +17,7 @@ func NewCmd(injectedApp *application.Avalanche) *cobra.Command {
 		Short: "Interact with the Primary Network",
 		Long: `The primary command suite provides a collection of tools for interacting with the
 Primary Network`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cobrautils.CommandSuiteUsage(cmd, args)
-		},
+		RunE: cobrautils.CommandSuiteUsage,
 	}
 	app = injectedApp
 	// primary addValidator

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/cmd/updatecmd"
 	"github.com/ava-labs/avalanche-cli/internal/migrations"
 	"github.com/ava-labs/avalanche-cli/pkg/application"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/config"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/metrics"
@@ -59,14 +60,19 @@ in with avalanche subnet create myNewSubnet.`,
 		PersistentPreRunE: createApp,
 		Version:           Version,
 		PersistentPostRun: handleTracking,
+		SilenceErrors:     true,
+		SilenceUsage:      true,
 	}
 
 	// Disable printing the completion command
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.avalanche-cli/config.json)")
-	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "ERROR", "log level for the application")
-	rootCmd.PersistentFlags().BoolVar(&skipCheck, constants.SkipUpdateFlag, false, "skip check for new versions")
+	rootCmd.PersistentFlags().
+		StringVar(&cfgFile, "config", "", "config file (default is $HOME/.avalanche-cli/config.json)")
+	rootCmd.PersistentFlags().
+		StringVar(&logLevel, "log-level", "ERROR", "log level for the application")
+	rootCmd.PersistentFlags().
+		BoolVar(&skipCheck, constants.SkipUpdateFlag, false, "skip check for new versions")
 
 	// add sub commands
 	rootCmd.AddCommand(subnetcmd.NewCmd(app))
@@ -92,6 +98,8 @@ in with avalanche subnet create myNewSubnet.`,
 	// add teleporter command
 	rootCmd.AddCommand(teleportercmd.NewCmd(app))
 
+	cobrautils.ConfigureRootCmd(rootCmd)
+
 	return rootCmd
 }
 
@@ -112,7 +120,9 @@ func createApp(cmd *cobra.Command, _ []string) error {
 	if err := migrations.RunMigrations(app); err != nil {
 		return err
 	}
-	if utils.IsE2E() && !app.Conf.ConfigFileExists() && !utils.FileExists(utils.UserHomePath(constants.OldMetricsConfigFileName)) && metrics.CheckCommandIsNotCompletion(cmd) {
+	if utils.IsE2E() && !app.Conf.ConfigFileExists() &&
+		!utils.FileExists(utils.UserHomePath(constants.OldMetricsConfigFileName)) &&
+		metrics.CheckCommandIsNotCompletion(cmd) {
 		err = metrics.HandleUserMetricsPreference(app)
 		if err != nil {
 			return err
@@ -146,15 +156,20 @@ func checkForUpdates(cmd *cobra.Command, app *application.Avalanche) error {
 				return nil
 			}
 		}
-		app.Log.Warn("failed to read last-actions file! This is non-critical but is logged", zap.Error(err))
+		app.Log.Warn(
+			"failed to read last-actions file! This is non-critical but is logged",
+			zap.Error(err),
+		)
 		lastActs = &application.LastActions{}
 	}
 
 	// if the user had requested to skipCheck less than 24 hrs ago, we skip in any case
 	if lastActs.LastSkipCheck != (time.Time{}) &&
 		time.Now().Before(lastActs.LastSkipCheck.Add(24*time.Hour)) {
-		app.Log.Debug("last checked %s, so less than 24 hrs earlier. Skipping to check for updates.",
-			zap.Time("lastSkipCheck", lastActs.LastSkipCheck))
+		app.Log.Debug(
+			"last checked %s, so less than 24 hrs earlier. Skipping to check for updates.",
+			zap.Time("lastSkipCheck", lastActs.LastSkipCheck),
+		)
 		return nil
 	}
 
@@ -173,16 +188,19 @@ func checkForUpdates(cmd *cobra.Command, app *application.Avalanche) error {
 	isUserCalled := false
 	commandList := strings.Fields(cmd.CommandPath())
 	if !(len(commandList) > 1 && commandList[1] == "update") {
-		if lastActs.LastCheckGit != (time.Time{}) && time.Now().Before(lastActs.LastCheckGit.Add(24*time.Hour)) {
+		if lastActs.LastCheckGit != (time.Time{}) &&
+			time.Now().Before(lastActs.LastCheckGit.Add(24*time.Hour)) {
 			if err := updatecmd.Update(cmd, isUserCalled, Version, lastActs); err != nil {
 				if errors.Is(err, updatecmd.ErrUserAbortedInstallation) {
 					return nil
 				}
 				if err == updatecmd.ErrNoVersion {
 					ux.Logger.PrintToUser(
-						"Attempted to check if a new version is available, but couldn't find the currently running version information")
+						"Attempted to check if a new version is available, but couldn't find the currently running version information",
+					)
 					ux.Logger.PrintToUser(
-						"Make sure to follow official instructions, or automatic updates won't be available for you")
+						"Make sure to follow official instructions, or automatic updates won't be available for you",
+					)
 					return nil
 				}
 				return err
@@ -308,7 +326,5 @@ func Execute() {
 	app = application.New()
 	rootCmd := NewRootCmd()
 	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
-	}
+	cobrautils.HandleErrors(err)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -112,6 +112,8 @@ func createApp(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	log.Info("-----------")
+	log.Info(fmt.Sprintf("cmd: %s", strings.Join(os.Args[1:], " ")))
 	cf := config.New()
 	app.Setup(baseDir, log, cf, prompts.NewPrompter(), application.NewDownloader())
 
@@ -316,7 +318,9 @@ func initConfig() {
 	app.Conf.SetConfig(app.Log, cfgFile)
 	// check if metrics setting is available, and if not load metricConfig
 	if !app.Conf.ConfigValueIsSet(constants.ConfigMetricsEnabledKey) {
-		app.Conf.MergeConfig(app.Log, oldMetricsConfig)
+		if utils.FileExists(oldMetricsConfig) {
+			app.Conf.MergeConfig(app.Log, oldMetricsConfig)
+		}
 	}
 }
 

--- a/cmd/subnetcmd/addDelegator.go
+++ b/cmd/subnetcmd/addDelegator.go
@@ -8,17 +8,17 @@ import (
 	"os"
 	"time"
 
-	"github.com/ava-labs/avalanche-cli/pkg/prompts"
-	"github.com/ava-labs/avalanchego/genesis"
-	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
-
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/keychain"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
+	"github.com/ava-labs/avalanche-cli/pkg/prompts"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	"github.com/ava-labs/avalanchego/genesis"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/spf13/cobra"
 )
 
@@ -45,9 +45,8 @@ To add a node as a delegator, you first need to provide
 the subnetID and the validator's unique NodeID. The command then prompts
 for the validation start time, duration, and stake weight. You can bypass
 these prompts by providing the values with flags.`,
-		SilenceUsage: true,
-		RunE:         addPermissionlessDelegator,
-		Args:         cobra.ExactArgs(1),
+		RunE: addPermissionlessDelegator,
+		Args: cobrautils.ExactArgs(1),
 	}
 
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, false, addPermissionlessDelegatorSupportedNetworkOptions)

--- a/cmd/subnetcmd/addValidator.go
+++ b/cmd/subnetcmd/addValidator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/keychain"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
@@ -56,9 +57,8 @@ these prompts by providing the values with flags.
 
 This command currently only works on Subnets deployed to either the Fuji
 Testnet or Mainnet.`,
-		SilenceUsage: true,
-		RunE:         addValidator,
-		Args:         cobra.ExactArgs(1),
+		RunE: addValidator,
+		Args: cobrautils.ExactArgs(1),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, true, addValidatorSupportedNetworkOptions)
 

--- a/cmd/subnetcmd/changeOwner.go
+++ b/cmd/subnetcmd/changeOwner.go
@@ -5,6 +5,7 @@ package subnetcmd
 import (
 	"fmt"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/keychain"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
@@ -27,9 +28,8 @@ func newChangeOwnerCmd() *cobra.Command {
 		Long: `The subnet changeOwner changes the owner of the deployed Subnet.
 
 This command currently only works on Subnets deployed to Devnet, Fuji or Mainnet.`,
-		SilenceUsage: true,
-		RunE:         changeOwner,
-		Args:         cobra.ExactArgs(1),
+		RunE: changeOwner,
+		Args: cobrautils.ExactArgs(1),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, true, changeOwnerSupportedNetworkOptions)
 	cmd.Flags().BoolVarP(&useLedger, "ledger", "g", false, "use ledger instead of key (always true on mainnet, defaults to false on fuji/devnet)")

--- a/cmd/subnetcmd/configure.go
+++ b/cmd/subnetcmd/configure.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
@@ -30,9 +31,8 @@ func newConfigureCmd() *cobra.Command {
 Subnet config which applies to all chains/VMs in the Subnet. Each chain within the Subnet
 can have its own chain config. A chain can also have special requirements for the AvalancheGo node 
 configuration itself. This command allows you to set all those files.`,
-		SilenceUsage: true,
-		RunE:         configure,
-		Args:         cobra.ExactArgs(1),
+		RunE: configure,
+		Args: cobrautils.ExactArgs(1),
 	}
 
 	cmd.Flags().StringVar(&nodeConf, "node-config", "", "path to avalanchego node configuration")

--- a/cmd/subnetcmd/create.go
+++ b/cmd/subnetcmd/create.go
@@ -13,6 +13,7 @@ import (
 	"unicode"
 
 	"github.com/ava-labs/avalanche-cli/cmd/flags"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/metrics"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
@@ -69,8 +70,7 @@ the path to your genesis and VM binaries with the --genesis and --vm flags.
 By default, running the command with a subnetName that already exists
 causes the command to fail. If you’d like to overwrite an existing
 configuration, pass the -f flag.`,
-		SilenceUsage:      true,
-		Args:              cobra.ExactArgs(1),
+		Args:              cobrautils.ExactArgs(1),
 		RunE:              createSubnetConfig,
 		PersistentPostRun: handlePostRun,
 	}

--- a/cmd/subnetcmd/deploy.go
+++ b/cmd/subnetcmd/deploy.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/key"
 	"github.com/ava-labs/avalanche-cli/pkg/keychain"
@@ -78,10 +79,9 @@ allowed. If you'd like to redeploy a Subnet locally for testing, you must first 
 avalanche network clean to reset all deployed chain state. Subsequent local deploys
 redeploy the chain with fresh state. You can deploy the same Subnet to multiple networks,
 so you can take your locally tested Subnet and deploy it on Fuji or Mainnet.`,
-		SilenceUsage:      true,
 		RunE:              deploySubnet,
 		PersistentPostRun: handlePostRun,
-		Args:              cobra.ExactArgs(1),
+		Args:              cobrautils.ExactArgs(1),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, true, deploySupportedNetworkOptions)
 	cmd.Flags().StringVar(&userProvidedAvagoVersion, "avalanchego-version", "latest", "use this version of avalanchego (ex: v1.17.12)")

--- a/cmd/subnetcmd/describe.go
+++ b/cmd/subnetcmd/describe.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/key"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
@@ -46,7 +47,7 @@ func newDescribeCmd() *cobra.Command {
 By default, the command prints a summary of the configuration. By providing the --genesis
 flag, the command instead prints out the raw genesis file.`,
 		RunE: readGenesis,
-		Args: cobra.ExactArgs(1),
+		Args: cobrautils.ExactArgs(1),
 	}
 	cmd.Flags().BoolVarP(
 		&printGenesisOnly,

--- a/cmd/subnetcmd/elastic.go
+++ b/cmd/subnetcmd/elastic.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	es "github.com/ava-labs/avalanche-cli/pkg/elasticsubnet"
 	"github.com/ava-labs/avalanche-cli/pkg/keychain"
@@ -59,8 +60,7 @@ P-Chain. When enabling Elastic Validation, the creator permanently locks the Sub
 (they relinquish their control keys), specifies an Avalanche Native Token (ANT) that validators must use for staking 
 and that will be distributed as staking rewards, and provides a set of parameters that govern how the Subnet’s staking 
 mechanics will work.`,
-		SilenceUsage:      true,
-		Args:              cobra.ExactArgs(1),
+		Args:              cobrautils.ExactArgs(1),
 		RunE:              transformElasticSubnet,
 		PersistentPostRun: handlePostRun,
 	}

--- a/cmd/subnetcmd/export.go
+++ b/cmd/subnetcmd/export.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
-
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/prompts"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
@@ -31,9 +31,8 @@ func newExportCmd() *cobra.Command {
 
 The command prompts for an output path. You can also provide one with
 the --output flag.`,
-		RunE:         exportSubnet,
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
+		RunE: exportSubnet,
+		Args: cobrautils.ExactArgs(1),
 	}
 
 	cmd.Flags().StringVarP(

--- a/cmd/subnetcmd/import.go
+++ b/cmd/subnetcmd/import.go
@@ -17,9 +17,7 @@ func newImportCmd() *cobra.Command {
 This command suite supports importing from a file created on another computer,
 or importing from subnets running public networks
 (e.g. created manually or with the deprecated subnet-cli)`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cobrautils.CommandSuiteUsage(cmd, args)
-		},
+		RunE: cobrautils.CommandSuiteUsage,
 	}
 	// subnet import file
 	cmd.AddCommand(newImportFileCmd())

--- a/cmd/subnetcmd/import.go
+++ b/cmd/subnetcmd/import.go
@@ -3,8 +3,7 @@
 package subnetcmd
 
 import (
-	"fmt"
-
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/spf13/cobra"
 )
 
@@ -15,14 +14,11 @@ func newImportCmd() *cobra.Command {
 		Short: "Import subnets into avalanche-cli",
 		Long: `Import subnet configurations into avalanche-cli.
 
-This command supports importing from a file created on another computer,
+This command suite supports importing from a file created on another computer,
 or importing from subnets running public networks
 (e.g. created manually or with the deprecated subnet-cli)`,
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				fmt.Println(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cobrautils.CommandSuiteUsage(cmd, args)
 		},
 	}
 	// subnet import file

--- a/cmd/subnetcmd/import_file.go
+++ b/cmd/subnetcmd/import_file.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 
 	"github.com/ava-labs/avalanche-cli/pkg/apmintegration"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
@@ -29,11 +30,10 @@ var (
 // avalanche subnet import
 func newImportFileCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "file [subnetPath]",
-		Short:        "Import an existing subnet config",
-		RunE:         importSubnet,
-		SilenceUsage: true,
-		Args:         cobra.MaximumNArgs(1),
+		Use:   "file [subnetPath]",
+		Short: "Import an existing subnet config",
+		RunE:  importSubnet,
+		Args:  cobrautils.MaximumNArgs(1),
 		Long: `The subnet import command will import a subnet configuration from a file or a git repository.
 
 To import from a file, you can optionally provide the path as a command-line argument.

--- a/cmd/subnetcmd/import_public.go
+++ b/cmd/subnetcmd/import_public.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
@@ -32,11 +33,10 @@ var (
 // avalanche subnet import public
 func newImportPublicCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "public [subnetPath]",
-		Short:        "Import an existing subnet config from running subnets on a public network",
-		RunE:         importPublic,
-		SilenceUsage: true,
-		Args:         cobra.MaximumNArgs(1),
+		Use:   "public [subnetPath]",
+		Short: "Import an existing subnet config from running subnets on a public network",
+		RunE:  importPublic,
+		Args:  cobrautils.MaximumNArgs(1),
 		Long: `The subnet import public command imports a Subnet configuration from a running network.
 
 The genesis file should be available from the disk for this to work. By default, an imported Subnet

--- a/cmd/subnetcmd/join.go
+++ b/cmd/subnetcmd/join.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ava-labs/avalanche-cli/pkg/application"
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/keychain"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
@@ -73,9 +74,8 @@ you provide the --avalanchego-config flag, this command attempts to edit the con
 at that path.
 
 This command currently only supports Subnets deployed on the Fuji Testnet and Mainnet.`,
-		SilenceUsage: true,
-		RunE:         joinCmd,
-		Args:         cobra.ExactArgs(1),
+		RunE: joinCmd,
+		Args: cobrautils.ExactArgs(1),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, false, joinAllSupportedNetworkOptions)
 	cmd.Flags().StringVar(&avagoConfigPath, "avalanchego-config", "", "file path of the avalanchego config file")

--- a/cmd/subnetcmd/list.go
+++ b/cmd/subnetcmd/list.go
@@ -29,8 +29,7 @@ func newListCmd() *cobra.Command {
 		Long: `The subnet list command prints the names of all created Subnet configurations. Without any flags,
 it prints some general, static information about the Subnet. With the --deployed flag, the command
 shows additional information including the VMID, BlockchainID and SubnetID.`,
-		RunE:         listSubnets,
-		SilenceUsage: true,
+		RunE: listSubnets,
 	}
 	cmd.Flags().BoolVar(&deployed, "deployed", false, "show additional deploy information")
 	return cmd

--- a/cmd/subnetcmd/publish.go
+++ b/cmd/subnetcmd/publish.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ava-labs/apm/types"
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/prompts"
@@ -42,12 +43,11 @@ type newPublisherFunc func(string, string, string) subnet.Publisher
 // avalanche subnet publish
 func newPublishCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "publish [subnetName]",
-		Short:        "Publish the subnet's VM to a repository",
-		Long:         `The subnet publish command publishes the Subnet's VM to a repository.`,
-		SilenceUsage: true,
-		RunE:         publish,
-		Args:         cobra.ExactArgs(1),
+		Use:   "publish [subnetName]",
+		Short: "Publish the subnet's VM to a repository",
+		Long:  `The subnet publish command publishes the Subnet's VM to a repository.`,
+		RunE:  publish,
+		Args:  cobrautils.ExactArgs(1),
 	}
 	cmd.Flags().StringVar(&alias, "alias", "",
 		"We publish to a remote repo, but identify the repo locally under a user-provided alias (e.g. myrepo).")

--- a/cmd/subnetcmd/removeValidator.go
+++ b/cmd/subnetcmd/removeValidator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/keychain"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
@@ -33,9 +34,8 @@ validating your deployed Subnet.
 
 To remove the validator from the Subnet's allow list, provide the validator's unique NodeID. You can bypass
 these prompts by providing the values with flags.`,
-		SilenceUsage: true,
-		RunE:         removeValidator,
-		Args:         cobra.ExactArgs(1),
+		RunE: removeValidator,
+		Args: cobrautils.ExactArgs(1),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, false, removeValidatorSupportedNetworkOptions)
 	cmd.Flags().StringVarP(&keyName, "key", "k", "", "select the key to use [fuji deploy only]")

--- a/cmd/subnetcmd/stats.go
+++ b/cmd/subnetcmd/stats.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
@@ -26,12 +27,11 @@ var statsSupportedNetworkOptions = []networkoptions.NetworkOption{networkoptions
 // avalanche subnet stats
 func newStatsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "stats [subnetName]",
-		Short:        "Show validator statistics for the given subnet",
-		Long:         `The subnet stats command prints validator statistics for the given Subnet.`,
-		Args:         cobra.ExactArgs(1),
-		RunE:         stats,
-		SilenceUsage: true,
+		Use:   "stats [subnetName]",
+		Short: "Show validator statistics for the given subnet",
+		Long:  `The subnet stats command prints validator statistics for the given Subnet.`,
+		Args:  cobrautils.ExactArgs(1),
+		RunE:  stats,
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, false, statsSupportedNetworkOptions)
 	return cmd

--- a/cmd/subnetcmd/subnet.go
+++ b/cmd/subnetcmd/subnet.go
@@ -23,9 +23,7 @@ To get started, use the subnet create command wizard to walk through the
 configuration of your very first Subnet. Then, go ahead and deploy it
 with the subnet deploy command. You can use the rest of the commands to
 manage your Subnet configurations and live deployments.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cobrautils.CommandSuiteUsage(cmd, args)
-		},
+		RunE: cobrautils.CommandSuiteUsage,
 	}
 	app = injectedApp
 	// subnet create

--- a/cmd/subnetcmd/subnet.go
+++ b/cmd/subnetcmd/subnet.go
@@ -3,10 +3,9 @@
 package subnetcmd
 
 import (
-	"fmt"
-
 	"github.com/ava-labs/avalanche-cli/cmd/subnetcmd/upgradecmd"
 	"github.com/ava-labs/avalanche-cli/pkg/application"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/spf13/cobra"
 )
 
@@ -24,11 +23,8 @@ To get started, use the subnet create command wizard to walk through the
 configuration of your very first Subnet. Then, go ahead and deploy it
 with the subnet deploy command. You can use the rest of the commands to
 manage your Subnet configurations and live deployments.`,
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				fmt.Println(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cobrautils.CommandSuiteUsage(cmd, args)
 		},
 	}
 	app = injectedApp

--- a/cmd/subnetcmd/upgradecmd/apply.go
+++ b/cmd/subnetcmd/upgradecmd/apply.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
@@ -71,7 +72,7 @@ After you update your validator's configuration, you need to restart your valida
 If you provide the --avalanchego-chain-config-dir flag, this command attempts to write the upgrade file at that path.
 Refer to https://docs.avax.network/nodes/maintain/chain-config-flags#subnet-chain-configs for related documentation.`,
 		RunE: applyCmd,
-		Args: cobra.ExactArgs(1),
+		Args: cobrautils.ExactArgs(1),
 	}
 
 	cmd.Flags().BoolVar(&useConfig, "config", false, "create upgrade config for future subnet deployments (same as generate)")

--- a/cmd/subnetcmd/upgradecmd/export.go
+++ b/cmd/subnetcmd/upgradecmd/export.go
@@ -5,6 +5,7 @@ package upgradecmd
 import (
 	"os"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/spf13/cobra"
@@ -19,7 +20,7 @@ func newUpgradeExportCmd() *cobra.Command {
 		Short: "Export the upgrade bytes file to a location of choice on disk",
 		Long:  `Export the upgrade bytes file to a location of choice on disk`,
 		RunE:  upgradeExportCmd,
-		Args:  cobra.ExactArgs(1),
+		Args:  cobrautils.ExactArgs(1),
 	}
 
 	cmd.Flags().StringVar(&upgradeBytesFilePath, upgradeBytesFilePathKey, "", "Export upgrade bytes file to location of choice on disk")

--- a/cmd/subnetcmd/upgradecmd/generate.go
+++ b/cmd/subnetcmd/upgradecmd/generate.go
@@ -9,17 +9,16 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/ava-labs/avalanche-cli/pkg/models"
-	"github.com/ava-labs/avalanchego/utils/units"
-	"github.com/ava-labs/coreth/ethclient"
-	"go.uber.org/zap"
-
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
+	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/prompts"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanche-cli/pkg/vm"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/coreth/ethclient"
 	"github.com/ava-labs/subnet-evm/commontype"
 	"github.com/ava-labs/subnet-evm/params"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/deployerallowlist"
@@ -31,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 )
 
 const (
@@ -56,7 +56,7 @@ func newUpgradeGenerateCmd() *cobra.Command {
 		Long: `The subnet upgrade generate command builds a new upgrade.json file to customize your Subnet. It
 guides the user through the process using an interactive wizard.`,
 		RunE: upgradeGenerateCmd,
-		Args: cobra.ExactArgs(1),
+		Args: cobrautils.ExactArgs(1),
 	}
 	return cmd
 }

--- a/cmd/subnetcmd/upgradecmd/import.go
+++ b/cmd/subnetcmd/upgradecmd/import.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/spf13/cobra"
 )
@@ -21,7 +22,7 @@ func newUpgradeImportCmd() *cobra.Command {
 		Short: "Import the upgrade bytes file into the local environment",
 		Long:  `Import the upgrade bytes file into the local environment`,
 		RunE:  upgradeImportCmd,
-		Args:  cobra.ExactArgs(1),
+		Args:  cobrautils.ExactArgs(1),
 	}
 
 	cmd.Flags().StringVar(&upgradeBytesFilePath, upgradeBytesFilePathKey, "", "Import upgrade bytes file into local environment")

--- a/cmd/subnetcmd/upgradecmd/print.go
+++ b/cmd/subnetcmd/upgradecmd/print.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/spf13/cobra"
 )
@@ -17,7 +18,7 @@ func newUpgradePrintCmd() *cobra.Command {
 		Short: "Print the upgrade.json file content",
 		Long:  `Print the upgrade.json file content`,
 		RunE:  upgradePrintCmd,
-		Args:  cobra.ExactArgs(1),
+		Args:  cobrautils.ExactArgs(1),
 	}
 
 	return cmd

--- a/cmd/subnetcmd/upgradecmd/upgrade.go
+++ b/cmd/subnetcmd/upgradecmd/upgrade.go
@@ -17,9 +17,7 @@ func NewCmd(injectedApp *application.Avalanche) *cobra.Command {
 		Short: "Upgrade your Subnets",
 		Long: `The subnet upgrade command suite provides a collection of tools for
 updating your developmental and deployed Subnets.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cobrautils.CommandSuiteUsage(cmd, args)
-		},
+		RunE: cobrautils.CommandSuiteUsage,
 	}
 	app = injectedApp
 	// subnet upgrade vm

--- a/cmd/subnetcmd/upgradecmd/upgrade.go
+++ b/cmd/subnetcmd/upgradecmd/upgrade.go
@@ -3,9 +3,8 @@
 package upgradecmd
 
 import (
-	"fmt"
-
 	"github.com/ava-labs/avalanche-cli/pkg/application"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +17,8 @@ func NewCmd(injectedApp *application.Avalanche) *cobra.Command {
 		Short: "Upgrade your Subnets",
 		Long: `The subnet upgrade command suite provides a collection of tools for
 updating your developmental and deployed Subnets.`,
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				fmt.Println(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cobrautils.CommandSuiteUsage(cmd, args)
 		},
 	}
 	app = injectedApp

--- a/cmd/subnetcmd/upgradecmd/vm.go
+++ b/cmd/subnetcmd/upgradecmd/vm.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/plugins"
@@ -49,9 +50,8 @@ can upgrade both local Subnets and publicly deployed Subnets on Fuji and Mainnet
 
 The command walks the user through an interactive wizard. The user can skip the wizard by providing
 command line flags.`,
-		RunE:         upgradeVM,
-		Args:         cobra.ExactArgs(1),
-		SilenceUsage: true,
+		RunE: upgradeVM,
+		Args: cobrautils.ExactArgs(1),
 	}
 
 	cmd.Flags().BoolVar(&useConfig, "config", false, "upgrade config for future subnet deployments")

--- a/cmd/subnetcmd/validators.go
+++ b/cmd/subnetcmd/validators.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
@@ -27,9 +28,8 @@ func newValidatorsCmd() *cobra.Command {
 		Short: "List a subnet's validators",
 		Long: `The subnet validators command lists the validators of a subnet and provides
 severarl statistics about them.`,
-		RunE:         printValidators,
-		Args:         cobra.ExactArgs(1),
-		SilenceUsage: true,
+		RunE: printValidators,
+		Args: cobrautils.ExactArgs(1),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, false, validatorsSupportedNetworkOptions)
 	return cmd

--- a/cmd/subnetcmd/vmid.go
+++ b/cmd/subnetcmd/vmid.go
@@ -5,6 +5,7 @@ package subnetcmd
 import (
 	"fmt"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanche-network-runner/utils"
 	"github.com/spf13/cobra"
@@ -13,12 +14,11 @@ import (
 // avalanche subnet create
 func vmidCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "vmid [vmName]",
-		Short:        "Prints the VMID of a VM",
-		Long:         `The subnet vmid command prints the virtual machine ID (VMID) for the given Subnet.`,
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
-		RunE:         printVMID,
+		Use:   "vmid [vmName]",
+		Short: "Prints the VMID of a VM",
+		Long:  `The subnet vmid command prints the virtual machine ID (VMID) for the given Subnet.`,
+		Args:  cobrautils.ExactArgs(1),
+		RunE:  printVMID,
 	}
 	return cmd
 }

--- a/cmd/teleportercmd/addSubnetToRelayerService.go
+++ b/cmd/teleportercmd/addSubnetToRelayerService.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
 	"github.com/ava-labs/avalanche-cli/pkg/teleporter"
@@ -27,12 +28,11 @@ var (
 // avalanche teleporter relayer addSubnetToService
 func newAddSubnetToRelayerServiceCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "addSubnetToService [subnetName]",
-		Short:        "Adds a subnet to the AWM relayer service configuration",
-		Long:         `Adds a subnet to the AWM relayer service configuration".`,
-		SilenceUsage: true,
-		RunE:         addSubnetToRelayerService,
-		Args:         cobra.ExactArgs(1),
+		Use:   "addSubnetToService [subnetName]",
+		Short: "Adds a subnet to the AWM relayer service configuration",
+		Long:  `Adds a subnet to the AWM relayer service configuration".`,
+		RunE:  addSubnetToRelayerService,
+		Args:  cobrautils.ExactArgs(1),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &addSubnetToRelayerServiceFlags.Network, true, addSubnetToRelayerServiceSupportedNetworkOptions)
 	cmd.Flags().StringVar(&addSubnetToRelayerServiceFlags.CloudNodeID, "cloud-node-id", "", "generate a config to be used on given cloud node")

--- a/cmd/teleportercmd/deploy.go
+++ b/cmd/teleportercmd/deploy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/ava-labs/avalanche-cli/cmd/subnetcmd"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
@@ -20,12 +21,11 @@ var deploySupportedNetworkOptions = []networkoptions.NetworkOption{networkoption
 // avalanche teleporter deploy
 func newDeployCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "deploy [subnetName]",
-		Short:        "Deploys Teleporter into the given Subnet",
-		Long:         `Deploys Teleporter into the given Subnet.`,
-		SilenceUsage: true,
-		RunE:         deploy,
-		Args:         cobra.ExactArgs(1),
+		Use:   "deploy [subnetName]",
+		Short: "Deploys Teleporter into the given Subnet",
+		Long:  `Deploys Teleporter into the given Subnet.`,
+		RunE:  deploy,
+		Args:  cobrautils.ExactArgs(1),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, true, deploySupportedNetworkOptions)
 	return cmd

--- a/cmd/teleportercmd/msg.go
+++ b/cmd/teleportercmd/msg.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/evm"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
@@ -28,12 +29,11 @@ var (
 // avalanche teleporter msg
 func newMsgCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "msg [sourceSubnetName] [destinationSubnetName] [messageContent]",
-		Short:        "Verifies exchange of teleporter message between two subnets",
-		Long:         `Sends and wait reception for a teleporter msg between two subnets (Currently only for local network).`,
-		SilenceUsage: true,
-		RunE:         msg,
-		Args:         cobra.ExactArgs(3),
+		Use:   "msg [sourceSubnetName] [destinationSubnetName] [messageContent]",
+		Short: "Verifies exchange of teleporter message between two subnets",
+		Long:  `Sends and wait reception for a teleporter msg between two subnets (Currently only for local network).`,
+		RunE:  msg,
+		Args:  cobrautils.ExactArgs(3),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, true, msgSupportedNetworkOptions)
 	return cmd

--- a/cmd/teleportercmd/prepareRelayerService.go
+++ b/cmd/teleportercmd/prepareRelayerService.go
@@ -9,6 +9,7 @@ import (
 	"os/user"
 	"path/filepath"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/teleporter"
 	"github.com/spf13/cobra"
@@ -20,12 +21,11 @@ var awmRelayerServiceTemplate []byte
 // avalanche teleporter msg
 func newPrepareRelayerServiceCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "prepareService",
-		Short:        "Installs AWM relayer as a service",
-		Long:         `Installs AWM relayer as a service. Disabled by default.`,
-		SilenceUsage: true,
-		RunE:         prepareRelayerService,
-		Args:         cobra.ExactArgs(0),
+		Use:   "prepareService",
+		Short: "Installs AWM relayer as a service",
+		Long:  `Installs AWM relayer as a service. Disabled by default.`,
+		RunE:  prepareRelayerService,
+		Args:  cobrautils.ExactArgs(0),
 	}
 	return cmd
 }

--- a/cmd/teleportercmd/relayer.go
+++ b/cmd/teleportercmd/relayer.go
@@ -14,9 +14,7 @@ func newRelayerCmd() *cobra.Command {
 		Short: "Install and configure relayer on localhost",
 		Long: `The relayert command suite provides a collection of tools for installing
 and configuring an AWM relayer on localhost.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cobrautils.CommandSuiteUsage(cmd, args)
-		},
+		RunE: cobrautils.CommandSuiteUsage,
 	}
 	cmd.AddCommand(newPrepareRelayerServiceCmd())
 	cmd.AddCommand(newAddSubnetToRelayerServiceCmd())

--- a/cmd/teleportercmd/relayer.go
+++ b/cmd/teleportercmd/relayer.go
@@ -3,8 +3,7 @@
 package teleportercmd
 
 import (
-	"fmt"
-
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/spf13/cobra"
 )
 
@@ -15,11 +14,8 @@ func newRelayerCmd() *cobra.Command {
 		Short: "Install and configure relayer on localhost",
 		Long: `The relayert command suite provides a collection of tools for installing
 and configuring an AWM relayer on localhost.`,
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				fmt.Println(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cobrautils.CommandSuiteUsage(cmd, args)
 		},
 	}
 	cmd.AddCommand(newPrepareRelayerServiceCmd())

--- a/cmd/teleportercmd/startRelayer.go
+++ b/cmd/teleportercmd/startRelayer.go
@@ -5,6 +5,7 @@ package teleportercmd
 import (
 	"fmt"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
 	"github.com/ava-labs/avalanche-cli/pkg/node"
@@ -20,12 +21,11 @@ var startRelayerNetworkOptions = []networkoptions.NetworkOption{networkoptions.L
 // avalanche teleporter relayer start
 func newStartRelayerCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "start",
-		Short:        "starts AWM relayer",
-		Long:         `Starts AWM relayer on the specified network (Currently only for local network).`,
-		SilenceUsage: true,
-		RunE:         startRelayer,
-		Args:         cobra.ExactArgs(0),
+		Use:   "start",
+		Short: "starts AWM relayer",
+		Long:  `Starts AWM relayer on the specified network (Currently only for local network).`,
+		RunE:  startRelayer,
+		Args:  cobrautils.ExactArgs(0),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, true, startRelayerNetworkOptions)
 	return cmd

--- a/cmd/teleportercmd/stopRelayer.go
+++ b/cmd/teleportercmd/stopRelayer.go
@@ -5,6 +5,7 @@ package teleportercmd
 import (
 	"fmt"
 
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
 	"github.com/ava-labs/avalanche-cli/pkg/node"
@@ -20,12 +21,11 @@ var stopRelayerNetworkOptions = []networkoptions.NetworkOption{networkoptions.Lo
 // avalanche teleporter relayer stop
 func newStopRelayerCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "stop",
-		Short:        "stops AWM relayer",
-		Long:         `Stops AWM relayer on the specified network (Currently only for local network, cluster).`,
-		SilenceUsage: true,
-		RunE:         stopRelayer,
-		Args:         cobra.ExactArgs(0),
+		Use:   "stop",
+		Short: "stops AWM relayer",
+		Long:  `Stops AWM relayer on the specified network (Currently only for local network, cluster).`,
+		RunE:  stopRelayer,
+		Args:  cobrautils.ExactArgs(0),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, true, stopRelayerNetworkOptions)
 	return cmd

--- a/cmd/teleportercmd/teleporter.go
+++ b/cmd/teleportercmd/teleporter.go
@@ -17,9 +17,7 @@ func NewCmd(injectedApp *application.Avalanche) *cobra.Command {
 		Short: "Interact with teleporter-enabled subnets",
 		Long: `The teleporter command suite provides a collection of tools for interacting
 with Teleporter-Enabled Subnets.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cobrautils.CommandSuiteUsage(cmd, args)
-		},
+		RunE: cobrautils.CommandSuiteUsage,
 	}
 	app = injectedApp
 	// teleporter msg

--- a/cmd/teleportercmd/teleporter.go
+++ b/cmd/teleportercmd/teleporter.go
@@ -3,9 +3,8 @@
 package teleportercmd
 
 import (
-	"fmt"
-
 	"github.com/ava-labs/avalanche-cli/pkg/application"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +17,8 @@ func NewCmd(injectedApp *application.Avalanche) *cobra.Command {
 		Short: "Interact with teleporter-enabled subnets",
 		Long: `The teleporter command suite provides a collection of tools for interacting
 with Teleporter-Enabled Subnets.`,
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				fmt.Println(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cobrautils.CommandSuiteUsage(cmd, args)
 		},
 	}
 	app = injectedApp

--- a/cmd/transactioncmd/transaction.go
+++ b/cmd/transactioncmd/transaction.go
@@ -3,9 +3,8 @@
 package transactioncmd
 
 import (
-	"fmt"
-
 	"github.com/ava-labs/avalanche-cli/pkg/application"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/spf13/cobra"
 )
 
@@ -17,11 +16,8 @@ func NewCmd(injectedApp *application.Avalanche) *cobra.Command {
 		Use:   "transaction",
 		Short: "Sign and execute specific transactions",
 		Long:  `The transaction command suite provides all of the utilities required to sign multisig transactions.`,
-		Run: func(cmd *cobra.Command, _ []string) {
-			err := cmd.Help()
-			if err != nil {
-				fmt.Println(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cobrautils.CommandSuiteUsage(cmd, args)
 		},
 	}
 	app = injectedApp

--- a/cmd/transactioncmd/transaction.go
+++ b/cmd/transactioncmd/transaction.go
@@ -16,9 +16,7 @@ func NewCmd(injectedApp *application.Avalanche) *cobra.Command {
 		Use:   "transaction",
 		Short: "Sign and execute specific transactions",
 		Long:  `The transaction command suite provides all of the utilities required to sign multisig transactions.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cobrautils.CommandSuiteUsage(cmd, args)
-		},
+		RunE:  cobrautils.CommandSuiteUsage,
 	}
 	app = injectedApp
 	// subnet upgrade vm

--- a/cmd/transactioncmd/transaction_commit.go
+++ b/cmd/transactioncmd/transaction_commit.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/ava-labs/avalanche-cli/cmd/subnetcmd"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/keychain"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
 	"github.com/ava-labs/avalanche-cli/pkg/txutils"
@@ -18,12 +19,11 @@ import (
 // avalanche transaction commit
 func newTransactionCommitCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "commit [subnetName]",
-		Short:        "commit a transaction",
-		Long:         "The transaction commit command commits a transaction by submitting it to the P-Chain.",
-		RunE:         commitTx,
-		Args:         cobra.ExactArgs(1),
-		SilenceUsage: true,
+		Use:   "commit [subnetName]",
+		Short: "commit a transaction",
+		Long:  "The transaction commit command commits a transaction by submitting it to the P-Chain.",
+		RunE:  commitTx,
+		Args:  cobrautils.ExactArgs(1),
 	}
 
 	cmd.Flags().StringVar(&inputTxPath, inputTxPathFlag, "", "Path to the transaction signed by all signatories")

--- a/cmd/transactioncmd/transaction_sign.go
+++ b/cmd/transactioncmd/transaction_sign.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/ava-labs/avalanche-cli/cmd/subnetcmd"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/keychain"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/prompts"
@@ -31,12 +32,11 @@ var (
 // avalanche transaction sign
 func newTransactionSignCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "sign [subnetName]",
-		Short:        "sign a transaction",
-		Long:         "The transaction sign command signs a multisig transaction.",
-		RunE:         signTx,
-		Args:         cobra.ExactArgs(1),
-		SilenceUsage: true,
+		Use:   "sign [subnetName]",
+		Short: "sign a transaction",
+		Long:  "The transaction sign command signs a multisig transaction.",
+		RunE:  signTx,
+		Args:  cobrautils.ExactArgs(1),
 	}
 
 	cmd.Flags().StringVar(&inputTxPath, inputTxPathFlag, "", "Path to the transaction file for signing")

--- a/cmd/updatecmd/update.go
+++ b/cmd/updatecmd/update.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ava-labs/avalanche-cli/pkg/application"
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/spf13/cobra"
@@ -29,13 +30,12 @@ var (
 func NewCmd(injectedApp *application.Avalanche, version string) *cobra.Command {
 	app = injectedApp
 	cmd := &cobra.Command{
-		Use:          "update",
-		Short:        "Check for latest updates of Avalanche-CLI",
-		Long:         `Check if an update is available, and prompt the user to install it`,
-		RunE:         runUpdate,
-		Args:         cobra.ExactArgs(0),
-		SilenceUsage: true,
-		Version:      version,
+		Use:     "update",
+		Short:   "Check for latest updates of Avalanche-CLI",
+		Long:    `Check if an update is available, and prompt the user to install it`,
+		RunE:    runUpdate,
+		Args:    cobrautils.ExactArgs(0),
+		Version: version,
 	}
 
 	cmd.Flags().BoolVarP(&yes, "confirm", "c", false, "Assume yes for installation")

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -479,6 +479,10 @@ func (app *Avalanche) CreateSidecar(sc *models.Sidecar) error {
 }
 
 func (app *Avalanche) LoadSidecar(subnetName string) (models.Sidecar, error) {
+	if !app.SidecarExists(subnetName) {
+		return models.Sidecar{}, fmt.Errorf("subnet %q does not exist", subnetName)
+	}
+
 	sidecarPath := app.GetSidecarPath(subnetName)
 	jsonBytes, err := os.ReadFile(sidecarPath)
 	if err != nil {

--- a/pkg/cobrautils/cobrautils.go
+++ b/pkg/cobrautils/cobrautils.go
@@ -1,0 +1,101 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+package cobrautils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type UsageError struct {
+	cmd *cobra.Command
+	err error
+}
+
+func (e UsageError) Error() string {
+	return fmt.Sprintf("Usage error: %s", e.err)
+}
+
+func NewUsageError(cmd *cobra.Command, err error) UsageError {
+	return UsageError{
+		cmd: cmd,
+		err: err,
+	}
+}
+
+func ExactArgs(n int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		err := cobra.ExactArgs(n)(cmd, args)
+		if err != nil {
+			err = NewUsageError(cmd, err)
+		}
+		return err
+	}
+}
+
+func MaximumNArgs(n int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		err := cobra.MaximumNArgs(n)(cmd, args)
+		if err != nil {
+			err = NewUsageError(cmd, err)
+		}
+		return err
+	}
+}
+
+func MinimumNArgs(n int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		err := cobra.MinimumNArgs(n)(cmd, args)
+		if err != nil {
+			err = NewUsageError(cmd, err)
+		}
+		return err
+	}
+}
+
+func RangeArgs(min int, max int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		err := cobra.RangeArgs(min, max)(cmd, args)
+		if err != nil {
+			err = NewUsageError(cmd, err)
+		}
+		return err
+	}
+}
+
+func HandleErrors(err error) {
+	if err != nil {
+		usageErr, ok := err.(UsageError)
+		if ok {
+			usageErr.cmd.Println(usageErr)
+			usageErr.cmd.Println()
+			usageErr.cmd.Println(usageErr.cmd.UsageString())
+		} else {
+			fmt.Printf("Error: %s\n", err)
+		}
+		os.Exit(1)
+	}
+}
+
+func CommandSuiteUsage(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return NewUsageError(
+			cmd,
+			fmt.Errorf("invalid subcommand %q", strings.Join(args, " ")),
+		)
+	}
+	err := cmd.Help()
+	if err != nil {
+		fmt.Println(err)
+	}
+	return nil
+}
+
+func ConfigureRootCmd(cmd *cobra.Command) {
+	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return NewUsageError(cmd, err)
+	})
+}

--- a/pkg/cobrautils/cobrautils.go
+++ b/pkg/cobrautils/cobrautils.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ava-labs/avalanche-cli/pkg/ux"
+
 	"github.com/spf13/cobra"
 )
 
@@ -74,7 +76,7 @@ func HandleErrors(err error) {
 			usageErr.cmd.Println()
 			usageErr.cmd.Println(usageErr.cmd.UsageString())
 		} else {
-			fmt.Printf("Error: %s\n", err)
+			ux.Logger.PrintToUser("Error: %s", err)
 		}
 		os.Exit(1)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,10 +28,8 @@ func (*Config) SetConfig(log logging.Logger, s string) {
 	viper.SetConfigFile(s)
 	viper.AutomaticEnv() // read in environment variables that match
 	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		log.Info("Using config file", zap.String("config-file", s))
-	} else {
-		log.Info("No log file found")
+	if err := viper.ReadInConfig(); err != nil {
+		log.Info("No config file found", zap.Error(err))
 	}
 }
 


### PR DESCRIPTION
- if invalid subcommand, print error message and usage msg
- if invalid flag, print error message and usage msg
- if invalid number of positional args, print error message and usage msg
- if no subcommand is provided, print usage msg
- for other errors, just print the error
- log errors to log file
- log cmdline to log file
- improve error msg when subnet name is invalid and the cmd tries to get sidecar
- remove airdrop key on subnet delete
- avoid trying to merge config file that does not exist

Closes https://github.com/ava-labs/avalanche-cli/issues/1781 https://github.com/ava-labs/avalanche-cli/issues/1250 https://github.com/ava-labs/avalanche-cli/issues/1008