### PR TITLE
assume blockchain endpoint only for cli managed node sync

### DIFF
--- a/pkg/contract/chain.go
+++ b/pkg/contract/chain.go
@@ -99,18 +99,7 @@ func GetBlockchainEndpoints(
 		rpcEndpoint string
 		wsEndpoint  string
 	)
-	switch {
-	case chainSpec.CChain:
-		rpcEndpoint = network.CChainEndpoint()
-		wsEndpoint = network.CChainWSEndpoint()
-	case network.Kind == models.Local || network.Kind == models.Devnet:
-		blockchainID, err := GetBlockchainID(app, network, chainSpec)
-		if err != nil {
-			return "", "", err
-		}
-		rpcEndpoint = network.BlockchainEndpoint(blockchainID.String())
-		wsEndpoint = network.BlockchainWSEndpoint(blockchainID.String())
-	case chainSpec.BlockchainName != "":
+	if chainSpec.BlockchainName != "" {
 		sc, err := app.LoadSidecar(chainSpec.BlockchainName)
 		if err != nil {
 			return "", "", fmt.Errorf("failed to load sidecar: %w", err)
@@ -123,6 +112,20 @@ func GetBlockchainEndpoints(
 		}
 		if len(sc.Networks[network.Name()].WSEndpoints) > 0 {
 			wsEndpoint = sc.Networks[network.Name()].WSEndpoints[0]
+		}
+	}
+	if rpcEndpoint == "" {
+		switch {
+		case chainSpec.CChain:
+			rpcEndpoint = network.CChainEndpoint()
+			wsEndpoint = network.CChainWSEndpoint()
+		case network.Kind == models.Local:
+			blockchainID, err := GetBlockchainID(app, network, chainSpec)
+			if err != nil {
+				return "", "", err
+			}
+			rpcEndpoint = network.BlockchainEndpoint(blockchainID.String())
+			wsEndpoint = network.BlockchainWSEndpoint(blockchainID.String())
 		}
 	}
 	blockchainDesc, err := GetBlockchainDesc(chainSpec)


### PR DESCRIPTION
## Why this should be merged
Currently, when interacting with a devnet, CLI assumes the blockchain endpoint
can be derived from the devnet public endpoint. This PR removes this assumption.

## How this works
It only assumes such endpoint derivation for local networks.  It also keeps the current
assumptions:
- c-chain can be derived from devnet public endpoint
- endpoint can be taken from blockchain sidecar if information is present there
(typically for node sync/track managed by CLI)

## How this was tested

## How is this documented
