### PR TITLE
Add native remote option to Tokentransferrer 

### DIFF
--- a/cmd/interchaincmd/tokentransferrercmd/deploy.go
+++ b/cmd/interchaincmd/tokentransferrercmd/deploy.go
@@ -11,7 +11,6 @@ import (
 	cmdflags "github.com/ava-labs/avalanche-cli/cmd/flags"
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/contract"
-	"github.com/ava-labs/avalanche-cli/pkg/evm"
 	"github.com/ava-labs/avalanche-cli/pkg/ictt"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
 	"github.com/ava-labs/avalanche-cli/pkg/prompts"
@@ -591,13 +590,6 @@ func CallDeploy(_ []string, flags DeployFlags) error {
 			return err
 		}
 
-		client, err := evm.GetClient(remoteEndpoint)
-		if err != nil {
-			return err
-		}
-
-		fmt.Println(evm.GetAddressBalance(client, homeKey.C()))
-
 		err = ictt.Send(
 			homeEndpoint,
 			homeAddress,
@@ -629,7 +621,6 @@ func CallDeploy(_ []string, flags DeployFlags) error {
 			}
 			time.Sleep(checkInterval)
 		}
-		fmt.Println(evm.GetAddressBalance(client, homeKey.C()))
 	}
 
 	ux.Logger.PrintToUser("Remote Deployed to %s", remoteEndpoint)

