### PR TITLE
fix: add icm addr to given genesis

### DIFF
--- a/cmd/blockchaincmd/create.go
+++ b/cmd/blockchaincmd/create.go
@@ -50,7 +50,7 @@ type CreateFlags struct {
 var (
 	createFlags CreateFlags
 	forceCreate bool
-	genesisFile string
+	genesisPath string
 	vmFile      string
 	useRepo     bool
 
@@ -80,7 +80,7 @@ configuration, pass the -f flag.`,
 		RunE:              createBlockchainConfig,
 		PersistentPostRun: handlePostRun,
 	}
-	cmd.Flags().StringVar(&genesisFile, "genesis", "", "file path of genesis to use")
+	cmd.Flags().StringVar(&genesisPath, "genesis", "", "file path of genesis to use")
 	cmd.Flags().BoolVar(&createFlags.useSubnetEvm, "evm", false, "use the Subnet-EVM as the base template")
 	cmd.Flags().BoolVar(&createFlags.useCustomVM, "custom", false, "use a custom VM template")
 	cmd.Flags().StringVar(&createFlags.vmVersion, "vm-version", "", "version of Subnet-EVM template to use")
@@ -108,7 +108,7 @@ func CallCreate(
 	cmd *cobra.Command,
 	blockchainName string,
 	forceCreateParam bool,
-	genesisFileParam string,
+	genesisPathParam string,
 	useSubnetEvmParam bool,
 	useCustomParam bool,
 	vmVersionParam string,
@@ -123,7 +123,7 @@ func CallCreate(
 	customVMBuildScriptParam string,
 ) error {
 	forceCreate = forceCreateParam
-	genesisFile = genesisFileParam
+	genesisPath = genesisPathParam
 	createFlags.useSubnetEvm = useSubnetEvmParam
 	createFlags.vmVersion = vmVersionParam
 	createFlags.chainID = evmChainIDParam
@@ -171,7 +171,7 @@ func createBlockchainConfig(cmd *cobra.Command, args []string) error {
 	}
 
 	// genesis flags exclusiveness
-	if genesisFile != "" && (createFlags.chainID != 0 || defaultsKind != vm.NoDefaults) {
+	if genesisPath != "" && (createFlags.chainID != 0 || defaultsKind != vm.NoDefaults) {
 		return errMutuallyExclusiveVMConfigOptions
 	}
 
@@ -212,7 +212,7 @@ func createBlockchainConfig(cmd *cobra.Command, args []string) error {
 	}
 
 	if vmType == models.SubnetEvm {
-		if genesisFile == "" {
+		if genesisPath == "" {
 			// Default
 			defaultsKind, err = vm.PromptDefaults(app, defaultsKind)
 			if err != nil {
@@ -238,8 +238,8 @@ func createBlockchainConfig(cmd *cobra.Command, args []string) error {
 
 		var tokenSymbol string
 
-		if genesisFile != "" {
-			if evmCompatibleGenesis, err := utils.FileIsSubnetEVMGenesis(genesisFile); err != nil {
+		if genesisPath != "" {
+			if evmCompatibleGenesis, err := utils.FileIsSubnetEVMGenesis(genesisPath); err != nil {
 				return err
 			} else if !evmCompatibleGenesis {
 				return fmt.Errorf("the provided genesis file has no proper Subnet-EVM format")
@@ -253,7 +253,7 @@ func createBlockchainConfig(cmd *cobra.Command, args []string) error {
 				return err
 			}
 			ux.Logger.PrintToUser("importing genesis for blockchain %s", blockchainName)
-			genesisBytes, err = os.ReadFile(genesisFile)
+			genesisBytes, err = os.ReadFile(genesisPath)
 			if err != nil {
 				return err
 			}
@@ -295,7 +295,7 @@ func createBlockchainConfig(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	} else {
-		genesisBytes, err = vm.LoadCustomGenesis(app, genesisFile)
+		genesisPath, genesisBytes, err = vm.LoadCustomGenesis(app, genesisPath)
 		if err != nil {
 			return err
 		}
@@ -331,12 +331,16 @@ func createBlockchainConfig(cmd *cobra.Command, args []string) error {
 		sc.ExternalToken = useExternalGasToken
 		sc.TeleporterKey = constants.ICMKeyName
 		sc.TeleporterVersion = teleporterInfo.Version
-		if genesisFile != "" {
-			if evmCompatibleGenesis, err := utils.FileIsSubnetEVMGenesis(genesisFile); err != nil {
+		if genesisPath != "" {
+			if evmCompatibleGenesis, err := utils.FileIsSubnetEVMGenesis(genesisPath); err != nil {
 				return err
-			} else if !evmCompatibleGenesis {
+			} else if evmCompatibleGenesis {
 				// evm genesis file was given. make appropriate checks and customizations for teleporter
-				genesisBytes, err = addSubnetEVMGenesisPrefundedAddress(genesisBytes, teleporterInfo.FundedAddress, teleporterInfo.FundedBalance.String())
+				genesisBytes, err = addSubnetEVMGenesisPrefundedAddress(
+					genesisBytes,
+					teleporterInfo.FundedAddress,
+					teleporterInfo.FundedBalance.String(),
+				)
 				if err != nil {
 					return err
 				}

--- a/cmd/blockchaincmd/create.go
+++ b/cmd/blockchaincmd/create.go
@@ -295,7 +295,13 @@ func createBlockchainConfig(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	} else {
-		genesisPath, genesisBytes, err = vm.LoadCustomGenesis(app, genesisPath)
+		if genesisPath == "" {
+			genesisPath, err = app.Prompt.CaptureExistingFilepath("Enter path to custom genesis")
+			if err != nil {
+				return err
+			}
+		}
+		genesisBytes, err = os.ReadFile(genesisPath)
 		if err != nil {
 			return err
 		}

--- a/cmd/blockchaincmd/export_test.go
+++ b/cmd/blockchaincmd/export_test.go
@@ -35,10 +35,7 @@ func TestExportImportSubnet(t *testing.T) {
 
 	app.Setup(testDir, logging.NoLog{}, nil, prompts.NewPrompter(), &mockAppDownloader)
 	ux.NewUserLog(logging.NoLog{}, io.Discard)
-	_, genBytes, err := vm.LoadCustomGenesis(
-		app,
-		"../../"+utils.SubnetEvmGenesisPath,
-	)
+	genBytes, err := os.ReadFile("../../" + utils.SubnetEvmGenesisPath)
 	require.NoError(err)
 	sc, err := vm.CreateEvmSidecar(
 		app,

--- a/cmd/blockchaincmd/export_test.go
+++ b/cmd/blockchaincmd/export_test.go
@@ -35,7 +35,7 @@ func TestExportImportSubnet(t *testing.T) {
 
 	app.Setup(testDir, logging.NoLog{}, nil, prompts.NewPrompter(), &mockAppDownloader)
 	ux.NewUserLog(logging.NoLog{}, io.Discard)
-	genBytes, err := vm.LoadCustomGenesis(
+	_, genBytes, err := vm.LoadCustomGenesis(
 		app,
 		"../../"+utils.SubnetEvmGenesisPath,
 	)

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/ava-labs/avalanche-cli
 
-go 1.21.12
-toolchain go1.22.5
+go 1.22.7
 
 require (
 	github.com/ava-labs/apm v1.0.0

--- a/pkg/vm/create_custom.go
+++ b/pkg/vm/create_custom.go
@@ -83,17 +83,16 @@ func CreateCustomSidecar(
 	return sc, nil
 }
 
-func LoadCustomGenesis(app *application.Avalanche, genesisPath string) ([]byte, error) {
+func LoadCustomGenesis(app *application.Avalanche, genesisPath string) (string, []byte, error) {
 	var err error
 	if genesisPath == "" {
 		genesisPath, err = app.Prompt.CaptureExistingFilepath("Enter path to custom genesis")
 		if err != nil {
-			return nil, err
+			return "", nil, err
 		}
 	}
-
 	genesisBytes, err := os.ReadFile(genesisPath)
-	return genesisBytes, err
+	return genesisPath, genesisBytes, err
 }
 
 func SetCustomVMSourceCodeFields(app *application.Avalanche, sc *models.Sidecar, customVMRepoURL string, customVMBranch string, customVMBuildScript string) error {

--- a/pkg/vm/create_custom.go
+++ b/pkg/vm/create_custom.go
@@ -83,18 +83,6 @@ func CreateCustomSidecar(
 	return sc, nil
 }
 
-func LoadCustomGenesis(app *application.Avalanche, genesisPath string) (string, []byte, error) {
-	var err error
-	if genesisPath == "" {
-		genesisPath, err = app.Prompt.CaptureExistingFilepath("Enter path to custom genesis")
-		if err != nil {
-			return "", nil, err
-		}
-	}
-	genesisBytes, err := os.ReadFile(genesisPath)
-	return genesisPath, genesisBytes, err
-}
-
 func SetCustomVMSourceCodeFields(app *application.Avalanche, sc *models.Sidecar, customVMRepoURL string, customVMBranch string, customVMBuildScript string) error {
 	var err error
 	if customVMRepoURL != "" {


### PR DESCRIPTION
## Why this should be merged

Closes https://github.com/ava-labs/avalanche-cli/issues/2199

For a Custom VM based on Subnet-evm, or for a Subnet-Evm with a user-provided genesis,
there is no automatic allocation of funds into the standard icm deployer address, so
local blockchain deploy fails.

## How this works
It fix the logic that checks if a genesis was given (either Custom or Subnet-EVM), and if it was given
as is indeed Subnet-EVM compatible, adds the allocation.

## How this was tested
Blockchains conf where created for a given genesis, either by prompt or flag, to custom vm or subnet-evm.
Verifying local deploy works.

## How is this documented
