### PR TITLE
Enable devnet key spec

### DIFF
--- a/cmd/nodecmd/wiz.go
+++ b/cmd/nodecmd/wiz.go
@@ -286,6 +286,7 @@ func wiz(cmd *cobra.Command, args []string) error {
 	ux.Logger.PrintToUser(logging.Green.Wrap("Adding nodes as subnet validators"))
 	ux.Logger.PrintToUser("")
 	avoidSubnetValidationChecks = true
+	useEwoq = true
 	if err := validateSubnet(cmd, []string{clusterName, subnetName}); err != nil {
 		return err
 	}

--- a/pkg/keychain/keychain.go
+++ b/pkg/keychain/keychain.go
@@ -136,10 +136,13 @@ func GetKeychainFromCmdLineFlags(
 			}
 		}
 	case network.Kind == models.Devnet:
-		// going to just use ewoq atm
-		useEwoq = true
-		if keyName != "" || useLedger {
-			return nil, ErrNonEwoqKeyOnDevnet
+		// prompt the user if no key source was provided
+		if !useEwoq && !useLedger && keyName == "" {
+			var err error
+			useLedger, keyName, err = prompts.GetKeyOrLedger(app.Prompt, keychainGoal, app.GetKeyDir(), true)
+			if err != nil {
+				return nil, err
+			}
 		}
 	case network.Kind == models.Fuji:
 		if useEwoq {


### PR DESCRIPTION
adds the possibility to use a key other than ewoq for devnets