### PR TITLE
  imds_support  = "v2.0"

### DIFF
--- a/.github/packer/aws-ubuntu-docker.pkr.hcl
+++ b/.github/packer/aws-ubuntu-docker.pkr.hcl
@@ -36,6 +36,7 @@ source "amazon-ebs" "ubuntu_amd64" {
   ami_description = "Avalanche-CLI Ubuntu 20.04 Docker"
   instance_type = "t3.xlarge"
   region        = "us-east-1"
+  imds_support  = "v2.0"
   source_ami_filter {
     filters = {
       name                = "ubuntu/images/*ubuntu-focal-20.04-amd64-server-*"
@@ -64,6 +65,7 @@ source "amazon-ebs" "ubuntu_arm64" {
   ami_description = "Avalanche-CLI Ubuntu 20.04 Docker"
   instance_type = "t4g.xlarge"  # Adjust the instance type for arm64
   region        = "us-east-1"
+  imds_support  = "v2.0"
   source_ami_filter {
     filters = {
       name                = "ubuntu/images/*ubuntu-focal-20.04-arm64-server-*"  # Filter for arm64 AMIs


### PR DESCRIPTION
## Why this should be merged
fixes current issue with AMIs as per security team suggestion
## How this works
it's makes `packer` to use  imds v2 and not legacy
## How this was tested
n/a
## How is this documented
n/a