### PR TITLE
nits on `avalanche key transfer` command - merge to main

### DIFF
--- a/cmd/keycmd/transfer.go
+++ b/cmd/keycmd/transfer.go
@@ -426,9 +426,9 @@ func transferF(*cobra.Command, []string) error {
 		var useLedger bool
 		goalStr := ""
 		if send {
-			goalStr = " for the sender address"
+			goalStr = "as the sender address"
 		} else {
-			goalStr = " for the destination address"
+			goalStr = "as the destination address"
 		}
 		useLedger, keyName, err = prompts.GetKeyOrLedger(app.Prompt, goalStr, app.GetKeyDir(), true)
 		if err != nil {

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -758,7 +758,7 @@ func (prompter *realPrompter) ChooseKeyOrLedger(goal string) (bool, error) {
 		ledgerOption = "Use ledger"
 	)
 	option, err := prompter.CaptureList(
-		fmt.Sprintf("Which key source should be used to %s?", goal),
+		fmt.Sprintf("Which key should be used %s?", goal),
 		[]string{keyOption, ledgerOption},
 	)
 	if err != nil {
@@ -871,7 +871,7 @@ func CaptureKeyName(prompt Prompter, goal string, keyDir string, includeEwoq boo
 	if size > 10 {
 		size = 10
 	}
-	keyName, err := prompt.CaptureListWithSize(fmt.Sprintf("Which stored key should be used to %s?", goal), keyNames, size)
+	keyName, err := prompt.CaptureListWithSize(fmt.Sprintf("Which stored key should be used %s?", goal), keyNames, size)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Previously https://github.com/ava-labs/avalanche-cli/pull/2225

## Why this should be merged

When prompted for the sender address, the user currently sees this improper prompt:

```zsh
? Which key source should be used to  for the sender address?:
  ▸ Use stored key
    Use ledger
```

## How this works

Changes the phrasing and corrects spacing so that the user sees:

```zsh
? Which key should be used as the sender address?:
  ▸ Use stored key
    Use ledger
```

## How this was tested

`avalanche key transfer`

## How is this documented

~I am currently writing a doc on how to use this command: https://github.com/ava-labs/avalanche-docs/pull/1910`
I wrote a doc on how to use this command: https://docs.avax.network/tooling/transactions/native-send