### PR TITLE
Update release-public-ami.yml

### DIFF
--- a/.github/workflows/release-public-ami.yml
+++ b/.github/workflows/release-public-ami.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   build-public-ami-and-upload:
+    name: Build Public AMIs for AWS and GCP
     runs-on: ubuntu-20.04
     timeout-minutes: 45
 

--- a/.github/workflows/release-public-ami.yml
+++ b/.github/workflows/release-public-ami.yml
@@ -58,7 +58,7 @@ jobs:
       - name: install nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '16'
 
       - name: install npx aws-amicleaner
         run: npm install -g aws-amicleaner

--- a/.github/workflows/release-public-ami.yml
+++ b/.github/workflows/release-public-ami.yml
@@ -32,7 +32,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Configure GCP credentials
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.EXPERIMENTAL_GCP_SA_KEY_PACKER }}
 


### PR DESCRIPTION
fix 
```
Run google-github-actions/auth@v0
Error: The v0 series of google-github-actions/auth is no longer maintained. It will not receive updates, improvements, or security patches. Please upgrade to the latest supported versions: 

    https://github.com/google-github-actions/auth
  ```