### PR TITLE
add checks for local cluster. minor refactor

### DIFF
--- a/cmd/nodecmd/add_dashboard.go
+++ b/cmd/nodecmd/add_dashboard.go
@@ -33,7 +33,7 @@ func addDashboard(_ *cobra.Command, args []string) error {
 		return err
 	}
 	if clusterConfig.Local {
-		return notImplementedForLocal(clusterName, "addDashboard")
+		return notImplementedForLocal("addDashboard")
 	}
 	if customGrafanaDashboardPath != "" {
 		if err := addCustomDashboard(clusterName, blockchainName); err != nil {

--- a/cmd/nodecmd/add_dashboard.go
+++ b/cmd/nodecmd/add_dashboard.go
@@ -28,6 +28,13 @@ cluster.`,
 
 func addDashboard(_ *cobra.Command, args []string) error {
 	clusterName := args[0]
+	clusterConfig, err := app.GetClusterConfig(clusterName)
+	if err != nil {
+		return err
+	}
+	if clusterConfig.Local {
+		return notImplementedForLocal(clusterName, "addDashboard")
+	}
 	if customGrafanaDashboardPath != "" {
 		if err := addCustomDashboard(clusterName, blockchainName); err != nil {
 			return err

--- a/cmd/nodecmd/create.go
+++ b/cmd/nodecmd/create.go
@@ -833,28 +833,22 @@ func saveExternalHostConfig(externalHostConfig models.RegionConfig, hostRegion, 
 }
 
 func getExistingMonitoringInstance(clusterName string) (string, error) {
-	if app.ClustersConfigExists() {
-		clustersConfig, err := app.LoadClustersConfig()
-		if err != nil {
-			return "", err
-		}
-		if _, ok := clustersConfig.Clusters[clusterName]; ok {
-			if clustersConfig.Clusters[clusterName].MonitoringInstance != "" {
-				return clustersConfig.Clusters[clusterName].MonitoringInstance, nil
-			}
+	clustersConfig, err := app.GetClustersConfig()
+	if err != nil {
+		return "", err
+	}
+	if _, ok := clustersConfig.Clusters[clusterName]; ok {
+		if clustersConfig.Clusters[clusterName].MonitoringInstance != "" {
+			return clustersConfig.Clusters[clusterName].MonitoringInstance, nil
 		}
 	}
 	return "", nil
 }
 
 func updateKeyPairClustersConfig(cloudConfig models.NodeConfig) error {
-	clustersConfig := models.ClustersConfig{}
-	var err error
-	if app.ClustersConfigExists() {
-		clustersConfig, err = app.LoadClustersConfig()
-		if err != nil {
-			return err
-		}
+	clustersConfig, err := app.GetClustersConfig()
+	if err != nil {
+		return err
 	}
 	if clustersConfig.KeyPair == nil {
 		clustersConfig.KeyPair = make(map[string]string)
@@ -887,13 +881,9 @@ func getNodeCloudConfig(node string) (models.RegionConfig, string, error) {
 }
 
 func addNodeToClustersConfig(network models.Network, nodeID, clusterName string, isAPIInstance bool, isExternalHost bool, nodeRole, loadTestName string) error {
-	clustersConfig := models.ClustersConfig{}
-	if app.ClustersConfigExists() {
-		var err error
-		clustersConfig, err = app.LoadClustersConfig()
-		if err != nil {
-			return err
-		}
+	clustersConfig, err := app.GetClustersConfig()
+	if err != nil {
+		return err
 	}
 	if clustersConfig.Clusters == nil {
 		clustersConfig.Clusters = make(map[string]models.ClusterConfig)

--- a/cmd/nodecmd/create.go
+++ b/cmd/nodecmd/create.go
@@ -199,7 +199,14 @@ func preCreateChecks(clusterName string) error {
 	if err := failForExternal(clusterName); err != nil {
 		return err
 	}
-
+	// check for local
+	clusterConfig, err := app.GetClusterConfig(clusterName)
+	if err != nil {
+		return err
+	}
+	if clusterConfig.Local {
+		return notImplementedForLocal("addDashboard")
+	}
 	return nil
 }
 
@@ -833,14 +840,13 @@ func saveExternalHostConfig(externalHostConfig models.RegionConfig, hostRegion, 
 }
 
 func getExistingMonitoringInstance(clusterName string) (string, error) {
-	clustersConfig, err := app.GetClustersConfig()
+	// check for local
+	clusterConfig, err := app.GetClusterConfig(clusterName)
 	if err != nil {
 		return "", err
 	}
-	if _, ok := clustersConfig.Clusters[clusterName]; ok {
-		if clustersConfig.Clusters[clusterName].MonitoringInstance != "" {
-			return clustersConfig.Clusters[clusterName].MonitoringInstance, nil
-		}
+	if clusterConfig.MonitoringInstance != "" {
+		return clusterConfig.MonitoringInstance, nil
 	}
 	return "", nil
 }

--- a/cmd/nodecmd/create_gcp.go
+++ b/cmd/nodecmd/create_gcp.go
@@ -53,16 +53,13 @@ func getGCPCloudCredentials() (*compute.Service, string, string, error) {
 	var err error
 	var gcpCredentialsPath string
 	var gcpProjectName string
-	clustersConfig := models.ClustersConfig{}
-	if app.ClustersConfigExists() {
-		clustersConfig, err = app.LoadClustersConfig()
-		if err != nil {
-			return nil, "", "", err
-		}
-		if clustersConfig.GCPConfig != (models.GCPConfig{}) {
-			gcpProjectName = clustersConfig.GCPConfig.ProjectName
-			gcpCredentialsPath = clustersConfig.GCPConfig.ServiceAccFilePath
-		}
+	clustersConfig, err := app.GetClustersConfig()
+	if err != nil {
+		return nil, "", "", err
+	}
+	if clustersConfig.GCPConfig != (models.GCPConfig{}) {
+		gcpProjectName = clustersConfig.GCPConfig.ProjectName
+		gcpCredentialsPath = clustersConfig.GCPConfig.ServiceAccFilePath
 	}
 	if gcpProjectName == "" {
 		if cmdLineGCPProjectName != "" {
@@ -380,13 +377,9 @@ func createGCPInstance(
 }
 
 func updateClustersConfigGCPKeyFilepath(projectName, serviceAccountKeyFilepath string) error {
-	clustersConfig := models.ClustersConfig{}
-	var err error
-	if app.ClustersConfigExists() {
-		clustersConfig, err = app.LoadClustersConfig()
-		if err != nil {
-			return err
-		}
+	clustersConfig, err := app.GetClustersConfig()
+	if err != nil {
+		return err
 	}
 	if projectName != "" {
 		clustersConfig.GCPConfig.ProjectName = projectName

--- a/cmd/nodecmd/deploy.go
+++ b/cmd/nodecmd/deploy.go
@@ -47,11 +47,14 @@ func deploySubnet(cmd *cobra.Command, args []string) error {
 	if _, err := blockchaincmd.ValidateSubnetNameAndGetChains([]string{subnetName}); err != nil {
 		return err
 	}
-	clustersConfig, err := app.LoadClustersConfig()
+	clusterConfig, err := app.GetClusterConfig(clusterName)
 	if err != nil {
 		return err
 	}
-	if clustersConfig.Clusters[clusterName].Network.Kind != models.Devnet {
+	if clusterConfig.Local {
+		return notImplementedForLocal(clusterName, "deploy")
+	}
+	if clusterConfig.Network.Kind != models.Devnet {
 		return fmt.Errorf("node deploy command must be applied to devnet clusters")
 	}
 	hosts, err := ansible.GetInventoryFromAnsibleInventoryFile(app.GetAnsibleInventoryDirPath(clusterName))

--- a/cmd/nodecmd/deploy.go
+++ b/cmd/nodecmd/deploy.go
@@ -52,7 +52,7 @@ func deploySubnet(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if clusterConfig.Local {
-		return notImplementedForLocal(clusterName, "deploy")
+		return notImplementedForLocal("deploy")
 	}
 	if clusterConfig.Network.Kind != models.Devnet {
 		return fmt.Errorf("node deploy command must be applied to devnet clusters")

--- a/cmd/nodecmd/destroy.go
+++ b/cmd/nodecmd/destroy.go
@@ -154,7 +154,7 @@ func destroyNodes(_ *cobra.Command, args []string) error {
 		return err
 	}
 	if clusterConfig.Local {
-		return notImplementedForLocal(clusterName, "destroy")
+		return notImplementedForLocal("destroy")
 	}
 	isExternalCluster, err := checkClusterExternal(clusterName)
 	if err != nil {

--- a/cmd/nodecmd/import.go
+++ b/cmd/nodecmd/import.go
@@ -109,13 +109,12 @@ func importFile(_ *cobra.Command, args []string) error {
 	// add cluster
 	clustersConfig := models.ClustersConfig{}
 	clustersConfig.Clusters = make(map[string]models.ClusterConfig)
-	if app.ClustersConfigExists() {
-		clustersConfig, err = app.LoadClustersConfig()
-		if err != nil {
-			ux.Logger.RedXToUser("error loading clusters config: %v", err)
-			return err
-		}
+	clustersConfig, err = app.GetClustersConfig()
+	if err != nil {
+		ux.Logger.RedXToUser("error loading clusters config: %v", err)
+		return err
 	}
+
 	importCluster.ClusterConfig.Network.ClusterName = clusterName
 	clustersConfig.Clusters[clusterName] = importCluster.ClusterConfig
 	if err := app.WriteClustersConfigFile(&clustersConfig); err != nil {

--- a/cmd/nodecmd/list.go
+++ b/cmd/nodecmd/list.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
-	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 
 	"github.com/spf13/cobra"
@@ -29,13 +28,9 @@ The node list command lists all clusters together with their nodes.`,
 }
 
 func list(_ *cobra.Command, _ []string) error {
-	var err error
-	clustersConfig := models.ClustersConfig{}
-	if app.ClustersConfigExists() {
-		clustersConfig, err = app.LoadClustersConfig()
-		if err != nil {
-			return err
-		}
+	clustersConfig, err := app.GetClustersConfig()
+	if err != nil {
+		return err
 	}
 	if len(clustersConfig.Clusters) == 0 {
 		ux.Logger.PrintToUser("There are no clusters defined.")

--- a/cmd/nodecmd/load_test_start.go
+++ b/cmd/nodecmd/load_test_start.go
@@ -522,15 +522,13 @@ func GetLoadTestScript(app *application.Avalanche) error {
 }
 
 func getExistingLoadTestInstance(clusterName, loadTestName string) (string, error) {
-	if app.ClustersConfigExists() {
-		clustersConfig, err := app.LoadClustersConfig()
-		if err != nil {
-			return "", err
-		}
-		if _, ok := clustersConfig.Clusters[clusterName]; ok {
-			if _, loadTestExists := clustersConfig.Clusters[clusterName].LoadTestInstance[loadTestName]; loadTestExists {
-				return clustersConfig.Clusters[clusterName].LoadTestInstance[loadTestName], nil
-			}
+	clustersConfig, err := app.GetClustersConfig()
+	if err != nil {
+		return "", err
+	}
+	if _, ok := clustersConfig.Clusters[clusterName]; ok {
+		if _, loadTestExists := clustersConfig.Clusters[clusterName].LoadTestInstance[loadTestName]; loadTestExists {
+			return clustersConfig.Clusters[clusterName].LoadTestInstance[loadTestName], nil
 		}
 	}
 	return "", nil

--- a/cmd/nodecmd/load_test_stop.go
+++ b/cmd/nodecmd/load_test_stop.go
@@ -40,13 +40,9 @@ separate cloud server created to host the load test.`,
 }
 
 func getLoadTestInstancesInCluster(clusterName string) ([]string, error) {
-	clustersConfig := models.ClustersConfig{}
-	if app.ClustersConfigExists() {
-		var err error
-		clustersConfig, err = app.LoadClustersConfig()
-		if err != nil {
-			return nil, err
-		}
+	clustersConfig, err := app.GetClustersConfig()
+	if err != nil {
+		return nil, err
 	}
 	if _, ok := clustersConfig.Clusters[clusterName]; !ok {
 		return nil, fmt.Errorf("cluster %s doesn't exist", clusterName)
@@ -58,13 +54,9 @@ func getLoadTestInstancesInCluster(clusterName string) ([]string, error) {
 }
 
 func checkLoadTestExists(clusterName, loadTestName string) (bool, error) {
-	clustersConfig := models.ClustersConfig{}
-	if app.ClustersConfigExists() {
-		var err error
-		clustersConfig, err = app.LoadClustersConfig()
-		if err != nil {
-			return false, err
-		}
+	clustersConfig, err := app.GetClustersConfig()
+	if err != nil {
+		return false, err
 	}
 	if _, ok := clustersConfig.Clusters[clusterName]; !ok {
 		return false, fmt.Errorf("cluster %s doesn't exist", clusterName)
@@ -252,13 +244,9 @@ func destroyNode(node, clusterName, loadTestName string, ec2Svc *awsAPI.AwsCloud
 }
 
 func removeLoadTestNodeFromClustersConfig(clusterName, loadTestName string) error {
-	clustersConfig := models.ClustersConfig{}
-	var err error
-	if app.ClustersConfigExists() {
-		clustersConfig, err = app.LoadClustersConfig()
-		if err != nil {
-			return err
-		}
+	clustersConfig, err := app.GetClustersConfig()
+	if err != nil {
+		return err
 	}
 	if clustersConfig.Clusters != nil {
 		if _, ok := clustersConfig.Clusters[clusterName]; !ok {

--- a/cmd/nodecmd/local.go
+++ b/cmd/nodecmd/local.go
@@ -509,7 +509,7 @@ func localTrack(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func notImplementedForLocal(clusterName string, what string) error {
-	ux.Logger.PrintToUser("Local cluster %s does not support %s cmd", logging.LightBlue.Wrap(clusterName), logging.LightBlue.Wrap(what))
+func notImplementedForLocal(what string) error {
+	ux.Logger.PrintToUser("Unsupported cmd: %s is not supported by local clusters", logging.LightBlue.Wrap(what))
 	return nil
 }

--- a/cmd/nodecmd/local.go
+++ b/cmd/nodecmd/local.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ava-labs/avalanche-network-runner/client"
 	anrutils "github.com/ava-labs/avalanche-network-runner/utils"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/spf13/cobra"
 )
@@ -422,13 +423,9 @@ func addLocalClusterConfig(network models.Network) error {
 }
 
 func checkClusterIsLocal(clusterName string) (bool, error) {
-	clustersConfig := models.ClustersConfig{}
-	if app.ClustersConfigExists() {
-		var err error
-		clustersConfig, err = app.LoadClustersConfig()
-		if err != nil {
-			return false, err
-		}
+	clustersConfig, err := app.GetClustersConfig()
+	if err != nil {
+		return false, err
 	}
 	clusterConf, ok := clustersConfig.Clusters[clusterName]
 	return ok && clusterConf.Local, nil
@@ -509,5 +506,10 @@ func localTrack(_ *cobra.Command, args []string) error {
 		return err
 	}
 	ux.Logger.GreenCheckmarkToUser("%s successfully tracking %s", clusterName, blockchainName)
+	return nil
+}
+
+func notImplementedForLocal(clusterName string, what string) error {
+	ux.Logger.PrintToUser("Local cluster %s does not support %s cmd", logging.LightBlue.Wrap(clusterName), logging.LightBlue.Wrap(what))
 	return nil
 }

--- a/cmd/nodecmd/resize.go
+++ b/cmd/nodecmd/resize.go
@@ -61,7 +61,7 @@ func preResizeChecks(clusterName string) error {
 		return err
 	}
 	if clusterConfig.Local {
-		return notImplementedForLocal(clusterName, "resize")
+		return notImplementedForLocal("resize")
 	}
 	return nil
 }

--- a/cmd/nodecmd/resize.go
+++ b/cmd/nodecmd/resize.go
@@ -56,6 +56,13 @@ func preResizeChecks(clusterName string) error {
 	if err := failForExternal(clusterName); err != nil {
 		return fmt.Errorf("cannot resize external cluster %s", clusterName)
 	}
+	clusterConfig, err := app.GetClusterConfig(clusterName)
+	if err != nil {
+		return err
+	}
+	if clusterConfig.Local {
+		return notImplementedForLocal(clusterName, "resize")
+	}
 	return nil
 }
 

--- a/cmd/nodecmd/scp.go
+++ b/cmd/nodecmd/scp.go
@@ -82,12 +82,12 @@ func scpNode(_ *cobra.Command, args []string) error {
 	}
 	sourceClusterConfig := clustersConfig.Clusters[sourceClusterNameOrNodeID]
 	if sourceClusterExists && sourceClusterConfig.Local {
-		return notImplementedForLocal(sourceClusterNameOrNodeID, "scp")
+		return notImplementedForLocal("scp")
 	}
 
 	destClusterConfig := clustersConfig.Clusters[destClusterNameOrNodeID]
 	if destClusterExists && destClusterConfig.Local {
-		return notImplementedForLocal(destClusterNameOrNodeID, "scp")
+		return notImplementedForLocal("scp")
 	}
 
 	switch {

--- a/cmd/nodecmd/scp.go
+++ b/cmd/nodecmd/scp.go
@@ -55,13 +55,9 @@ $ avalanche node scp node1:/tmp/file.txt NodeID-XXXX:/tmp/file.txt
 }
 
 func scpNode(_ *cobra.Command, args []string) error {
-	var err error
-	clustersConfig := models.ClustersConfig{}
-	if app.ClustersConfigExists() {
-		clustersConfig, err = app.LoadClustersConfig()
-		if err != nil {
-			return err
-		}
+	clustersConfig, err := app.GetClustersConfig()
+	if err != nil {
+		return err
 	}
 	if len(clustersConfig.Clusters) == 0 {
 		ux.Logger.PrintToUser("There are no clusters defined.")
@@ -83,6 +79,15 @@ func scpNode(_ *cobra.Command, args []string) error {
 	}
 	if sourceClusterExists && destClusterExists {
 		return fmt.Errorf("both source and destination cannot be clusters")
+	}
+	sourceClusterConfig := clustersConfig.Clusters[sourceClusterNameOrNodeID]
+	if sourceClusterExists && sourceClusterConfig.Local {
+		return notImplementedForLocal(sourceClusterNameOrNodeID, "scp")
+	}
+
+	destClusterConfig := clustersConfig.Clusters[destClusterNameOrNodeID]
+	if destClusterExists && destClusterConfig.Local {
+		return notImplementedForLocal(destClusterNameOrNodeID, "scp")
 	}
 
 	switch {
@@ -245,13 +250,9 @@ func prepareSCPTarget(op ClusterOp, host *models.Host, clusterName string, dest 
 
 // getHostClusterPair returns the host and cluster name for the given node or cloudID
 func getHostClusterPair(nodeOrCloudIDOrIP string) (*models.Host, string) {
-	var err error
-	clustersConfig := models.ClustersConfig{}
-	if app.ClustersConfigExists() {
-		clustersConfig, err = app.LoadClustersConfig()
-		if err != nil {
-			return nil, ""
-		}
+	clustersConfig, err := app.GetClustersConfig()
+	if err != nil {
+		return nil, ""
 	}
 	for clusterName := range clustersConfig.Clusters {
 		clusterHosts, err := GetAllClusterHosts(clusterName)

--- a/cmd/nodecmd/ssh.go
+++ b/cmd/nodecmd/ssh.go
@@ -77,7 +77,7 @@ func sshNode(_ *cobra.Command, args []string) error {
 				return printClusterConnectionString(clusterNameOrNodeID, clustersConfig.Clusters[clusterNameOrNodeID].Network.Kind.String())
 			} else {
 				if clustersConfig.Clusters[clusterNameOrNodeID].Local {
-					return notImplementedForLocal(clusterNameOrNodeID, "ssh")
+					return notImplementedForLocal("ssh")
 				}
 				clusterHosts, err := GetAllClusterHosts(clusterNameOrNodeID)
 				if err != nil {

--- a/cmd/nodecmd/status.go
+++ b/cmd/nodecmd/status.go
@@ -57,6 +57,10 @@ func statusNode(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	// local cluster doesn't have nodes
+	if clusterConf.Local {
+		return notImplementedForLocal(clusterName, "status")
+	}
 	var blockchainID ids.ID
 	if blockchainName != "" {
 		sc, err := app.LoadSidecar(blockchainName)
@@ -68,6 +72,7 @@ func statusNode(_ *cobra.Command, args []string) error {
 			return ErrNoBlockchainID
 		}
 	}
+
 	hostIDs := utils.Filter(clusterConf.GetCloudIDs(), clusterConf.IsAvalancheGoHost)
 	nodeIDs, err := utils.MapWithError(hostIDs, func(s string) (string, error) {
 		n, err := getNodeID(app.GetNodeInstanceDirPath(s))

--- a/cmd/nodecmd/status.go
+++ b/cmd/nodecmd/status.go
@@ -59,7 +59,7 @@ func statusNode(_ *cobra.Command, args []string) error {
 	}
 	// local cluster doesn't have nodes
 	if clusterConf.Local {
-		return notImplementedForLocal(clusterName, "status")
+		return notImplementedForLocal("status")
 	}
 	var blockchainID ids.ID
 	if blockchainName != "" {

--- a/cmd/nodecmd/update_subnet.go
+++ b/cmd/nodecmd/update_subnet.go
@@ -42,7 +42,7 @@ func updateSubnet(_ *cobra.Command, args []string) error {
 		return err
 	}
 	if clusterConfig.Local {
-		return notImplementedForLocal(clusterName, "update")
+		return notImplementedForLocal("update")
 	}
 	if _, err := blockchaincmd.ValidateSubnetNameAndGetChains([]string{subnetName}); err != nil {
 		return err

--- a/cmd/nodecmd/update_subnet.go
+++ b/cmd/nodecmd/update_subnet.go
@@ -41,6 +41,9 @@ func updateSubnet(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	if clusterConfig.Local {
+		return notImplementedForLocal(clusterName, "update")
+	}
 	if _, err := blockchaincmd.ValidateSubnetNameAndGetChains([]string{subnetName}); err != nil {
 		return err
 	}

--- a/cmd/nodecmd/upgrade.go
+++ b/cmd/nodecmd/upgrade.go
@@ -54,6 +54,9 @@ func upgrade(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	if clusterConfig.Local {
+		return notImplementedForLocal(clusterName, "upgrade")
+	}
 	network := clusterConfig.Network
 	hosts, err := ansible.GetInventoryFromAnsibleInventoryFile(app.GetAnsibleInventoryDirPath(clusterName))
 	if err != nil {

--- a/cmd/nodecmd/upgrade.go
+++ b/cmd/nodecmd/upgrade.go
@@ -55,7 +55,7 @@ func upgrade(_ *cobra.Command, args []string) error {
 		return err
 	}
 	if clusterConfig.Local {
-		return notImplementedForLocal(clusterName, "upgrade")
+		return notImplementedForLocal("upgrade")
 	}
 	network := clusterConfig.Network
 	hosts, err := ansible.GetInventoryFromAnsibleInventoryFile(app.GetAnsibleInventoryDirPath(clusterName))

--- a/cmd/nodecmd/validate_primary.go
+++ b/cmd/nodecmd/validate_primary.go
@@ -296,7 +296,7 @@ func validatePrimaryNetwork(_ *cobra.Command, args []string) error {
 		return err
 	}
 	if clusterConfig.Local {
-		return notImplementedForLocal(clusterName, "validate primary")
+		return notImplementedForLocal("validate primary")
 	}
 	network := clusterConfig.Network
 

--- a/cmd/nodecmd/validate_primary.go
+++ b/cmd/nodecmd/validate_primary.go
@@ -295,6 +295,9 @@ func validatePrimaryNetwork(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	if clusterConfig.Local {
+		return notImplementedForLocal(clusterName, "validate primary")
+	}
 	network := clusterConfig.Network
 
 	allHosts, err := ansible.GetInventoryFromAnsibleInventoryFile(app.GetAnsibleInventoryDirPath(clusterName))

--- a/cmd/nodecmd/validate_subnet.go
+++ b/cmd/nodecmd/validate_subnet.go
@@ -185,7 +185,7 @@ func validateSubnet(_ *cobra.Command, args []string) error {
 		return err
 	}
 	if clusterConfig.Local {
-		return notImplementedForLocal(clusterName, "validate subnet")
+		return notImplementedForLocal("validate subnet")
 	}
 	network := clusterConfig.Network
 

--- a/cmd/nodecmd/validate_subnet.go
+++ b/cmd/nodecmd/validate_subnet.go
@@ -184,6 +184,9 @@ func validateSubnet(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	if clusterConfig.Local {
+		return notImplementedForLocal(clusterName, "validate subnet")
+	}
 	network := clusterConfig.Network
 
 	allHosts, err := ansible.GetInventoryFromAnsibleInventoryFile(app.GetAnsibleInventoryDirPath(clusterName))

--- a/cmd/nodecmd/whitelist.go
+++ b/cmd/nodecmd/whitelist.go
@@ -68,6 +68,14 @@ func whitelist(_ *cobra.Command, args []string) error {
 		return err
 	}
 
+	clustersConfig, err := app.LoadClustersConfig()
+	if err != nil {
+		return err
+	}
+	clusterConfig := clustersConfig.Clusters[clusterName]
+	if clusterConfig.Local {
+		return notImplementedForLocal(clusterName, "whitelist")
+	}
 	if discoverIP {
 		userIPAddress, err = utils.GetUserIPAddress()
 		if err != nil {

--- a/cmd/nodecmd/whitelist.go
+++ b/cmd/nodecmd/whitelist.go
@@ -74,7 +74,7 @@ func whitelist(_ *cobra.Command, args []string) error {
 	}
 	clusterConfig := clustersConfig.Clusters[clusterName]
 	if clusterConfig.Local {
-		return notImplementedForLocal(clusterName, "whitelist")
+		return notImplementedForLocal("whitelist")
 	}
 	if discoverIP {
 		userIPAddress, err = utils.GetUserIPAddress()

--- a/go.sum
+++ b/go.sum
@@ -83,16 +83,10 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/ava-labs/apm v1.0.0 h1:6FwozH67hEkbWVsOXNZGexBy5KLpNeYucN9zcFUHv+Q=
 github.com/ava-labs/apm v1.0.0/go.mod h1:TJL7pTlZNvQatsQPsLUtDHApEwVZ/qS7iSNtRFU83mc=
-github.com/ava-labs/avalanche-network-runner v1.8.4-0.20241003175856-6b1bcdf33e7a h1:xd2RUTW9w34+V6yI7zWfByHZ8y5CeXhvHK+nAJ9FCbI=
-github.com/ava-labs/avalanche-network-runner v1.8.4-0.20241003175856-6b1bcdf33e7a/go.mod h1:l4QzFnujbyyyeq6oBQ4F6sw9TrTQCjD2V4vUd7ZBCCo=
-github.com/ava-labs/avalanche-network-runner v1.8.4-0.20241011192344-249709ce7115 h1:cgEHfZ1UFdVpFxv6zkJOt3pKXjLJceXYPM3pjBoxk0w=
-github.com/ava-labs/avalanche-network-runner v1.8.4-0.20241011192344-249709ce7115/go.mod h1:l4QzFnujbyyyeq6oBQ4F6sw9TrTQCjD2V4vUd7ZBCCo=
 github.com/ava-labs/avalanche-network-runner v1.8.4-0.20241011195013-51e7833ea2da h1:goZVOXxAu47xw2zasimAA0tuAWdiABtjlSwsImDeTL8=
 github.com/ava-labs/avalanche-network-runner v1.8.4-0.20241011195013-51e7833ea2da/go.mod h1:l4QzFnujbyyyeq6oBQ4F6sw9TrTQCjD2V4vUd7ZBCCo=
 github.com/ava-labs/avalanchego v1.12.0-initial-poc.3 h1:JfVooBCdMzpeGUT9/phJNl2GHflkGehlMJokXeWKa2A=
 github.com/ava-labs/avalanchego v1.12.0-initial-poc.3/go.mod h1:qSHmog3wMVjo/ruIAQo0ppXAilyni07NIu5K88RyhWE=
-github.com/ava-labs/awm-relayer v1.4.1-0.20241003162124-807fd305670f h1:YUQF1wQJeEcTMC5W/OrwgSFTFMS4zeCM8O02rLeEDow=
-github.com/ava-labs/awm-relayer v1.4.1-0.20241003162124-807fd305670f/go.mod h1:K01Md6zPkOFRWeQyxmZ/t9HJfoNgUGqa1L8rOp35GXw=
 github.com/ava-labs/awm-relayer v1.4.1-0.20241010130039-bceba83023b8 h1:M58jcqAG51RrKKVCfhAZpPqCFdkqRzahEgkFqQA5EME=
 github.com/ava-labs/awm-relayer v1.4.1-0.20241010130039-bceba83023b8/go.mod h1:K01Md6zPkOFRWeQyxmZ/t9HJfoNgUGqa1L8rOp35GXw=
 github.com/ava-labs/coreth v0.13.8 h1:f14X3KgwHl9LwzfxlN6S4bbn5VA2rhEsNnHaRLSTo/8=

--- a/internal/mocks/process_checker.go
+++ b/internal/mocks/process_checker.go
@@ -14,7 +14,7 @@ type ProcessChecker struct {
 }
 
 // IsServerProcessRunning provides a mock function with given fields: app
-func (_m *ProcessChecker) IsServerProcessRunning(app *application.Avalanche) (bool, error) {
+func (_m *ProcessChecker) IsServerProcessRunning(app *application.Avalanche, _ string) (bool, error) {
 	ret := _m.Called(app)
 
 	if len(ret) == 0 {

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -689,6 +689,13 @@ func (app *Avalanche) LoadClustersConfig() (models.ClustersConfig, error) {
 	return models.ClustersConfig{}, fmt.Errorf("unsupported clusters config version %s", v)
 }
 
+func (app *Avalanche) GetClustersConfig() (models.ClustersConfig, error) {
+	if app.ClustersConfigExists() {
+		return app.LoadClustersConfig()
+	}
+	return models.ClustersConfig{}, nil
+}
+
 func (app *Avalanche) WriteClustersConfigFile(clustersConfig *models.ClustersConfig) error {
 	clustersConfigPath := app.GetClustersConfigPath()
 	if err := os.MkdirAll(filepath.Dir(clustersConfigPath), constants.DefaultPerms755); err != nil {
@@ -787,13 +794,9 @@ func (app *Avalanche) SetupMonitoringEnv() error {
 }
 
 func (app *Avalanche) ClusterExists(clusterName string) (bool, error) {
-	clustersConfig := models.ClustersConfig{}
-	if app.ClustersConfigExists() {
-		var err error
-		clustersConfig, err = app.LoadClustersConfig()
-		if err != nil {
-			return false, err
-		}
+	clustersConfig, err := app.GetClustersConfig()
+	if err != nil {
+		return false, err
 	}
 	_, ok := clustersConfig.Clusters[clusterName]
 	return ok, nil

--- a/pkg/subnet/local_test.go
+++ b/pkg/subnet/local_test.go
@@ -143,7 +143,7 @@ func TestDeployToLocal(t *testing.T) {
 	icmSpec := ICMSpec{
 		SkipICMDeploy: true,
 	}
-	deployInfo, err := testDeployer.DeployToLocalNetwork(testChainName, testGenesis.Name(), icmSpec, "")
+	deployInfo, err := testDeployer.DeployToLocalNetwork(testChainName, testGenesis.Name(), icmSpec, "", "")
 	require.NoError(err)
 	require.Equal(testSubnetID2, deployInfo.SubnetID.String())
 	require.Equal(testBlockChainID2, deployInfo.BlockchainID.String())


### PR DESCRIPTION

## Why this should be merged
it adds checks for unsupported  by local cluster commands

## How this works
adds checks
also refactors getclustersconfig functionality so it's less verbose to use 

## How this was tested
❯ ./bin/avalanche node validate primary local1
Local cluster local1 does not support validate primary cmd

## How is this documented
n/a
