### PR TITLE
golang bump to v1.22.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/ava-labs/avalanche-cli
 
-go 1.21.12
-toolchain go1.22.5
+go 1.22.7
 
 require (
 	github.com/ava-labs/apm v1.0.0


### PR DESCRIPTION
## Why this should be merged
A golang bump is needed to be compatible with awm-relayer libraries.
Also, a dependabot dep already bumped a toolchain, which is forcing automatic 
conversion of go.mod each time a compilation is made.

## How this works
Modifies go.mod. It removes the toolchain req. It bumps go version.

## How this was tested

## How is this documented
