### PR TITLE
ICTT Deployment Fixes

### DIFF
--- a/cmd/keycmd/list.go
+++ b/cmd/keycmd/list.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ava-labs/coreth/ethclient"
 	"github.com/ethereum/go-ethereum/common"
 	goethereumethclient "github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/liyue201/erc20-go/erc20"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
@@ -566,15 +565,22 @@ func getEvmBasedChainAddrInfo(
 				continue
 			}
 
-			log.Info("Getting balance for token", "token", tokenSymbol, "address", tokenAddress)
+			// Get the raw balance for the given token.
 			balance, err := token.BalanceOf(nil, common.HexToAddress(cChainAddr))
 			if err != nil {
 				return addressInfos, err
 			}
-			formattedBalance, err := formatCChainBalance(balance)
+
+			// Get the decimal count for the token to format the balance.
+			// Note: decimals() is not officially part of the IERC20 interface, but is a common extension.
+			decimals, err := token.Decimals(nil)
 			if err != nil {
 				return addressInfos, err
 			}
+
+			// Format the balance to a human-readable string.
+			formattedBalance := utils.FormatAmount(balance, decimals)
+
 			info := addressInfo{
 				kind:    kind,
 				name:    name,

--- a/cmd/keycmd/list.go
+++ b/cmd/keycmd/list.go
@@ -566,7 +566,7 @@ func getEvmBasedChainAddrInfo(
 				continue
 			}
 
-			log.Info("Getting balance for token", "token", tokenSymbol, "address", tokenAddress, "url", cGethClient.URL)
+			log.Info("Getting balance for token", "token", tokenSymbol, "address", tokenAddress)
 			balance, err := token.BalanceOf(nil, common.HexToAddress(cChainAddr))
 			if err != nil {
 				return addressInfos, err

--- a/cmd/keycmd/list.go
+++ b/cmd/keycmd/list.go
@@ -579,7 +579,12 @@ func getEvmBasedChainAddrInfo(
 			}
 
 			// Format the balance to a human-readable string.
-			formattedBalance := utils.FormatAmount(balance, decimals)
+			var formattedBalance string
+			if useGwei {
+				formattedBalance = fmt.Sprintf("%d", balance)
+			} else {
+				formattedBalance = utils.FormatAmount(balance, decimals)
+			}
 
 			info := addressInfo{
 				kind:    kind,

--- a/pkg/ictt/deploy.go
+++ b/pkg/ictt/deploy.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ava-labs/avalanche-cli/pkg/contract"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
+	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -26,11 +27,12 @@ type TokenRemoteSettings struct {
 	TokenHomeDecimals         uint8
 }
 
-func RegisterERC20Remote(
+func RegisterRemote(
 	rpcURL string,
 	privateKey string,
 	remoteAddress common.Address,
 ) error {
+	ux.Logger.PrintToUser("Registering remote contract with home contract")
 	feeInfo := TeleporterFeeInfo{
 		Amount: big.NewInt(0),
 	}

--- a/pkg/ictt/operate.go
+++ b/pkg/ictt/operate.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 
 	"github.com/ava-labs/avalanche-cli/pkg/contract"
+	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -458,6 +459,7 @@ func TokenHomeAddCollateral(
 	remoteAddress common.Address,
 	amount *big.Int,
 ) error {
+	ux.Logger.PrintToUser("Collateralizing remote contract on the home chain")
 	endpointKind, err := GetEndpointKind(
 		rpcURL,
 		homeAddress,


### PR DESCRIPTION
## Why this should be merged
- Fixes a bug where `homeKey` was left uninitialized prior to use when using an existing `TokenHome` contract and deploying a new `NativeTokenRemote`
- Fixes a bug in balance displays for ERC20 tokens with a decimal count other than 18
- Fixes a bug where the collateral provided to a `TokenHome` contract was previously in the remote denomination. Now it uses the correct amount in the home denomination, as reported by the home contract.
- Adds additional logging

## How this works
- ERC20 balances are now displayed using their specific `decimals()` count if `useGwei` is false.
- The amount of collateral to be added is fetched from the token home rather than using the remote supply.
- Always prompts for the key to use on the home chain for deployment or collateralization.

## How this was tested
Going through the flow of running `avalanche ictt deploy --deploy-native-remote` for a Fuji L1, and deploying a `NativeTokenRemote` connected to the existing USDC `TokenHome` contract on the C-Chain

## How is this documented
N/A
