### PR TITLE
Evm debug config

### DIFF
--- a/cmd/blockchaincmd/configure.go
+++ b/cmd/blockchaincmd/configure.go
@@ -113,8 +113,8 @@ func configure(_ *cobra.Command, args []string) error {
 	}
 
 	// load each provided file
-	for filename, configPath := range configsToLoad {
-		if err = updateConf(blockchainName, configPath, filename); err != nil {
+	for filename, path := range configsToLoad {
+		if err = copyBlockchainConf(blockchainName, path, filename); err != nil {
 			return err
 		}
 	}
@@ -122,12 +122,12 @@ func configure(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func updateConf(subnet, path, filename string) error {
+func copyBlockchainConf(blockchainName, path, configFilename string) error {
 	var (
 		fileBytes []byte
 		err       error
 	)
-	if strings.ToLower(filepath.Ext(filename)) == "json" {
+	if strings.ToLower(filepath.Ext(configFilename)) == "json" {
 		fileBytes, err = utils.ValidateJSON(path)
 		if err != nil {
 			return err
@@ -138,16 +138,23 @@ func updateConf(subnet, path, filename string) error {
 			return err
 		}
 	}
-	subnetDir := filepath.Join(app.GetSubnetDir(), subnet)
-	if err := os.MkdirAll(subnetDir, constants.DefaultPerms755); err != nil {
+	return SetBlockchainConf(blockchainName, fileBytes, configFilename)
+}
+
+func SetBlockchainConf(
+	blockchainName string,
+	fileBytes []byte,
+	configFilename string,
+) error {
+	blockchainDir := filepath.Join(app.GetSubnetDir(), blockchainName)
+	if err := os.MkdirAll(blockchainDir, constants.DefaultPerms755); err != nil {
 		return err
 	}
-	fileName := filepath.Join(subnetDir, filename)
+	fileName := filepath.Join(blockchainDir, configFilename)
 	_ = os.RemoveAll(fileName)
 	if err := os.WriteFile(fileName, fileBytes, constants.WriteReadReadPerms); err != nil {
 		return err
 	}
 	ux.Logger.PrintToUser("File %s successfully written", fileName)
-
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/ava-labs/avalanche-cli
 
-go 1.21.12
-toolchain go1.22.5
+go 1.22
+
+toolchain go1.22.7
 
 require (
 	github.com/ava-labs/apm v1.0.0

--- a/pkg/vm/evm_debug_config.json
+++ b/pkg/vm/evm_debug_config.json
@@ -1,0 +1,21 @@
+{
+  "log-level": "debug",
+  "warp-api-enabled": true,
+  "eth-apis": [
+    "eth",
+    "eth-filter",
+    "net",
+    "admin",
+    "web3",
+    "internal-eth",
+    "internal-blockchain",
+    "internal-transaction",
+    "internal-debug",
+    "internal-account",
+    "internal-personal",
+    "debug",
+    "debug-tracer",
+    "debug-file-tracer",
+    "debug-handler"
+  ]
+}

--- a/pkg/vm/evm_settings.go
+++ b/pkg/vm/evm_settings.go
@@ -4,10 +4,14 @@
 package vm
 
 import (
+	_ "embed"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 )
+
+//go:embed evm_debug_config.json
+var EvmDebugConfig []byte
 
 var (
 	// current avacloud settings


### PR DESCRIPTION
## Why this should be merged
Users seems to need an easy way to setup subnet evm blockchains, so as evm traces can be obtained.
This PR is adding a flag `--debug` to `blockchain create` that will configure the blockchain for that.
The PR is not trying to make it default, even for developing, but that can be done depending on
PR review comments.
Closes https://github.com/ava-labs/avalanche-cli/issues/1616

## How this works
It adds a --debug flag to blockchain create. When used, it automatically generates a blockchain conf that enables
debugging.

## How this was tested
A blockchain was started on local machine with the given conf, and trace call was made on a tx.

## How is this documented