--- a/cmd/interchaincmd/tokentransferrercmd/deploy.go
+++ b/cmd/interchaincmd/tokentransferrercmd/deploy.go
@@ -11,6 +11,7 @@ import (
 	cmdflags "github.com/ava-labs/avalanche-cli/cmd/flags"
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/contract"
+	"github.com/ava-labs/avalanche-cli/pkg/evm"
 	"github.com/ava-labs/avalanche-cli/pkg/ictt"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
 	"github.com/ava-labs/avalanche-cli/pkg/prompts"
@@ -590,6 +591,13 @@ func CallDeploy(_ []string, flags DeployFlags) error {
 			return err
 		}
 
+		client, err := evm.GetClient(remoteEndpoint)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(evm.GetAddressBalance(client, homeKey.C()))
+
 		err = ictt.Send(
 			homeEndpoint,
 			homeAddress,
@@ -602,6 +610,7 @@ func CallDeploy(_ []string, flags DeployFlags) error {
 		if err != nil {
 			return err
 		}
+
 		t0 := time.Now()
 		for {
 			isCollateralized, err := ictt.TokenRemoteIsCollateralized(
@@ -620,6 +629,7 @@ func CallDeploy(_ []string, flags DeployFlags) error {
 			}
 			time.Sleep(checkInterval)
 		}
+		fmt.Println(evm.GetAddressBalance(client, homeKey.C()))
 	}
 
 	ux.Logger.PrintToUser("Remote Deployed to %s", remoteEndpoint)

--- a/cmd/interchaincmd/tokentransferrercmd/deploy.go
+++ b/cmd/interchaincmd/tokentransferrercmd/deploy.go
@@ -294,6 +294,9 @@ func CallDeploy(_ []string, flags DeployFlags) error {
 	// Remote Chain Prompts
 	if !flags.remoteFlags.chainFlags.CChain && flags.remoteFlags.chainFlags.SubnetName == "" {
 		prompt := "Where should the token be available as an ERC-20?"
+		if flags.remoteFlags.native {
+			prompt = "Where should the token be available as a Native Token?"
+		}
 		if cancel, err := promptChain(prompt, network, flags.homeFlags.chainFlags.CChain, flags.homeFlags.chainFlags.SubnetName, &flags.remoteFlags.chainFlags); err != nil {
 			return err
 		} else if cancel {

--- a/cmd/interchaincmd/tokentransferrercmd/deploy.go
+++ b/cmd/interchaincmd/tokentransferrercmd/deploy.go
@@ -449,20 +449,26 @@ func CallDeploy(_ []string, flags DeployFlags) error {
 		return err
 	}
 
-	remoteAddress, err := ictt.DeployERC20Remote(
-		icttSrcDir,
-		remoteEndpoint,
-		remoteKey.PrivKeyHex(),
-		common.HexToAddress(remoteRegistryAddress),
-		common.HexToAddress(remoteKey.C()),
-		homeBlockchainID,
-		homeAddress,
-		tokenName,
-		tokenSymbol,
-		tokenDecimals,
-	)
-	if err != nil {
-		return err
+	var remoteAddress common.Address
+
+	if !flags.remoteFlags.native {
+		remoteAddress, err = ictt.DeployERC20Remote(
+			icttSrcDir,
+			remoteEndpoint,
+			remoteKey.PrivKeyHex(),
+			common.HexToAddress(remoteRegistryAddress),
+			common.HexToAddress(remoteKey.C()),
+			homeBlockchainID,
+			homeAddress,
+			tokenName,
+			tokenSymbol,
+			tokenDecimals,
+		)
+		if err != nil {
+			return err
+		}
+	} else {
+
 	}
 
 	if err := ictt.RegisterERC20Remote(

--- a/cmd/interchaincmd/tokentransferrercmd/deploy.go
+++ b/cmd/interchaincmd/tokentransferrercmd/deploy.go
@@ -5,6 +5,7 @@ package tokentransferrercmd
 import (
 	_ "embed"
 	"fmt"
+	"math/big"
 
 	cmdflags "github.com/ava-labs/avalanche-cli/cmd/flags"
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
@@ -468,7 +469,39 @@ func CallDeploy(_ []string, flags DeployFlags) error {
 			return err
 		}
 	} else {
-
+		nativeTokenSymbol, err := getNativeTokenSymbol(
+			flags.remoteFlags.chainFlags.SubnetName,
+			flags.remoteFlags.chainFlags.CChain,
+		)
+		if err != nil {
+			return err
+		}
+		supply, err := contract.GetEVMSubnetGenesisSupply(
+			app,
+			network,
+			flags.remoteFlags.chainFlags.SubnetName,
+			flags.remoteFlags.chainFlags.CChain,
+			"",
+		)
+		if err != nil {
+			return err
+		}
+		remoteAddress, err = ictt.DeployNativeRemote(
+			icttSrcDir,
+			remoteEndpoint,
+			remoteKey.PrivKeyHex(),
+			common.HexToAddress(remoteRegistryAddress),
+			common.HexToAddress(remoteKey.C()),
+			homeBlockchainID,
+			homeAddress,
+			tokenDecimals,
+			nativeTokenSymbol,
+			supply,
+			big.NewInt(0),
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	if err := ictt.RegisterERC20Remote(

--- a/cmd/keycmd/list.go
+++ b/cmd/keycmd/list.go
@@ -49,6 +49,7 @@ var (
 	cchain          bool
 	xchain          bool
 	useNanoAvax     bool
+	useGwei         bool
 	ledgerIndices   []uint
 	keys            []string
 	tokenAddresses  []string
@@ -99,6 +100,12 @@ keys or for the ledger addresses associated to certain indices.`,
 		"n",
 		false,
 		"use nano Avax for balances",
+	)
+	cmd.Flags().BoolVar(
+		&useGwei,
+		"use-gwei",
+		false,
+		"use gwei for EVM balances",
 	)
 	cmd.Flags().UintSliceVarP(
 		&ledgerIndices,
@@ -595,6 +602,9 @@ func getCChainBalanceStr(cClient ethclient.Client, addrStr string) (string, erro
 }
 
 func formatCChainBalance(balance *big.Int) (string, error) {
+	if useGwei {
+		return fmt.Sprintf("%d", balance), nil
+	}
 	// convert to nAvax
 	balance = balance.Div(balance, big.NewInt(int64(units.Avax)))
 	if balance.Cmp(big.NewInt(0)) == 0 {

--- a/cmd/keycmd/list.go
+++ b/cmd/keycmd/list.go
@@ -127,6 +127,12 @@ keys or for the ledger addresses associated to certain indices.`,
 		"subnets to show information about (p=p-chain, x=x-chain, c=c-chain, and subnet names) (default p,x,c)",
 	)
 	cmd.Flags().StringSliceVar(
+		&subnets,
+		"blockchains",
+		[]string{},
+		"blockchains to show information about (p=p-chain, x=x-chain, c=c-chain, and blockchain names) (default p,x,c)",
+	)
+	cmd.Flags().StringSliceVar(
 		&tokenAddresses,
 		"tokens",
 		[]string{"Native"},

--- a/cmd/keycmd/transfer.go
+++ b/cmd/keycmd/transfer.go
@@ -390,45 +390,15 @@ func transferF(*cobra.Command, []string) error {
 		amount = amount.Mul(amount, new(big.Float).SetFloat64(float64(units.Avax)))
 		amount = amount.Mul(amount, new(big.Float).SetFloat64(float64(units.Avax)))
 		amountInt, _ := amount.Int(nil)
-		endpointKind, err := ictt.GetEndpointKind(
+		return ictt.Send(
 			originURL,
 			goethereumcommon.HexToAddress(originTransferrerAddress),
+			privateKey,
+			destinationBlockchainID,
+			goethereumcommon.HexToAddress(destinationTransferrerAddress),
+			destinationAddr,
+			amountInt,
 		)
-		if err != nil {
-			return err
-		}
-		switch endpointKind {
-		case ictt.ERC20TokenRemote:
-			return ictt.ERC20TokenRemoteSend(
-				originURL,
-				goethereumcommon.HexToAddress(originTransferrerAddress),
-				privateKey,
-				destinationBlockchainID,
-				goethereumcommon.HexToAddress(destinationTransferrerAddress),
-				destinationAddr,
-				amountInt,
-			)
-		case ictt.ERC20TokenHome:
-			return ictt.ERC20TokenHomeSend(
-				originURL,
-				goethereumcommon.HexToAddress(originTransferrerAddress),
-				privateKey,
-				destinationBlockchainID,
-				goethereumcommon.HexToAddress(destinationTransferrerAddress),
-				destinationAddr,
-				amountInt,
-			)
-		case ictt.NativeTokenHome:
-			return ictt.NativeTokenHomeSend(
-				originURL,
-				goethereumcommon.HexToAddress(originTransferrerAddress),
-				privateKey,
-				destinationBlockchainID,
-				goethereumcommon.HexToAddress(destinationTransferrerAddress),
-				destinationAddr,
-				amountInt,
-			)
-		}
 	}
 
 	if !send && !receive {

--- a/cmd/teleportercmd/msg.go
+++ b/cmd/teleportercmd/msg.go
@@ -109,7 +109,7 @@ func msg(_ *cobra.Command, args []string) error {
 		}
 	}
 
-	_, _, sourceBlockchainID, sourceMessengerAddress, _, _, err := teleporter.GetSubnetParams(
+	_, _, _, sourceBlockchainID, sourceMessengerAddress, _, _, err := teleporter.GetSubnetParams(
 		app,
 		network,
 		sourceSubnetName,
@@ -118,7 +118,7 @@ func msg(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	_, _, destBlockchainID, destMessengerAddress, _, _, err := teleporter.GetSubnetParams(
+	_, _, _, destBlockchainID, destMessengerAddress, _, _, err := teleporter.GetSubnetParams(
 		app,
 		network,
 		destSubnetName,

--- a/cmd/teleportercmd/relayercmd/addSubnetToService.go
+++ b/cmd/teleportercmd/relayercmd/addSubnetToService.go
@@ -62,7 +62,7 @@ func CallAddSubnetToService(subnetName string, flags AddSubnetToServiceFlags) er
 		return err
 	}
 
-	_, subnetID, chainID, messengerAddress, registryAddress, _, err := teleporter.GetSubnetParams(app, network, "", true)
+	_, _, subnetID, chainID, messengerAddress, registryAddress, _, err := teleporter.GetSubnetParams(app, network, "", true)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func CallAddSubnetToService(subnetName string, flags AddSubnetToServiceFlags) er
 		return err
 	}
 
-	_, subnetID, chainID, messengerAddress, registryAddress, _, err = teleporter.GetSubnetParams(app, network, subnetName, false)
+	_, _, subnetID, chainID, messengerAddress, registryAddress, _, err = teleporter.GetSubnetParams(app, network, subnetName, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/teleportercmd/relayercmd/logs.go
+++ b/cmd/teleportercmd/relayercmd/logs.go
@@ -198,13 +198,13 @@ func getBlockchainIDToSubnetNameMap(network models.Network) (map[string]string, 
 	}
 	blockchainIDToSubnetName := map[string]string{}
 	for _, subnetName := range subnetNames {
-		_, _, blockchainID, _, _, _, err := teleporter.GetSubnetParams(app, network, subnetName, false)
+		_, _, _, blockchainID, _, _, _, err := teleporter.GetSubnetParams(app, network, subnetName, false)
 		if err != nil {
 			return nil, err
 		}
 		blockchainIDToSubnetName[blockchainID.String()] = subnetName
 	}
-	_, _, blockchainID, _, _, _, err := teleporter.GetSubnetParams(app, network, "", true)
+	_, _, _, blockchainID, _, _, _, err := teleporter.GetSubnetParams(app, network, "", true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/contract/allocations.go
+++ b/pkg/contract/allocations.go
@@ -113,7 +113,7 @@ func GetEVMSubnetPrefundedKey(
 	isCChain bool,
 	blockchainID string,
 ) (string, string, error) {
-	genesisData, err := GetEVMSubnetGenesis(
+	genesisData, err := GetBlockchainGenesis(
 		app,
 		network,
 		subnetName,
@@ -122,6 +122,9 @@ func GetEVMSubnetPrefundedKey(
 	)
 	if err != nil {
 		return "", "", err
+	}
+	if !utils.ByteSliceIsSubnetEvmGenesis(genesisData) {
+		return "", "", fmt.Errorf("search for prefunded key is only supported on EVM based vms")
 	}
 	_, genesisAddress, genesisPrivateKey, err := GetSubnetAirdropKeyInfo(
 		app,
@@ -135,8 +138,8 @@ func GetEVMSubnetPrefundedKey(
 	return genesisAddress, genesisPrivateKey, nil
 }
 
-// get the deployed subnet genesis
-func GetEVMSubnetGenesis(
+// get the deployed blockchain genesis
+func GetBlockchainGenesis(
 	app *application.Avalanche,
 	network models.Network,
 	subnetName string,
@@ -181,9 +184,6 @@ func GetEVMSubnetGenesis(
 	if err != nil {
 		return nil, err
 	}
-	if !utils.ByteSliceIsSubnetEvmGenesis(createChainTx.GenesisData) {
-		return nil, fmt.Errorf("search for prefunded key is only supported on EVM based vms")
-	}
 	return createChainTx.GenesisData, err
 }
 
@@ -208,7 +208,7 @@ func GetEVMSubnetGenesisSupply(
 	isCChain bool,
 	blockchainID string,
 ) (*big.Int, error) {
-	genesisData, err := GetEVMSubnetGenesis(
+	genesisData, err := GetBlockchainGenesis(
 		app,
 		network,
 		subnetName,
@@ -216,7 +216,10 @@ func GetEVMSubnetGenesisSupply(
 		blockchainID,
 	)
 	if err != nil {
-		return new(big.Int), err
+		return nil, err
+	}
+	if !utils.ByteSliceIsSubnetEvmGenesis(genesisData) {
+		return nil, fmt.Errorf("genesis supply calculation is only supported on EVM based vms")
 	}
 	return sumGenesisSupply(genesisData)
 }
@@ -262,7 +265,7 @@ func GetEVMSubnetGenesisNativeMinterAdmin(
 	isCChain bool,
 	blockchainID string,
 ) (bool, bool, string, string, string, error) {
-	genesisData, err := GetEVMSubnetGenesis(
+	genesisData, err := GetBlockchainGenesis(
 		app,
 		network,
 		subnetName,
@@ -271,6 +274,9 @@ func GetEVMSubnetGenesisNativeMinterAdmin(
 	)
 	if err != nil {
 		return false, false, "", "", "", err
+	}
+	if !utils.ByteSliceIsSubnetEvmGenesis(genesisData) {
+		return false, false, "", "", "", fmt.Errorf("genesis native minter admin query is only supported on EVM based vms")
 	}
 	return getGenesisNativeMinterAdmin(app, network, genesisData)
 }

--- a/pkg/ictt/deploy.go
+++ b/pkg/ictt/deploy.go
@@ -82,6 +82,44 @@ func DeployERC20Remote(
 	)
 }
 
+func DeployNativeRemote(
+	srcDir string,
+	rpcURL string,
+	privateKey string,
+	teleporterRegistryAddress common.Address,
+	teleporterManagerAddress common.Address,
+	tokenHomeBlockchainID [32]byte,
+	tokenHomeAddress common.Address,
+	tokenDecimals uint8,
+	nativeAssetSymbol string,
+	initialReserveImbalance *big.Int,
+	burnedFeesReportingRewardPercentage *big.Int,
+) (common.Address, error) {
+	binPath := filepath.Join(srcDir, "contracts/out/NativeTokenRemote.sol/NativeTokenRemote.bin")
+	binBytes, err := os.ReadFile(binPath)
+	if err != nil {
+		return common.Address{}, err
+	}
+	tokenRemoteSettings := TokenRemoteSettings{
+		TeleporterRegistryAddress: teleporterRegistryAddress,
+		TeleporterManager:         teleporterManagerAddress,
+		TokenHomeBlockchainID:     tokenHomeBlockchainID,
+		TokenHomeAddress:          tokenHomeAddress,
+		// TODO: user case for home having diff decimals
+		TokenHomeDecimals: tokenDecimals,
+	}
+	return contract.DeployContract(
+		rpcURL,
+		privateKey,
+		binBytes,
+		"((address, address, bytes32, address, uint8), string, uint256, uint256)",
+		tokenRemoteSettings,
+		nativeAssetSymbol,
+		initialReserveImbalance,
+		burnedFeesReportingRewardPercentage,
+	)
+}
+
 func DeployERC20Home(
 	srcDir string,
 	rpcURL string,

--- a/pkg/ictt/operate.go
+++ b/pkg/ictt/operate.go
@@ -331,3 +331,71 @@ func TokenHomeAddCollateral(
 	)
 	return err
 }
+
+func Send(
+	rpcURL string,
+	address common.Address,
+	privateKey string,
+	destinationBlockchainID ids.ID,
+	destinationAddress common.Address,
+	amountRecipient common.Address,
+	amount *big.Int,
+) error {
+	endpointKind, err := GetEndpointKind(
+		rpcURL,
+		address,
+	)
+	if err != nil {
+		return err
+	}
+	switch endpointKind {
+	case ERC20TokenRemote:
+		return ERC20TokenRemoteSend(
+			rpcURL,
+			address,
+			privateKey,
+			destinationBlockchainID,
+			destinationAddress,
+			amountRecipient,
+			amount,
+		)
+	case ERC20TokenHome:
+		return ERC20TokenHomeSend(
+			rpcURL,
+			address,
+			privateKey,
+			destinationBlockchainID,
+			destinationAddress,
+			amountRecipient,
+			amount,
+		)
+	case NativeTokenHome:
+		return NativeTokenHomeSend(
+			rpcURL,
+			address,
+			privateKey,
+			destinationBlockchainID,
+			destinationAddress,
+			amountRecipient,
+			amount,
+		)
+	}
+	return fmt.Errorf("unknown ictt endpoint")
+}
+
+func EnableMinter(
+	rpcURL string,
+	privateKey string,
+	toEnableAddress common.Address,
+) error {
+	address := common.HexToAddress("0x0200000000000000000000000000000000000001")
+	_, _, err := contract.TxToMethod(
+		rpcURL,
+		privateKey,
+		address,
+		nil,
+		"setEnabled(address)",
+		toEnableAddress,
+	)
+	return err
+}

--- a/pkg/ictt/operate.go
+++ b/pkg/ictt/operate.go
@@ -533,20 +533,3 @@ func Send(
 	}
 	return fmt.Errorf("unknown ictt endpoint")
 }
-
-func EnableMinter(
-	rpcURL string,
-	privateKey string,
-	toEnableAddress common.Address,
-) error {
-	address := common.HexToAddress("0x0200000000000000000000000000000000000001")
-	_, _, err := contract.TxToMethod(
-		rpcURL,
-		privateKey,
-		address,
-		nil,
-		"setEnabled(address)",
-		toEnableAddress,
-	)
-	return err
-}

--- a/pkg/precompiles/allowlist.go
+++ b/pkg/precompiles/allowlist.go
@@ -1,0 +1,101 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+package precompiles
+
+import (
+	_ "embed"
+	"fmt"
+	"math/big"
+
+	"github.com/ava-labs/avalanche-cli/pkg/contract"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func SetAdmin(
+	rpcURL string,
+	precompile common.Address,
+	privateKey string,
+	toSet common.Address,
+) error {
+	_, _, err := contract.TxToMethod(
+		rpcURL,
+		privateKey,
+		precompile,
+		nil,
+		"setAdmin(address)",
+		toSet,
+	)
+	return err
+}
+
+func SetManager(
+	rpcURL string,
+	precompile common.Address,
+	privateKey string,
+	toSet common.Address,
+) error {
+	_, _, err := contract.TxToMethod(
+		rpcURL,
+		privateKey,
+		precompile,
+		nil,
+		"setManager(address)",
+		toSet,
+	)
+	return err
+}
+
+func SetEnabled(
+	rpcURL string,
+	precompile common.Address,
+	privateKey string,
+	toSet common.Address,
+) error {
+	_, _, err := contract.TxToMethod(
+		rpcURL,
+		privateKey,
+		precompile,
+		nil,
+		"setEnabled(address)",
+		toSet,
+	)
+	return err
+}
+
+func SetNone(
+	rpcURL string,
+	precompile common.Address,
+	privateKey string,
+	toSet common.Address,
+) error {
+	_, _, err := contract.TxToMethod(
+		rpcURL,
+		privateKey,
+		precompile,
+		nil,
+		"setNone(address)",
+		toSet,
+	)
+	return err
+}
+
+func ReadAllowList(
+	rpcURL string,
+	precompile common.Address,
+	toQuery common.Address,
+) (*big.Int, error) {
+	out, err := contract.CallToMethod(
+		rpcURL,
+		precompile,
+		"readAllowList(address)->(uint256)",
+		toQuery,
+	)
+	if err != nil {
+		return nil, err
+	}
+	role, b := out[0].(*big.Int)
+	if !b {
+		return nil, fmt.Errorf("error at readAllowList, expected *big.Int, got %T", out[0])
+	}
+	return role, nil
+}

--- a/pkg/precompiles/precompiles.go
+++ b/pkg/precompiles/precompiles.go
@@ -1,0 +1,13 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+package precompiles
+
+import (
+	_ "embed"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	NativeMinterPrecompile = common.HexToAddress("0x0200000000000000000000000000000000000001")
+)

--- a/pkg/precompiles/precompiles.go
+++ b/pkg/precompiles/precompiles.go
@@ -8,6 +8,4 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var (
-	NativeMinterPrecompile = common.HexToAddress("0x0200000000000000000000000000000000000001")
-)
+var NativeMinterPrecompile = common.HexToAddress("0x0200000000000000000000000000000000000001")


### PR DESCRIPTION
Closes https://github.com/ava-labs/avalanche-cli/issues/2029

Add flags:
- deploy-native-remote
- remove-minter-admin

It takes care of needed collateral from remote subnet genesis information, and
takes care of native minter setting also from remote subnet genesis information.

Demo video: https://youtu.be/xmeZ_9lQde8
