### PR TITLE
use wss for fuji

### DIFF
--- a/cmd/nodecmd/wiz.go
+++ b/cmd/nodecmd/wiz.go
@@ -1021,6 +1021,7 @@ func addBlockchainToRelayerConf(network models.Network, cloudNodeID string, bloc
 		configPath,
 		logging.Info.LowerString(),
 		app.GetAWMRelayerServiceStorageDir(storageBasePath),
+		constants.RemoteAWMRelayerMetricsPort,
 		network,
 	); err != nil {
 		return err

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -261,7 +261,13 @@ const (
 	ICMKeyName        = "cli-teleporter-deployer"
 	AWMRelayerKeyName = "cli-awm-relayer"
 
-	AWMRelayerMetricsPort = 9091
+	// to not interfere with other node services
+	RemoteAWMRelayerMetricsPort = 9091
+
+	// enables having many local relayers
+	LocalNetworkLocalAWMRelayerMetricsPort = 9091
+	DevnetLocalAWMRelayerMetricsPort       = 9092
+	FujiLocalAWMRelayerMetricsPort         = 9093
 
 	SubnetEVMBin = "subnet-evm"
 

--- a/pkg/models/network.go
+++ b/pkg/models/network.go
@@ -123,7 +123,14 @@ func (n Network) BlockchainWSEndpoint(blockchainID string) string {
 	trimmedURI := n.Endpoint
 	trimmedURI = strings.TrimPrefix(trimmedURI, "http://")
 	trimmedURI = strings.TrimPrefix(trimmedURI, "https://")
-	return fmt.Sprintf("ws://%s/ext/bc/%s/ws", trimmedURI, blockchainID)
+	scheme := "ws"
+	switch n.Kind {
+	case Fuji:
+		scheme = "wss"
+	case Mainnet:
+		scheme = "wss"
+	}
+	return fmt.Sprintf("%s://%s/ext/bc/%s/ws", scheme, trimmedURI, blockchainID)
 }
 
 func (n Network) NetworkIDFlagValue() string {

--- a/pkg/subnet/local.go
+++ b/pkg/subnet/local.go
@@ -364,6 +364,7 @@ func (d *LocalDeployer) doDeploy(chain string, genesisPath string, icmSpec ICMSp
 			relayerConfigPath,
 			logging.Info.LowerString(),
 			d.app.GetLocalRelayerStorageDir(models.Local),
+			constants.LocalNetworkLocalAWMRelayerMetricsPort,
 			network,
 		); err != nil {
 			return nil, err
@@ -508,6 +509,10 @@ func (d *LocalDeployer) doDeploy(chain string, genesisPath string, icmSpec ICMSp
 				d.app.GetLocalRelayerRunPath(models.Local),
 				d.app.GetLocalRelayerStorageDir(models.Local),
 			); err != nil {
+				logPath := d.app.GetLocalRelayerLogPath(models.Local)
+				if bs, err := os.ReadFile(logPath); err == nil {
+					ux.Logger.PrintToUser(string(bs))
+				}
 				return nil, err
 			}
 		}

--- a/pkg/teleporter/relayer.go
+++ b/pkg/teleporter/relayer.go
@@ -324,6 +324,7 @@ func CreateBaseRelayerConfigIfMissing(
 	relayerConfigPath string,
 	logLevel string,
 	storageLocation string,
+	metricsPort uint16,
 	network models.Network,
 ) error {
 	if !utils.FileExists(relayerConfigPath) {
@@ -331,6 +332,7 @@ func CreateBaseRelayerConfigIfMissing(
 			relayerConfigPath,
 			logLevel,
 			storageLocation,
+			metricsPort,
 			network,
 		)
 	}
@@ -341,6 +343,7 @@ func CreateBaseRelayerConfig(
 	relayerConfigPath string,
 	logLevel string,
 	storageLocation string,
+	metricsPort uint16,
 	network models.Network,
 ) error {
 	awmRelayerConfig := &config.Config{
@@ -357,7 +360,7 @@ func CreateBaseRelayerConfig(
 		ProcessMissedBlocks:    false,
 		SourceBlockchains:      []*config.SourceBlockchain{},
 		DestinationBlockchains: []*config.DestinationBlockchain{},
-		MetricsPort:            constants.AWMRelayerMetricsPort,
+		MetricsPort:            metricsPort,
 	}
 	return saveRelayerConfig(awmRelayerConfig, relayerConfigPath)
 }


### PR DESCRIPTION
- fix fuji c-chain ws endpoints by using wss schema
- disable (for the moment) the prompt for remote relayers
- sets different metrics ports for different (possible) local relayers
- show relayer logs in case of local network blockchain deploy relayer error
