### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
+
+* @ava-labs/tooling


### PR DESCRIPTION
First need to add @ava-labs/tooling to have write access on this repo. 

We can then replicate for any tooling related repos also.