### PR TITLE
fix awm relayer crash for wiz

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/ava-labs/avalanche-cli
 
-go 1.21.12
-toolchain go1.22.5
+go 1.22
+
+toolchain go1.22.6
 
 require (
 	github.com/ava-labs/apm v1.0.0

--- a/pkg/teleporter/relayer.go
+++ b/pkg/teleporter/relayer.go
@@ -29,9 +29,11 @@ import (
 )
 
 const (
-	localRelayerSetupTime     = 2 * time.Second
-	localRelayerCheckPoolTime = 100 * time.Millisecond
-	localRelayerCheckTimeout  = 3 * time.Second
+	localRelayerSetupTime            = 2 * time.Second
+	localRelayerCheckPoolTime        = 100 * time.Millisecond
+	localRelayerCheckTimeout         = 3 * time.Second
+	AWMRElayerDBWriteIntervalSeconds = 10
+	AWMRelayerSignatureCacheSize     = 1024
 )
 
 var teleporterRelayerRequiredBalance = big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(500)) // 500 AVAX
@@ -356,11 +358,13 @@ func CreateBaseRelayerConfig(
 			BaseURL:     network.Endpoint,
 			QueryParams: map[string]string{},
 		},
+		DBWriteIntervalSeconds: AWMRElayerDBWriteIntervalSeconds,
 		StorageLocation:        storageLocation,
 		ProcessMissedBlocks:    false,
 		SourceBlockchains:      []*config.SourceBlockchain{},
 		DestinationBlockchains: []*config.DestinationBlockchain{},
 		MetricsPort:            metricsPort,
+		SignatureCacheSize:     AWMRelayerSignatureCacheSize,
 	}
 	return saveRelayerConfig(awmRelayerConfig, relayerConfigPath)
 }


### PR DESCRIPTION
## Why this should be merged
fixed container crash for awm-relayer 
fixes crashes
```
goroutine 1 [running]:
main.main()
        /home/runner/work/awm-relayer/awm-relayer/relayer/main/main.go:79 +0x2436
panic: couldn't build config: failed to validate configuration: db-write-interval-seconds must be between 1 and 600
```
and
```
{"level":"info","timestamp":"2024-09-27T02:31:49.166Z","logger":"awm-relayer","caller":"main/main.go:550","msg":"starting metrics server...","port":9091}
{"level":"fatal","timestamp":"2024-09-27T02:31:49.166Z","logger":"awm-relayer","caller":"main/main.go:232","msg":"Failed to create signature aggregator","error":"failed to create signature cache: must provide a positive size"}
panic: failed to create signature cache: must provide a positive size
```
## How this works
adds configuration required as default values causes app crash
## How this was tested
```
./scripts/build.sh && ./bin/avalanche subnet delete r1;  ./bin/avalanche node destroy r1 -y ; ./bin/avalanche node devnet wiz r1 r1 --num-validators=1 --num-apis=1  --region us-east-1 --aws --node-type default  --use-static-ip=false  --enable-monitoring=false
```

## How is this documented
