### PR TITLE
on import, use genesis from blockchain tx

### DIFF
--- a/cmd/keycmd/list.go
+++ b/cmd/keycmd/list.go
@@ -145,7 +145,7 @@ func getClients(networks []models.Network, pchain bool, cchain bool, xchain bool
 			if err != nil {
 				return nil, nil, nil, nil, err
 			}
-			b, err := subnetcmd.HasSubnetEVMGenesis(subnetName)
+			b, _, err := subnetcmd.HasSubnetEVMGenesis(subnetName)
 			if err != nil {
 				return nil, nil, nil, nil, err
 			}

--- a/cmd/nodecmd/wiz.go
+++ b/cmd/nodecmd/wiz.go
@@ -266,7 +266,7 @@ func wiz(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	isEVMGenesis, err := subnetcmd.HasSubnetEVMGenesis(subnetName)
+	isEVMGenesis, _, err := subnetcmd.HasSubnetEVMGenesis(subnetName)
 	if err != nil {
 		return err
 	}
@@ -451,7 +451,7 @@ func hasTeleporterDeploys(
 		return false, err
 	}
 	for _, deployedSubnetName := range clusterConfig.Subnets {
-		deployedSubnetIsEVMGenesis, err := subnetcmd.HasSubnetEVMGenesis(deployedSubnetName)
+		deployedSubnetIsEVMGenesis, _, err := subnetcmd.HasSubnetEVMGenesis(deployedSubnetName)
 		if err != nil {
 			return false, err
 		}
@@ -474,7 +474,7 @@ func updateProposerVMs(
 		return err
 	}
 	for _, deployedSubnetName := range clusterConfig.Subnets {
-		deployedSubnetIsEVMGenesis, err := subnetcmd.HasSubnetEVMGenesis(deployedSubnetName)
+		deployedSubnetIsEVMGenesis, _, err := subnetcmd.HasSubnetEVMGenesis(deployedSubnetName)
 		if err != nil {
 			return err
 		}

--- a/cmd/subnetcmd/describe.go
+++ b/cmd/subnetcmd/describe.go
@@ -358,7 +358,7 @@ func readGenesis(_ *cobra.Command, args []string) error {
 		return printGenesis(sc, subnetName)
 	}
 
-	isEVM, err := HasSubnetEVMGenesis(subnetName)
+	isEVM, _, err := HasSubnetEVMGenesis(subnetName)
 	if err != nil {
 		return err
 	}

--- a/cmd/subnetcmd/import_public.go
+++ b/cmd/subnetcmd/import_public.go
@@ -78,7 +78,7 @@ func importPublic(*cobra.Command, []string) error {
 	var reply *info.GetNodeVersionReply
 
 	if nodeURL == "" {
-		yes, err := app.Prompt.CaptureNoYes("Have validator nodes with public API already been deployed to this subnet?")
+		yes, err := app.Prompt.CaptureNoYes("Have validator nodes already been deployed to this subnet?")
 		if err != nil {
 			return err
 		}

--- a/cmd/teleportercmd/deploy.go
+++ b/cmd/teleportercmd/deploy.go
@@ -54,7 +54,7 @@ func CallDeploy(subnetName string, flags networkoptions.NetworkFlags) error {
 	if !sc.TeleporterReady {
 		return fmt.Errorf("subnet is not configured for teleporter")
 	}
-	if b, err := subnetcmd.HasSubnetEVMGenesis(subnetName); err != nil {
+	if b, _, err := subnetcmd.HasSubnetEVMGenesis(subnetName); err != nil {
 		return err
 	} else if !b {
 		return fmt.Errorf("only Subnet-EVM based vms can be used for teleporter")

--- a/internal/migrations/subnetEVMRename.go
+++ b/internal/migrations/subnetEVMRename.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 
 	"github.com/ava-labs/avalanche-cli/pkg/application"
@@ -27,7 +28,8 @@ func migrateSubnetEVMNames(app *application.Avalanche, runner *migrationRunner) 
 			continue
 		}
 		// disregard any empty subnet directories
-		dirContents, err := os.ReadDir(filepath.Join(subnetDir, subnet.Name()))
+		dirName := filepath.Join(subnetDir, subnet.Name())
+		dirContents, err := os.ReadDir(dirName)
 		if err != nil {
 			return err
 		}
@@ -36,7 +38,12 @@ func migrateSubnetEVMNames(app *application.Avalanche, runner *migrationRunner) 
 		}
 
 		if !app.SidecarExists(subnet.Name()) {
-			return fmt.Errorf("subnet %s has inconsistent configuration. there is no sidecar on directory", subnet.Name())
+			return fmt.Errorf(
+				"subnet %s has inconsistent configuration. there is no %s file present on directory %s. please backup any file and then remove the subnet",
+				subnet.Name(),
+				constants.SidecarFileName,
+				dirName,
+			)
 		}
 
 		sc, err := app.LoadSidecar(subnet.Name())

--- a/internal/migrations/subnetEVMRename.go
+++ b/internal/migrations/subnetEVMRename.go
@@ -4,6 +4,7 @@
 package migrations
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -32,6 +33,10 @@ func migrateSubnetEVMNames(app *application.Avalanche, runner *migrationRunner) 
 		}
 		if len(dirContents) == 0 {
 			continue
+		}
+
+		if !app.SidecarExists(subnet.Name()) {
+			return fmt.Errorf("subnet %s has inconsistent configuration. there is no sidecar on directory", subnet.Name())
 		}
 
 		sc, err := app.LoadSidecar(subnet.Name())


### PR DESCRIPTION
Closes https://github.com/ava-labs/avalanche-cli/issues/1805
Also:
- stop marking the imported subnet as imported by APM. it is not the case. you can also infer if it is imported by looking at the ImporterVM field.
- show evm genesis validation error if any, on local deploy
- improve error message when internal migrations hits a subnet with no sidecar
- avoid creating a subnet with only genesis when asked to import a custom vm