### PR TITLE
Allowlist: Add red x to error message

### DIFF
--- a/pkg/vm/allowlist.go
+++ b/pkg/vm/allowlist.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ava-labs/avalanche-cli/pkg/application"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
+	"github.com/ava-labs/avalanche-cli/pkg/ux"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ethereum/go-ethereum/common"
@@ -59,11 +60,11 @@ func getNewAddresses(
 	for _, address := range addresses {
 		switch {
 		case utils.Belongs(adminAddresses, address):
-			fmt.Println(address.Hex() + " is already allowed as admin role")
+			ux.Logger.RedXToUser(address.Hex() + " is already allowed as admin role")
 		case utils.Belongs(managerAddresses, address):
-			fmt.Println(address.Hex() + " is already allowed as manager role")
+			ux.Logger.RedXToUser(address.Hex() + " is already allowed as manager role")
 		case utils.Belongs(enabledAddresses, address):
-			fmt.Println(address.Hex() + " is already allowed as enabled role")
+			ux.Logger.RedXToUser(address.Hex() + " is already allowed as enabled role")
 		default:
 			newAddresses = append(newAddresses, address)
 		}


### PR DESCRIPTION
When user wants to add an address to the allowlist that already has a role, an error message is printed. This one is hard to see, so I suggest adding a red X to the message