### PR TITLE
Integrate local devnet

### DIFF
--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/ava-labs/avalanchego/api/info"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,8 +16,6 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/evm"
 
 	"github.com/ava-labs/avalanche-cli/pkg/node"
-	"github.com/ava-labs/avalanchego/api/info"
-
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp/message"
 	"github.com/ethereum/go-ethereum/common"
 
@@ -53,6 +52,7 @@ import (
 var deploySupportedNetworkOptions = []networkoptions.NetworkOption{
 	networkoptions.Local,
 	networkoptions.Devnet,
+	networkoptions.EtnaDevnet,
 	networkoptions.Fuji,
 	networkoptions.Mainnet,
 }
@@ -67,6 +67,7 @@ var (
 	outputTxPath                    string
 	useLedger                       bool
 	useLocalMachine                 bool
+	localMachineCluster             string
 	useEwoq                         bool
 	ledgerAddresses                 []string
 	sovereign                       bool
@@ -134,8 +135,9 @@ so you can take your locally tested Subnet and deploy it on Fuji or Mainnet.`,
 	cmd.Flags().StringVar(&icmSpec.RegistryBydecodePath, "teleporter-registry-bytecode-path", "", "path to an interchain messenger registry bytecode file")
 	cmd.Flags().StringVar(&bootstrapValidatorsJSONFilePath, "bootstrap-filepath", "", "JSON file path that provides details about bootstrap validators, leave Node-ID and BLS values empty if using --generate-node-id=true")
 	cmd.Flags().BoolVar(&generateNodeID, "generate-node-id", false, "whether to create new node id for bootstrap validators (Node-ID and BLS values in bootstrap JSON file will be overridden if --bootstrap-filepath flag is used)")
-	cmd.Flags().StringSliceVar(&bootstrapEndpoints, "bootstrap-endpoints", nil, "take validator node info from the given endpoints")
+	cmd.Flags().StringSliceVar(&bootstrapEndpoints, "bootstrap-enu dpoints", nil, "take validator node info from the given endpoints")
 	cmd.Flags().BoolVar(&useLocalMachine, "use-local-machine", false, "use local machine as a blockchain validator")
+	cmd.Flags().StringVar(&localMachineCluster, "local-machine-cluster", "", "existing local machine to be used as a blockchain validator")
 	return cmd
 }
 
@@ -470,50 +472,85 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 		return PrintSubnetInfo(blockchainName, true)
 	}
 
-	if !useLocalMachine {
-		ux.Logger.PrintToUser("You can use your local machine as a bootstrap validator on the blockchain")
-		ux.Logger.PrintToUser("This means that you don't have to to set up a remote server on a cloud service (e.g. AWS / GCP) to be a validator on the blockchain.")
+	if sidecar.Sovereign {
+		if !useLocalMachine {
+			ux.Logger.PrintToUser("You can use your local machine as a bootstrap validator on the blockchain")
+			ux.Logger.PrintToUser("This means that you don't have to to set up a remote server on a cloud service (e.g. AWS / GCP) to be a validator on the blockchain.")
 
-		useLocalMachine, err = app.Prompt.CaptureYesNo("Do you want to use your local machine as a bootstrap validator?")
-		if err != nil {
-			return err
-		}
-	}
-	if useLocalMachine {
-		bootstrapEndpoints = []string{"http://127.0.0.1:9650"}
-	}
-
-	if len(bootstrapEndpoints) > 0 {
-		var changeAddr string
-		for _, endpoint := range bootstrapEndpoints {
-			infoClient := info.NewClient(endpoint)
-			ctx, cancel := utils.GetAPILargeContext()
-			defer cancel()
-			nodeID, proofOfPossession, err := infoClient.GetNodeID(ctx)
+			useLocalMachine, err = app.Prompt.CaptureYesNo("Do you want to use your local machine as a bootstrap validator?")
 			if err != nil {
 				return err
 			}
-			publicKey = "0x" + hex.EncodeToString(proofOfPossession.PublicKey[:])
-			pop = "0x" + hex.EncodeToString(proofOfPossession.ProofOfPossession[:])
-			changeAddr, err = getKeyForChangeOwner(nodeID.String(), changeAddr, network)
+		}
+		if useLocalMachine {
+			// stop any local avalanche go process running before we start local node
+			_ = node.StopLocalNode(app)
+			clusterName := fmt.Sprintf("%s-local-node", blockchainName)
+			if localMachineCluster != "" {
+				// don't destroy cluster if local cluster name is provided
+				clusterName = localMachineCluster
+			} else {
+				// destroy any cluster with same name before we start local node
+				// we don't want to reuse snapshots from previous sessions
+				if utils.DirectoryExists(app.GetLocalDir(clusterName)) {
+					_ = node.DestroyLocalNode(app, clusterName)
+				}
+			}
+			// TODO: replace bootstrapEndpoints with dynamic port number
+			bootstrapEndpoints = []string{"http://127.0.0.1:9650"}
+			anrSettings := node.ANRSettings{}
+			avagoVersionSettings := node.AvalancheGoVersionSettings{}
+			useEtnaDevnet := false
+			if network.Kind == models.EtnaDevnet {
+				useEtnaDevnet = true
+			}
+			if avagoBinaryPath == "" {
+				ux.Logger.PrintToUser("Local build of Avalanche Go is required to create an Avalanche node using local machine")
+				ux.Logger.PrintToUser("Please download Avalanche Go repo at https://github.com/ava-labs/avalanchego and build from source through ./scripts/build.sh")
+				ux.Logger.PrintToUser("Please provide the full path to Avalanche Go binary in the build directory (e.g, xxx/build/avalanchego)")
+				avagoBinaryPath, err = app.Prompt.CaptureString("Path to Avalanche Go build")
+				if err != nil {
+					return err
+				}
+			}
+			network = models.NewNetworkFromCluster(network, clusterName)
+			// anrSettings, avagoVersionSettings, globalNetworkFlags are empty
+			if err = node.StartLocalNode(app, clusterName, useEtnaDevnet, avagoBinaryPath, anrSettings, avagoVersionSettings, globalNetworkFlags, nil); err != nil {
+				return err
+			}
+		}
+
+		if len(bootstrapEndpoints) > 0 {
+			var changeAddr string
+			for _, endpoint := range bootstrapEndpoints {
+				infoClient := info.NewClient(endpoint)
+				ctx, cancel := utils.GetAPILargeContext()
+				defer cancel()
+				nodeID, proofOfPossession, err := infoClient.GetNodeID(ctx)
+				if err != nil {
+					return err
+				}
+				publicKey = "0x" + hex.EncodeToString(proofOfPossession.PublicKey[:])
+				pop = "0x" + hex.EncodeToString(proofOfPossession.ProofOfPossession[:])
+				changeAddr, err = getKeyForChangeOwner(nodeID.String(), changeAddr, network)
+				if err != nil {
+					return err
+				}
+				bootstrapValidators = append(bootstrapValidators, models.SubnetValidator{
+					NodeID:               nodeID.String(),
+					Weight:               constants.BootstrapValidatorWeight,
+					Balance:              constants.BootstrapValidatorBalance,
+					BLSPublicKey:         publicKey,
+					BLSProofOfPossession: pop,
+					ChangeOwnerAddr:      changeAddr,
+				})
+			}
+		}
+		if len(bootstrapValidators) == 0 {
+			bootstrapValidators, err = promptBootstrapValidators(network)
 			if err != nil {
 				return err
 			}
-			bootstrapValidators = append(bootstrapValidators, models.SubnetValidator{
-				NodeID:               nodeID.String(),
-				Weight:               constants.BootstrapValidatorWeight,
-				Balance:              constants.BootstrapValidatorBalance,
-				BLSPublicKey:         publicKey,
-				BLSProofOfPossession: pop,
-				ChangeOwnerAddr:      changeAddr,
-			})
-		}
-	}
-
-	if sidecar.Sovereign && len(bootstrapValidators) == 0 {
-		bootstrapValidators, err = promptBootstrapValidators(network)
-		if err != nil {
-			return err
 		}
 	}
 
@@ -796,7 +833,7 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			ux.Logger.PrintToUser("Initializing Proof of Authority Validator Manager contract on blockchain %s ...\", blockchainName")
+			ux.Logger.PrintToUser("Initializing Proof of Authority Validator Manager contract on blockchain %s ...", blockchainName)
 			if err := validatormanager.SetupPoA(
 				app,
 				network,

--- a/cmd/nodecmd/create.go
+++ b/cmd/nodecmd/create.go
@@ -21,10 +21,8 @@ import (
 
 	"github.com/ava-labs/avalanche-cli/pkg/metrics"
 
-	"github.com/ava-labs/avalanche-cli/cmd/blockchaincmd"
 	"github.com/ava-labs/avalanche-cli/cmd/flags"
 	"github.com/ava-labs/avalanche-cli/pkg/ansible"
-	"github.com/ava-labs/avalanche-cli/pkg/binutils"
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
@@ -267,7 +265,13 @@ func createNodes(cmd *cobra.Command, args []string) error {
 	}
 	network = models.NewNetworkFromCluster(network, clusterName)
 	globalNetworkFlags.UseDevnet = network.Kind == models.Devnet // set globalNetworkFlags.UseDevnet to true if network is devnet for further use
-	avalancheGoVersion, err := getAvalancheGoVersion()
+	avaGoVersionSetting := node.AvalancheGoVersionSettings{
+		UseAvalanchegoVersionFromSubnet:       useAvalanchegoVersionFromSubnet,
+		UseLatestAvalanchegoReleaseVersion:    useLatestAvalanchegoReleaseVersion,
+		UseLatestAvalanchegoPreReleaseVersion: useLatestAvalanchegoPreReleaseVersion,
+		UseCustomAvalanchegoVersion:           useCustomAvalanchegoVersion,
+	}
+	avalancheGoVersion, err := node.GetAvalancheGoVersion(app, avaGoVersionSetting)
 	if err != nil {
 		return err
 	}
@@ -898,7 +902,7 @@ func addNodeToClustersConfig(network models.Network, nodeID, clusterName string,
 	}
 	clusterConfig := clustersConfig.Clusters[clusterName]
 	// if supplied network in argument is empty, don't change current cluster network in cluster_config.json
-	if !network.IsUndefined() {
+	if network != models.UndefinedNetwork {
 		clusterConfig.Network = network
 	}
 	clusterConfig.HTTPAccess = constants.HTTPAccess(publicHTTPPortAccess)
@@ -985,57 +989,6 @@ func provideStakingCertAndKey(host *models.Host) error {
 	return ssh.RunSSHUploadStakingFiles(host, keyPath)
 }
 
-// getAvalancheGoVersion asks users whether they want to install the newest Avalanche Go version
-// or if they want to use the newest Avalanche Go Version that is still compatible with Subnet EVM
-// version of their choice
-func getAvalancheGoVersion() (string, error) {
-	// skip this logic if custom-avalanchego-version flag is set
-	if useCustomAvalanchegoVersion != "" {
-		return useCustomAvalanchegoVersion, nil
-	}
-	latestReleaseVersion, err := app.Downloader.GetLatestReleaseVersion(binutils.GetGithubLatestReleaseURL(
-		constants.AvaLabsOrg,
-		constants.AvalancheGoRepoName,
-	))
-	if err != nil {
-		return "", err
-	}
-	latestPreReleaseVersion, err := app.Downloader.GetLatestPreReleaseVersion(
-		constants.AvaLabsOrg,
-		constants.AvalancheGoRepoName,
-	)
-	if err != nil {
-		return "", err
-	}
-
-	if !useLatestAvalanchegoReleaseVersion && !useLatestAvalanchegoPreReleaseVersion && useCustomAvalanchegoVersion == "" && useAvalanchegoVersionFromSubnet == "" {
-		err := promptAvalancheGoVersionChoice(latestReleaseVersion, latestPreReleaseVersion)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	var version string
-	switch {
-	case useLatestAvalanchegoReleaseVersion:
-		version = latestReleaseVersion
-	case useLatestAvalanchegoPreReleaseVersion:
-		version = latestPreReleaseVersion
-	case useCustomAvalanchegoVersion != "":
-		version = useCustomAvalanchegoVersion
-	case useAvalanchegoVersionFromSubnet != "":
-		sc, err := app.LoadSidecar(useAvalanchegoVersionFromSubnet)
-		if err != nil {
-			return "", err
-		}
-		version, err = GetLatestAvagoVersionForRPC(sc.RPCVersion, latestPreReleaseVersion)
-		if err != nil {
-			return "", err
-		}
-	}
-	return version, nil
-}
-
 func GetLatestAvagoVersionForRPC(configuredRPCVersion int, latestPreReleaseVersion string) (string, error) {
 	desiredAvagoVersion, err := vm.GetLatestAvalancheGoByProtocolVersion(
 		app, configuredRPCVersion, constants.AvalancheGoCompatibilityURL)
@@ -1047,51 +1000,6 @@ func GetLatestAvagoVersionForRPC(configuredRPCVersion int, latestPreReleaseVersi
 		return "", err
 	}
 	return desiredAvagoVersion, nil
-}
-
-// promptAvalancheGoVersionChoice sets flags for either using the latest Avalanche Go
-// version or using the latest Avalanche Go version that is still compatible with the subnet that user
-// wants the cloud server to track
-func promptAvalancheGoVersionChoice(latestReleaseVersion string, latestPreReleaseVersion string) error {
-	latestReleaseVersionOption := "Use latest Avalanche Go Release Version" + versionComments[latestReleaseVersion]
-	latestPreReleaseVersionOption := "Use latest Avalanche Go Pre-release Version" + versionComments[latestPreReleaseVersion]
-	subnetBasedVersionOption := "Use the deployed Subnet's VM version that the node will be validating"
-	customOption := "Custom"
-
-	txt := "What version of Avalanche Go would you like to install in the node?"
-	versionOptions := []string{latestReleaseVersionOption, subnetBasedVersionOption, customOption}
-	if latestPreReleaseVersion != latestReleaseVersion {
-		versionOptions = []string{latestPreReleaseVersionOption, latestReleaseVersionOption, subnetBasedVersionOption, customOption}
-	}
-	versionOption, err := app.Prompt.CaptureList(txt, versionOptions)
-	if err != nil {
-		return err
-	}
-
-	switch versionOption {
-	case latestReleaseVersionOption:
-		useLatestAvalanchegoReleaseVersion = true
-	case latestPreReleaseVersionOption:
-		useLatestAvalanchegoPreReleaseVersion = true
-	case customOption:
-		useCustomAvalanchegoVersion, err = app.Prompt.CaptureVersion("Which version of AvalancheGo would you like to install? (Use format v1.10.13)")
-		if err != nil {
-			return err
-		}
-	default:
-		for {
-			useAvalanchegoVersionFromSubnet, err = app.Prompt.CaptureString("Which Subnet would you like to use to choose the avalanche go version?")
-			if err != nil {
-				return err
-			}
-			_, err = blockchaincmd.ValidateSubnetNameAndGetChains([]string{useAvalanchegoVersionFromSubnet})
-			if err == nil {
-				break
-			}
-			ux.Logger.PrintToUser(fmt.Sprintf("no subnet named %s found", useAvalanchegoVersionFromSubnet))
-		}
-	}
-	return nil
 }
 
 func setCloudService() (string, error) {

--- a/cmd/nodecmd/local.go
+++ b/cmd/nodecmd/local.go
@@ -3,21 +3,10 @@
 package nodecmd
 
 import (
-	"fmt"
-	"github.com/ava-labs/avalanche-cli/pkg/node"
-	"os"
-	"path/filepath"
-
-	"github.com/ava-labs/avalanche-cli/pkg/binutils"
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
-	"github.com/ava-labs/avalanche-cli/pkg/constants"
-	"github.com/ava-labs/avalanche-cli/pkg/localnet"
-	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
-	"github.com/ava-labs/avalanche-cli/pkg/subnet"
-	"github.com/ava-labs/avalanche-cli/pkg/utils"
+	"github.com/ava-labs/avalanche-cli/pkg/node"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
-	"github.com/ava-labs/avalanche-network-runner/client"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/spf13/cobra"
 )
@@ -121,341 +110,33 @@ func newLocalDestroyCmd() *cobra.Command {
 	}
 }
 
-// stub for now
-func preLocalChecks(clusterName string) error {
-	clusterExists, err := checkClusterExists(clusterName)
-	if err != nil {
-		return fmt.Errorf("error checking cluster: %w", err)
-	}
-	if clusterExists {
-		return fmt.Errorf("cluster %q already exists", clusterName)
-	}
-	// expand passed paths
-	if genesisPath != "" {
-		genesisPath = utils.ExpandHome(genesisPath)
-	}
-	if upgradePath != "" {
-		upgradePath = utils.ExpandHome(upgradePath)
-	}
-	// checks
-	if useCustomAvalanchegoVersion != "" && (useLatestAvalanchegoReleaseVersion || useLatestAvalanchegoPreReleaseVersion) {
-		return fmt.Errorf("specify either --custom-avalanchego-version or --latest-avalanchego-version")
-	}
-	if avalanchegoBinaryPath != "" && (useLatestAvalanchegoReleaseVersion || useLatestAvalanchegoPreReleaseVersion || useCustomAvalanchegoVersion != "") {
-		return fmt.Errorf("specify either --avalanchego-path or --latest-avalanchego-version or --custom-avalanchego-version")
-	}
-	if useEtnaDevnet && (globalNetworkFlags.UseDevnet || globalNetworkFlags.UseFuji) {
-		return fmt.Errorf("etna devnet can only be used with devnet")
-	}
-	if useEtnaDevnet && genesisPath != "" {
-		return fmt.Errorf("etna devnet uses predefined genesis file")
-	}
-	if useEtnaDevnet && upgradePath != "" {
-		return fmt.Errorf("etna devnet uses predefined upgrade file")
-	}
-	if useEtnaDevnet && (len(bootstrapIDs) != 0 || len(bootstrapIPs) != 0) {
-		return fmt.Errorf("etna devnet uses predefined bootstrap configuration")
-	}
-	if len(bootstrapIDs) != len(bootstrapIPs) {
-		return fmt.Errorf("number of bootstrap IDs and bootstrap IP:port pairs must be equal")
-	}
-	if genesisPath != "" && !utils.FileExists(genesisPath) {
-		return fmt.Errorf("genesis file %s does not exist", genesisPath)
-	}
-	if upgradePath != "" && !utils.FileExists(upgradePath) {
-		return fmt.Errorf("upgrade file %s does not exist", upgradePath)
-	}
-	return nil
-}
-
-func localClusterDataExists(clusterName string) bool {
-	rootDir := app.GetLocalDir(clusterName)
-	return utils.FileExists(filepath.Join(rootDir, "state.json"))
-}
-
 func localStartNode(_ *cobra.Command, args []string) error {
-	var err error
 	clusterName := args[0]
-	network := models.UndefinedNetwork
-
-	// check if this is existing cluster
-	rootDir := app.GetLocalDir(clusterName)
-	pluginDir := filepath.Join(rootDir, "node1", "plugins")
-	// make sure rootDir exists
-	if err := os.MkdirAll(rootDir, 0o700); err != nil {
-		return fmt.Errorf("could not create root directory %s: %w", rootDir, err)
+	anrSettings := node.ANRSettings{
+		GenesisPath:          genesisPath,
+		UpgradePath:          upgradePath,
+		BootstrapIDs:         bootstrapIDs,
+		BootstrapIPs:         bootstrapIPs,
+		StakingSignerKeyPath: stakingTLSKeyPath,
+		StakingCertKeyPath:   stakingCertKeyPath,
+		StakingTLSKeyPath:    stakingTLSKeyPath,
 	}
-	// make sure pluginDir exists
-	if err := os.MkdirAll(pluginDir, 0o700); err != nil {
-		return fmt.Errorf("could not create plugin directory %s: %w", pluginDir, err)
+	avaGoVersionSetting := node.AvalancheGoVersionSettings{
+		UseCustomAvalanchegoVersion:           useCustomAvalanchegoVersion,
+		UseLatestAvalanchegoPreReleaseVersion: useLatestAvalanchegoPreReleaseVersion,
+		UseLatestAvalanchegoReleaseVersion:    useLatestAvalanchegoReleaseVersion,
+		UseAvalanchegoVersionFromSubnet:       useAvalanchegoVersionFromSubnet,
 	}
-	ctx, cancel := utils.GetANRContext()
-	defer cancel()
-
-	// starts server
-	avalancheGoVersion := "latest"
-	if avalanchegoBinaryPath == "" {
-		avalancheGoVersion, err = getAvalancheGoVersion()
-		if err != nil {
-			return err
-		} else {
-			ux.Logger.PrintToUser("Using AvalancheGo version: %s", avalancheGoVersion)
-		}
-	}
-	serverLogPath := filepath.Join(rootDir, "server.log")
-	sd := subnet.NewLocalDeployer(app, avalancheGoVersion, avalanchegoBinaryPath, "")
-	if err := sd.StartServer(
-		constants.ServerRunFileLocalClusterPrefix,
-		binutils.LocalClusterGRPCServerPort,
-		binutils.LocalClusterGRPCGatewayPort,
-		rootDir,
-		serverLogPath,
-	); err != nil {
-		return err
-	}
-	_, avalancheGoBinPath, err := sd.SetupLocalEnv()
-	if err != nil {
-		return err
-	}
-	cli, err := binutils.NewGRPCClientWithEndpoint(binutils.LocalClusterGRPCServerEndpoint)
-	if err != nil {
-		return err
-	}
-	alreadyBootstrapped, err := localnet.CheckNetworkIsAlreadyBootstrapped(ctx, cli)
-	if err != nil {
-		return err
-	}
-	if alreadyBootstrapped {
-		ux.Logger.PrintToUser("")
-		ux.Logger.PrintToUser("A local cluster is already executing")
-		ux.Logger.PrintToUser("please stop it by calling 'node local stop'")
-		return nil
-	}
-
-	if localClusterDataExists(clusterName) {
-		ux.Logger.GreenCheckmarkToUser("Local cluster %s found. Booting up...", clusterName)
-		loadSnapshotOpts := []client.OpOption{
-			client.WithReassignPortsIfUsed(true),
-			client.WithPluginDir(pluginDir),
-			client.WithSnapshotPath(rootDir),
-		}
-		// load snapshot for existing network
-		if _, err := cli.LoadSnapshot(
-			ctx,
-			clusterName,
-			true, // in-place
-			loadSnapshotOpts...,
-		); err != nil {
-			return fmt.Errorf("failed to load snapshot: %w", err)
-		}
-	} else {
-		ux.Logger.GreenCheckmarkToUser("Local cluster %s not found. Creating...", clusterName)
-		if useEtnaDevnet {
-			network = models.NewNetwork(
-				models.Devnet,
-				constants.EtnaDevnetNetworkID,
-				constants.EtnaDevnetEndpoint,
-				clusterName,
-			)
-		} else {
-			network, err = networkoptions.GetNetworkFromCmdLineFlags(
-				app,
-				"",
-				globalNetworkFlags,
-				false,
-				true,
-				createSupportedNetworkOptions,
-				"",
-			)
-			if err != nil {
-				return err
-			}
-		}
-		if err := preLocalChecks(clusterName); err != nil {
-			return err
-		}
-		if useEtnaDevnet {
-			bootstrapIDs = constants.EtnaDevnetBootstrapNodeIDs
-			bootstrapIPs = constants.EtnaDevnetBootstrapIPs
-			// prepare genesis and upgrade files for anr
-			genesisFile, err := os.CreateTemp("", "etna_devnet_genesis")
-			if err != nil {
-				return fmt.Errorf("could not create save Etna Devnet genesis file: %w", err)
-			}
-			if _, err := genesisFile.Write(constants.EtnaDevnetGenesisData); err != nil {
-				return fmt.Errorf("could not write Etna Devnet genesis data: %w", err)
-			}
-			if err := genesisFile.Close(); err != nil {
-				return fmt.Errorf("could not close Etna Devnet genesis file: %w", err)
-			}
-			genesisPath = genesisFile.Name()
-			defer os.Remove(genesisPath)
-
-			upgradeFile, err := os.CreateTemp("", "etna_devnet_upgrade")
-			if err != nil {
-				return fmt.Errorf("could not create save Etna Devnet upgrade file: %w", err)
-			}
-			if _, err := upgradeFile.Write(constants.EtnaDevnetUpgradeData); err != nil {
-				return fmt.Errorf("could not write Etna Devnet upgrade data: %w", err)
-			}
-			upgradePath = upgradeFile.Name()
-			if err := upgradeFile.Close(); err != nil {
-				return fmt.Errorf("could not close Etna Devnet upgrade file: %w", err)
-			}
-			defer os.Remove(upgradePath)
-		}
-
-		if stakingTLSKeyPath != "" && stakingCertKeyPath != "" && stakingSignerKeyPath != "" {
-			if err := os.MkdirAll(filepath.Join(rootDir, "node1", "staking"), 0o700); err != nil {
-				return fmt.Errorf("could not create root directory %s: %w", rootDir, err)
-			}
-			if err := utils.FileCopy(stakingTLSKeyPath, filepath.Join(rootDir, "node1", "staking", "staker.key")); err != nil {
-				return err
-			}
-			if err := utils.FileCopy(stakingCertKeyPath, filepath.Join(rootDir, "node1", "staking", "staker.crt")); err != nil {
-				return err
-			}
-			if err := utils.FileCopy(stakingSignerKeyPath, filepath.Join(rootDir, "node1", "staking", "signer.key")); err != nil {
-				return err
-			}
-		}
-
-		anrOpts := []client.OpOption{
-			client.WithNumNodes(1),
-			client.WithNetworkID(network.ID),
-			client.WithExecPath(avalancheGoBinPath),
-			client.WithRootDataDir(rootDir),
-			client.WithReassignPortsIfUsed(true),
-			client.WithPluginDir(pluginDir),
-			client.WithFreshStakingIds(true),
-			client.WithZeroIP(false),
-		}
-		if genesisPath != "" && utils.FileExists(genesisPath) {
-			anrOpts = append(anrOpts, client.WithGenesisPath(genesisPath))
-		}
-		if upgradePath != "" && utils.FileExists(upgradePath) {
-			anrOpts = append(anrOpts, client.WithUpgradePath(upgradePath))
-		}
-		if bootstrapIDs != nil {
-			anrOpts = append(anrOpts, client.WithBootstrapNodeIDs(bootstrapIDs))
-		}
-		if bootstrapIPs != nil {
-			anrOpts = append(anrOpts, client.WithBootstrapNodeIPPortPairs(bootstrapIPs))
-		}
-
-		ux.Logger.PrintToUser("Starting local avalanchego node using root: %s ...", rootDir)
-		spinSession := ux.NewUserSpinner()
-		spinner := spinSession.SpinToUser("Booting Network. Wait until healthy...")
-		if _, err := cli.Start(ctx, avalancheGoBinPath, anrOpts...); err != nil {
-			ux.SpinFailWithError(spinner, "", err)
-			localDestroyNode(nil, []string{clusterName})
-			return fmt.Errorf("failed to start local avalanchego: %w", err)
-		}
-		ux.SpinComplete(spinner)
-		// save cluster config for the new local cluster
-		if err := addLocalClusterConfig(network); err != nil {
-			return err
-		}
-	}
-
-	ux.Logger.GreenCheckmarkToUser("Avalanchego started and ready to use from %s", rootDir)
-	ux.Logger.PrintToUser("")
-	ux.Logger.PrintToUser("Node logs directory: %s/node1/logs", rootDir)
-	ux.Logger.PrintToUser("")
-	ux.Logger.PrintToUser("Network ready to use.")
-	ux.Logger.PrintToUser("")
-
-	status, err := cli.Status(ctx)
-	if err != nil {
-		return err
-	}
-	for _, nodeInfo := range status.ClusterInfo.NodeInfos {
-		ux.Logger.PrintToUser("URI: %s", nodeInfo.Uri)
-		ux.Logger.PrintToUser("NodeID: %s", nodeInfo.Id)
-		ux.Logger.PrintToUser("")
-	}
-
-	return nil
+	return node.StartLocalNode(app, clusterName, useEtnaDevnet, avalanchegoBinaryPath, anrSettings, avaGoVersionSetting, globalNetworkFlags, createSupportedNetworkOptions)
 }
 
 func localStopNode(_ *cobra.Command, _ []string) error {
-	cli, err := binutils.NewGRPCClientWithEndpoint(
-		binutils.LocalClusterGRPCServerEndpoint,
-		binutils.WithAvoidRPCVersionCheck(true),
-		binutils.WithDialTimeout(constants.FastGRPCDialTimeout),
-	)
-	if err != nil {
-		return err
-	}
-	ctx, cancel := utils.GetANRContext()
-	defer cancel()
-	bootstrapped, err := localnet.CheckNetworkIsAlreadyBootstrapped(ctx, cli)
-	if err != nil {
-		return err
-	}
-	if bootstrapped {
-		if _, err = cli.Stop(ctx); err != nil {
-			return fmt.Errorf("failed to stop avalanchego: %w", err)
-		}
-	}
-	if err := binutils.KillgRPCServerProcess(
-		app,
-		binutils.LocalClusterGRPCServerEndpoint,
-		constants.ServerRunFileLocalClusterPrefix,
-	); err != nil {
-		return err
-	}
-	ux.Logger.GreenCheckmarkToUser("avalanchego stopped")
-	return nil
+	return node.StopLocalNode(app)
 }
 
 func localDestroyNode(_ *cobra.Command, args []string) error {
 	clusterName := args[0]
-
-	localStopNode(nil, nil)
-
-	rootDir := app.GetLocalDir(clusterName)
-	if err := os.RemoveAll(rootDir); err != nil {
-		return err
-	}
-
-	if ok, err := checkClusterIsLocal(clusterName); err != nil || !ok {
-		return fmt.Errorf("local cluster %q not found", clusterName)
-	}
-
-	clustersConfig, err := app.LoadClustersConfig()
-	if err != nil {
-		return err
-	}
-	delete(clustersConfig.Clusters, clusterName)
-	if err := app.WriteClustersConfigFile(&clustersConfig); err != nil {
-		return err
-	}
-
-	ux.Logger.GreenCheckmarkToUser("Local node %s cleaned up.", clusterName)
-	return nil
-}
-
-func addLocalClusterConfig(network models.Network) error {
-	clusterName := network.ClusterName
-	clustersConfig, err := app.LoadClustersConfig()
-	if err != nil {
-		return err
-	}
-	clusterConfig := clustersConfig.Clusters[clusterName]
-	clusterConfig.Local = true
-	clusterConfig.Network = network
-	clustersConfig.Clusters[clusterName] = clusterConfig
-	return app.WriteClustersConfigFile(&clustersConfig)
-}
-
-func checkClusterIsLocal(clusterName string) (bool, error) {
-	clustersConfig, err := app.GetClustersConfig()
-	if err != nil {
-		return false, err
-	}
-	clusterConf, ok := clustersConfig.Clusters[clusterName]
-	return ok && clusterConf.Local, nil
+	return node.DestroyLocalNode(app, clusterName)
 }
 
 func localTrack(_ *cobra.Command, args []string) error {
@@ -465,12 +146,4 @@ func localTrack(_ *cobra.Command, args []string) error {
 func notImplementedForLocal(what string) error {
 	ux.Logger.PrintToUser("Unsupported cmd: %s is not supported by local clusters", logging.LightBlue.Wrap(what))
 	return nil
-}
-
-func getRPCEndpoint(endpoint string, blockchainID string) string {
-	return models.NewDevnetNetwork(endpoint, 0).BlockchainEndpoint(blockchainID)
-}
-
-func getWSEndpoint(endpoint string, blockchainID string) string {
-	return models.NewDevnetNetwork(endpoint, 0).BlockchainWSEndpoint(blockchainID)
 }

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -808,7 +808,7 @@ func (app *Avalanche) GetClusterConfig(clusterName string) (models.ClusterConfig
 		return models.ClusterConfig{}, err
 	}
 	if !exists {
-		return models.ClusterConfig{}, fmt.Errorf("cluster %q does not exists", clusterName)
+		return models.ClusterConfig{}, fmt.Errorf("cluster %q does not exist", clusterName)
 	}
 	clustersConfig, err := app.LoadClustersConfig()
 	if err != nil {

--- a/pkg/keychain/keychain.go
+++ b/pkg/keychain/keychain.go
@@ -120,7 +120,6 @@ func GetKeychainFromCmdLineFlags(
 	if len(ledgerAddresses) > 0 {
 		useLedger = true
 	}
-
 	// check mutually exclusive flags
 	if !flags.EnsureMutuallyExclusive([]bool{useLedger, useEwoq, keyName != ""}) {
 		return nil, ErrMutuallyExlusiveKeySource
@@ -152,6 +151,15 @@ func GetKeychainFromCmdLineFlags(
 		if !useLedger && keyName == "" {
 			var err error
 			useLedger, keyName, err = prompts.GetKeyOrLedger(app.Prompt, keychainGoal, app.GetKeyDir(), false)
+			if err != nil {
+				return nil, err
+			}
+		}
+	case network.Kind == models.EtnaDevnet:
+		// prompt the user if no key source was provided
+		if !useEwoq && !useLedger && keyName == "" {
+			var err error
+			useLedger, keyName, err = prompts.GetKeyOrLedger(app.Prompt, keychainGoal, app.GetKeyDir(), true)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/models/network.go
+++ b/pkg/models/network.go
@@ -20,6 +20,7 @@ const (
 	Fuji
 	Local
 	Devnet
+	EtnaDevnet
 )
 
 func (nk NetworkKind) String() string {
@@ -32,6 +33,8 @@ func (nk NetworkKind) String() string {
 		return "Local Network"
 	case Devnet:
 		return "Devnet"
+	case EtnaDevnet:
+		return "Etna Devnet"
 	}
 	return "invalid network"
 }
@@ -54,10 +57,6 @@ func NewNetwork(kind NetworkKind, id uint32, endpoint string, clusterName string
 	}
 }
 
-func (n Network) IsUndefined() bool {
-	return n.Kind == Undefined
-}
-
 func NewLocalNetwork() Network {
 	return NewNetwork(Local, constants.LocalNetworkID, constants.LocalAPIEndpoint, "")
 }
@@ -70,6 +69,10 @@ func NewDevnetNetwork(endpoint string, id uint32) Network {
 		id = constants.DevnetNetworkID
 	}
 	return NewNetwork(Devnet, id, endpoint, "")
+}
+
+func NewEtnaDevnetNetwork() Network {
+	return NewNetwork(EtnaDevnet, constants.EtnaDevnetNetworkID, constants.EtnaDevnetEndpoint, "")
 }
 
 func NewFujiNetwork() Network {
@@ -101,7 +104,7 @@ func (n Network) StandardPublicEndpoint() bool {
 }
 
 func (n Network) Name() string {
-	if n.ClusterName != "" && n.Kind == Devnet {
+	if n.ClusterName != "" && (n.Kind == Devnet || n.Kind == EtnaDevnet) {
 		return "Cluster " + n.ClusterName
 	}
 	name := n.Kind.String()
@@ -141,6 +144,8 @@ func (n Network) NetworkIDFlagValue() string {
 	switch n.Kind {
 	case Local:
 		return fmt.Sprintf("network-%d", n.ID)
+	case EtnaDevnet:
+		return fmt.Sprintf("%d", n.ID)
 	case Devnet:
 		return fmt.Sprintf("network-%d", n.ID)
 	case Fuji:
@@ -155,6 +160,8 @@ func (n Network) GenesisParams() *genesis.Params {
 	switch n.Kind {
 	case Local:
 		return &genesis.LocalParams
+	case EtnaDevnet:
+		return &genesis.LocalParams // use LocalParams for now
 	case Devnet:
 		return &genesis.LocalParams
 	case Fuji:

--- a/pkg/node/helper.go
+++ b/pkg/node/helper.go
@@ -4,7 +4,11 @@ package node
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"github.com/ava-labs/avalanche-cli/pkg/binutils"
+	"github.com/ava-labs/avalanche-cli/pkg/subnet"
+	"github.com/ava-labs/avalanche-cli/pkg/vm"
 	"sync"
 	"time"
 
@@ -23,6 +27,23 @@ const (
 	HealthCheckPoolTime = 60 * time.Second
 	HealthCheckTimeout  = 3 * time.Minute
 )
+
+type AvalancheGoVersionSettings struct {
+	UseCustomAvalanchegoVersion           string
+	UseLatestAvalanchegoReleaseVersion    bool
+	UseLatestAvalanchegoPreReleaseVersion bool
+	UseAvalanchegoVersionFromSubnet       string
+}
+
+type ANRSettings struct {
+	GenesisPath          string
+	UpgradePath          string
+	BootstrapIDs         []string
+	BootstrapIPs         []string
+	StakingTLSKeyPath    string
+	StakingCertKeyPath   string
+	StakingSignerKeyPath string
+}
 
 func AuthorizedAccessFromSettings(app *application.Avalanche) bool {
 	return app.Conf.GetConfigBoolValue(constants.ConfigAuthorizeCloudAccessKey)
@@ -295,4 +316,119 @@ func GetClusterNameFromList(app *application.Avalanche) (string, error) {
 		return "", err
 	}
 	return clusterName, nil
+}
+
+// GetAvalancheGoVersion asks users whether they want to install the newest Avalanche Go version
+// or if they want to use the newest Avalanche Go Version that is still compatible with Subnet EVM
+// version of their choice
+func GetAvalancheGoVersion(app *application.Avalanche, avagoVersion AvalancheGoVersionSettings) (string, error) {
+	// skip this logic if custom-avalanchego-version flag is set
+	if avagoVersion.UseCustomAvalanchegoVersion != "" {
+		return avagoVersion.UseCustomAvalanchegoVersion, nil
+	}
+	latestReleaseVersion, err := app.Downloader.GetLatestReleaseVersion(binutils.GetGithubLatestReleaseURL(
+		constants.AvaLabsOrg,
+		constants.AvalancheGoRepoName,
+	))
+	if err != nil {
+		return "", err
+	}
+	latestPreReleaseVersion, err := app.Downloader.GetLatestPreReleaseVersion(
+		constants.AvaLabsOrg,
+		constants.AvalancheGoRepoName,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	if !avagoVersion.UseLatestAvalanchegoReleaseVersion && !avagoVersion.UseLatestAvalanchegoPreReleaseVersion && avagoVersion.UseCustomAvalanchegoVersion == "" && avagoVersion.UseAvalanchegoVersionFromSubnet == "" {
+		avagoVersion, err = promptAvalancheGoVersionChoice(app, latestReleaseVersion, latestPreReleaseVersion)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	var version string
+	switch {
+	case avagoVersion.UseLatestAvalanchegoReleaseVersion:
+		version = latestReleaseVersion
+	case avagoVersion.UseLatestAvalanchegoPreReleaseVersion:
+		version = latestPreReleaseVersion
+	case avagoVersion.UseCustomAvalanchegoVersion != "":
+		version = avagoVersion.UseCustomAvalanchegoVersion
+	case avagoVersion.UseAvalanchegoVersionFromSubnet != "":
+		sc, err := app.LoadSidecar(avagoVersion.UseAvalanchegoVersionFromSubnet)
+		if err != nil {
+			return "", err
+		}
+		version, err = GetLatestAvagoVersionForRPC(app, sc.RPCVersion, latestPreReleaseVersion)
+		if err != nil {
+			return "", err
+		}
+	}
+	return version, nil
+}
+
+// promptAvalancheGoVersionChoice sets flags for either using the latest Avalanche Go
+// version or using the latest Avalanche Go version that is still compatible with the subnet that user
+// wants the cloud server to track
+func promptAvalancheGoVersionChoice(app *application.Avalanche, latestReleaseVersion string, latestPreReleaseVersion string) (AvalancheGoVersionSettings, error) {
+	versionComments := map[string]string{
+		"v1.11.0-fuji": " (recommended for fuji durango)",
+	}
+	latestReleaseVersionOption := "Use latest Avalanche Go Release Version" + versionComments[latestReleaseVersion]
+	latestPreReleaseVersionOption := "Use latest Avalanche Go Pre-release Version" + versionComments[latestPreReleaseVersion]
+	subnetBasedVersionOption := "Use the deployed Subnet's VM version that the node will be validating"
+	customOption := "Custom"
+
+	txt := "What version of Avalanche Go would you like to install in the node?"
+	versionOptions := []string{latestReleaseVersionOption, subnetBasedVersionOption, customOption}
+	if latestPreReleaseVersion != latestReleaseVersion {
+		versionOptions = []string{latestPreReleaseVersionOption, latestReleaseVersionOption, subnetBasedVersionOption, customOption}
+	}
+	versionOption, err := app.Prompt.CaptureList(txt, versionOptions)
+	if err != nil {
+		return AvalancheGoVersionSettings{}, err
+	}
+
+	switch versionOption {
+	case latestReleaseVersionOption:
+		return AvalancheGoVersionSettings{UseLatestAvalanchegoReleaseVersion: true}, nil
+	case latestPreReleaseVersionOption:
+		return AvalancheGoVersionSettings{UseLatestAvalanchegoPreReleaseVersion: true}, nil
+	case customOption:
+		useCustomAvalanchegoVersion, err := app.Prompt.CaptureVersion("Which version of AvalancheGo would you like to install? (Use format v1.10.13)")
+		if err != nil {
+			return AvalancheGoVersionSettings{}, err
+		}
+		return AvalancheGoVersionSettings{UseCustomAvalanchegoVersion: useCustomAvalanchegoVersion}, nil
+	default:
+		useAvalanchegoVersionFromSubnet := ""
+		for {
+			useAvalanchegoVersionFromSubnet, err = app.Prompt.CaptureString("Which Subnet would you like to use to choose the avalanche go version?")
+			if err != nil {
+				return AvalancheGoVersionSettings{}, err
+			}
+			_, err = subnet.ValidateSubnetNameAndGetChains(app, []string{useAvalanchegoVersionFromSubnet})
+			if err == nil {
+				break
+			}
+			ux.Logger.PrintToUser(fmt.Sprintf("no subnet named %s found", useAvalanchegoVersionFromSubnet))
+		}
+		return AvalancheGoVersionSettings{UseAvalanchegoVersionFromSubnet: useAvalanchegoVersionFromSubnet}, nil
+
+	}
+}
+
+func GetLatestAvagoVersionForRPC(app *application.Avalanche, configuredRPCVersion int, latestPreReleaseVersion string) (string, error) {
+	desiredAvagoVersion, err := vm.GetLatestAvalancheGoByProtocolVersion(
+		app, configuredRPCVersion, constants.AvalancheGoCompatibilityURL)
+	if errors.Is(err, vm.ErrNoAvagoVersion) {
+		ux.Logger.PrintToUser("No Avago version found for subnet. Defaulting to latest pre-release version")
+		return latestPreReleaseVersion, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return desiredAvagoVersion, nil
 }

--- a/pkg/node/local.go
+++ b/pkg/node/local.go
@@ -1,0 +1,449 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+package node
+
+import (
+	"fmt"
+	"github.com/ava-labs/avalanche-cli/pkg/application"
+	"github.com/ava-labs/avalanche-cli/pkg/binutils"
+	"github.com/ava-labs/avalanche-cli/pkg/constants"
+	"github.com/ava-labs/avalanche-cli/pkg/localnet"
+	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
+	"github.com/ava-labs/avalanche-cli/pkg/subnet"
+	"github.com/ava-labs/avalanche-cli/pkg/utils"
+	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	"github.com/ava-labs/avalanche-network-runner/client"
+	anrutils "github.com/ava-labs/avalanche-network-runner/utils"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"os"
+	"path/filepath"
+)
+
+func TrackSubnetWithLocalMachine(app *application.Avalanche, clusterName, blockchainName string) error {
+	if ok, err := checkClusterIsLocal(app, clusterName); err != nil || !ok {
+		return fmt.Errorf("local node %q is not found", clusterName)
+	}
+	sc, err := app.LoadSidecar(blockchainName)
+	if err != nil {
+		return err
+	}
+	clustersConfig, err := app.LoadClustersConfig()
+	if err != nil {
+		return err
+	}
+	clusterConfig := clustersConfig.Clusters[clusterName]
+	network := clusterConfig.Network
+	if sc.Networks[network.Name()].BlockchainID == ids.Empty {
+		return fmt.Errorf("blockchain %s has not been deployed to %s", blockchainName, network.Name())
+	}
+	subnetID := sc.Networks[network.Name()].SubnetID
+	blockchainID := sc.Networks[network.Name()].BlockchainID
+	vmID, err := anrutils.VMID(blockchainName)
+	if err != nil {
+		return fmt.Errorf("failed to create VM ID from %s: %w", blockchainName, err)
+	}
+	var vmBin string
+	switch sc.VM {
+	case models.SubnetEvm:
+		_, vmBin, err = binutils.SetupSubnetEVM(app, sc.VMVersion)
+		if err != nil {
+			return fmt.Errorf("failed to install subnet-evm: %w", err)
+		}
+	case models.CustomVM:
+		vmBin = binutils.SetupCustomBin(app, blockchainName)
+	default:
+		return fmt.Errorf("unknown vm: %s", sc.VM)
+	}
+	rootDir := app.GetLocalDir(clusterName)
+	pluginPath := filepath.Join(rootDir, "node1", "plugins", vmID.String())
+	if err := utils.FileCopy(vmBin, pluginPath); err != nil {
+		return err
+	}
+	if err := os.Chmod(pluginPath, constants.DefaultPerms755); err != nil {
+		return err
+	}
+	if app.ChainConfigExists(blockchainName) {
+		inputChainConfigPath := app.GetChainConfigPath(blockchainName)
+		outputChainConfigPath := filepath.Join(rootDir, "node1", "configs", "chains", blockchainID.String(), "config.json")
+		if err := os.MkdirAll(filepath.Dir(outputChainConfigPath), 0o700); err != nil {
+			return fmt.Errorf("could not create chain conf directory %s: %w", filepath.Dir(outputChainConfigPath), err)
+		}
+		if err := utils.FileCopy(inputChainConfigPath, outputChainConfigPath); err != nil {
+			return err
+		}
+	}
+
+	cli, err := binutils.NewGRPCClientWithEndpoint(
+		binutils.LocalClusterGRPCServerEndpoint,
+		binutils.WithAvoidRPCVersionCheck(true),
+		binutils.WithDialTimeout(constants.FastGRPCDialTimeout),
+	)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := utils.GetANRContext()
+	defer cancel()
+	status, err := cli.Status(ctx)
+	if err != nil {
+		return err
+	}
+	publicEndpoints := []string{}
+	for _, nodeInfo := range status.ClusterInfo.NodeInfos {
+		if _, err := cli.RestartNode(ctx, nodeInfo.Name, client.WithWhitelistedSubnets(subnetID.String())); err != nil {
+			return err
+		}
+		publicEndpoints = append(publicEndpoints, nodeInfo.Uri)
+	}
+	networkInfo := sc.Networks[network.Name()]
+	rpcEndpoints := set.Of(networkInfo.RPCEndpoints...)
+	wsEndpoints := set.Of(networkInfo.WSEndpoints...)
+	for _, publicEndpoint := range publicEndpoints {
+		rpcEndpoints.Add(getRPCEndpoint(publicEndpoint, networkInfo.BlockchainID.String()))
+		wsEndpoints.Add(getWSEndpoint(publicEndpoint, networkInfo.BlockchainID.String()))
+	}
+	networkInfo.RPCEndpoints = rpcEndpoints.List()
+	networkInfo.WSEndpoints = wsEndpoints.List()
+	sc.Networks[clusterConfig.Network.Name()] = networkInfo
+	if err := app.UpdateSidecar(&sc); err != nil {
+		return err
+	}
+	ux.Logger.GreenCheckmarkToUser("%s successfully tracking %s", clusterName, blockchainName)
+	return nil
+}
+
+func checkClusterIsLocal(app *application.Avalanche, clusterName string) (bool, error) {
+	clustersConfig, err := app.GetClustersConfig()
+	if err != nil {
+		return false, err
+	}
+	clusterConf, ok := clustersConfig.Clusters[clusterName]
+	return ok && clusterConf.Local, nil
+}
+
+func StartLocalNode(app *application.Avalanche, clusterName string, useEtnaDevnet bool, avalanchegoBinaryPath string, anrSettings ANRSettings, avaGoVersionSetting AvalancheGoVersionSettings, globalNetworkFlags networkoptions.NetworkFlags, createSupportedNetworkOptions []networkoptions.NetworkOption) error {
+	network := models.UndefinedNetwork
+	var err error
+
+	// check if this is existing cluster
+	rootDir := app.GetLocalDir(clusterName)
+	pluginDir := filepath.Join(rootDir, "node1", "plugins")
+	// make sure rootDir exists
+	if err := os.MkdirAll(rootDir, 0o700); err != nil {
+		return fmt.Errorf("could not create root directory %s: %w", rootDir, err)
+	}
+	// make sure pluginDir exists
+	if err := os.MkdirAll(pluginDir, 0o700); err != nil {
+		return fmt.Errorf("could not create plugin directory %s: %w", pluginDir, err)
+	}
+	ctx, cancel := utils.GetANRContext()
+	defer cancel()
+
+	// starts server
+	avalancheGoVersion := "latest"
+	if avalanchegoBinaryPath == "" {
+		avalancheGoVersion, err = GetAvalancheGoVersion(app, avaGoVersionSetting)
+		if err != nil {
+			return err
+		} else {
+			ux.Logger.PrintToUser("Using AvalancheGo version: %s", avalancheGoVersion)
+		}
+	}
+	serverLogPath := filepath.Join(rootDir, "server.log")
+	sd := subnet.NewLocalDeployer(app, avalancheGoVersion, avalanchegoBinaryPath, "")
+	if err := sd.StartServer(
+		constants.ServerRunFileLocalClusterPrefix,
+		binutils.LocalClusterGRPCServerPort,
+		binutils.LocalClusterGRPCGatewayPort,
+		rootDir,
+		serverLogPath,
+	); err != nil {
+		return err
+	}
+	_, avalancheGoBinPath, err := sd.SetupLocalEnv()
+	if err != nil {
+		return err
+	}
+	cli, err := binutils.NewGRPCClientWithEndpoint(binutils.LocalClusterGRPCServerEndpoint)
+	if err != nil {
+		return err
+	}
+	alreadyBootstrapped, err := localnet.CheckNetworkIsAlreadyBootstrapped(ctx, cli)
+	if err != nil {
+		return err
+	}
+	if alreadyBootstrapped {
+		ux.Logger.PrintToUser("")
+		ux.Logger.PrintToUser("A local cluster is already executing")
+		ux.Logger.PrintToUser("please stop it by calling 'node local stop'")
+		return nil
+	}
+
+	if localClusterDataExists(app, clusterName) {
+		ux.Logger.GreenCheckmarkToUser("Local cluster %s found. Booting up...", clusterName)
+		loadSnapshotOpts := []client.OpOption{
+			client.WithReassignPortsIfUsed(true),
+			client.WithPluginDir(pluginDir),
+			client.WithSnapshotPath(rootDir),
+		}
+		// load snapshot for existing network
+		if _, err := cli.LoadSnapshot(
+			ctx,
+			clusterName,
+			true, // in-place
+			loadSnapshotOpts...,
+		); err != nil {
+			return fmt.Errorf("failed to load snapshot: %w", err)
+		}
+	} else {
+		ux.Logger.GreenCheckmarkToUser("Local cluster %s not found. Creating...", clusterName)
+		if useEtnaDevnet {
+			network = models.NewNetwork(
+				models.Devnet,
+				constants.EtnaDevnetNetworkID,
+				constants.EtnaDevnetEndpoint,
+				clusterName,
+			)
+		} else {
+			network, err = networkoptions.GetNetworkFromCmdLineFlags(
+				app,
+				"",
+				globalNetworkFlags,
+				false,
+				true,
+				createSupportedNetworkOptions,
+				"",
+			)
+			if err != nil {
+				return err
+			}
+		}
+		if err := preLocalChecks(app, clusterName, anrSettings, avaGoVersionSetting, avalanchegoBinaryPath, useEtnaDevnet, globalNetworkFlags); err != nil {
+			return err
+		}
+		if useEtnaDevnet {
+			anrSettings.BootstrapIDs = constants.EtnaDevnetBootstrapNodeIDs
+			anrSettings.BootstrapIPs = constants.EtnaDevnetBootstrapIPs
+			// prepare genesis and upgrade files for anr
+			genesisFile, err := os.CreateTemp("", "etna_devnet_genesis")
+			if err != nil {
+				return fmt.Errorf("could not create save Etna Devnet genesis file: %w", err)
+			}
+			if _, err := genesisFile.Write(constants.EtnaDevnetGenesisData); err != nil {
+				return fmt.Errorf("could not write Etna Devnet genesis data: %w", err)
+			}
+			if err := genesisFile.Close(); err != nil {
+				return fmt.Errorf("could not close Etna Devnet genesis file: %w", err)
+			}
+			anrSettings.GenesisPath = genesisFile.Name()
+			defer os.Remove(anrSettings.GenesisPath)
+
+			upgradeFile, err := os.CreateTemp("", "etna_devnet_upgrade")
+			if err != nil {
+				return fmt.Errorf("could not create save Etna Devnet upgrade file: %w", err)
+			}
+			if _, err := upgradeFile.Write(constants.EtnaDevnetUpgradeData); err != nil {
+				return fmt.Errorf("could not write Etna Devnet upgrade data: %w", err)
+			}
+			anrSettings.UpgradePath = upgradeFile.Name()
+			if err := upgradeFile.Close(); err != nil {
+				return fmt.Errorf("could not close Etna Devnet upgrade file: %w", err)
+			}
+			defer os.Remove(anrSettings.UpgradePath)
+		}
+
+		if anrSettings.StakingTLSKeyPath != "" && anrSettings.StakingCertKeyPath != "" && anrSettings.StakingSignerKeyPath != "" {
+			if err := os.MkdirAll(filepath.Join(rootDir, "node1", "staking"), 0o700); err != nil {
+				return fmt.Errorf("could not create root directory %s: %w", rootDir, err)
+			}
+			if err := utils.FileCopy(anrSettings.StakingTLSKeyPath, filepath.Join(rootDir, "node1", "staking", "staker.key")); err != nil {
+				return err
+			}
+			if err := utils.FileCopy(anrSettings.StakingCertKeyPath, filepath.Join(rootDir, "node1", "staking", "staker.crt")); err != nil {
+				return err
+			}
+			if err := utils.FileCopy(anrSettings.StakingSignerKeyPath, filepath.Join(rootDir, "node1", "staking", "signer.key")); err != nil {
+				return err
+			}
+		}
+
+		anrOpts := []client.OpOption{
+			client.WithNumNodes(1),
+			client.WithNetworkID(network.ID),
+			client.WithExecPath(avalancheGoBinPath),
+			client.WithRootDataDir(rootDir),
+			client.WithReassignPortsIfUsed(true),
+			client.WithPluginDir(pluginDir),
+			client.WithFreshStakingIds(true),
+			client.WithZeroIP(false),
+		}
+		if anrSettings.GenesisPath != "" && utils.FileExists(anrSettings.GenesisPath) {
+			anrOpts = append(anrOpts, client.WithGenesisPath(anrSettings.GenesisPath))
+		}
+		if anrSettings.UpgradePath != "" && utils.FileExists(anrSettings.UpgradePath) {
+			anrOpts = append(anrOpts, client.WithUpgradePath(anrSettings.UpgradePath))
+		}
+		if anrSettings.BootstrapIDs != nil {
+			anrOpts = append(anrOpts, client.WithBootstrapNodeIDs(anrSettings.BootstrapIDs))
+		}
+		if anrSettings.BootstrapIPs != nil {
+			anrOpts = append(anrOpts, client.WithBootstrapNodeIPPortPairs(anrSettings.BootstrapIPs))
+		}
+
+		ux.Logger.PrintToUser("Starting local avalanchego node using root: %s ...", rootDir)
+		spinSession := ux.NewUserSpinner()
+		spinner := spinSession.SpinToUser("Booting Network. Wait until healthy...")
+		if _, err := cli.Start(ctx, avalancheGoBinPath, anrOpts...); err != nil {
+			ux.SpinFailWithError(spinner, "", err)
+			DestroyLocalNode(app, clusterName)
+			return fmt.Errorf("failed to start local avalanchego: %w", err)
+		}
+		ux.SpinComplete(spinner)
+		spinSession.Stop()
+		// save cluster config for the new local cluster
+		if err := addLocalClusterConfig(app, network); err != nil {
+			return err
+		}
+	}
+
+	ux.Logger.GreenCheckmarkToUser("Avalanchego started and ready to use from %s", rootDir)
+	ux.Logger.PrintToUser("")
+	ux.Logger.PrintToUser("Node logs directory: %s/node1/logs", rootDir)
+	ux.Logger.PrintToUser("")
+	ux.Logger.PrintToUser("Network ready to use.")
+	ux.Logger.PrintToUser("")
+
+	status, err := cli.Status(ctx)
+	if err != nil {
+		return err
+	}
+	for _, nodeInfo := range status.ClusterInfo.NodeInfos {
+		ux.Logger.PrintToUser("URI: %s", nodeInfo.Uri)
+		ux.Logger.PrintToUser("NodeID: %s", nodeInfo.Id)
+		ux.Logger.PrintToUser("")
+	}
+
+	return nil
+}
+
+func localClusterDataExists(app *application.Avalanche, clusterName string) bool {
+	rootDir := app.GetLocalDir(clusterName)
+	return utils.FileExists(filepath.Join(rootDir, "state.json"))
+}
+
+// stub for now
+func preLocalChecks(app *application.Avalanche, clusterName string, anrSettings ANRSettings, avaGoVersionSettings AvalancheGoVersionSettings, avalanchegoBinaryPath string, useEtnaDevnet bool, globalNetworkFlags networkoptions.NetworkFlags) error {
+	clusterExists, err := CheckClusterExists(app, clusterName)
+	if err != nil {
+		return fmt.Errorf("error checking cluster: %w", err)
+	}
+	if clusterExists {
+		return fmt.Errorf("cluster %q already exists", clusterName)
+	}
+	// expand passed paths
+	if anrSettings.GenesisPath != "" {
+		anrSettings.GenesisPath = utils.ExpandHome(anrSettings.GenesisPath)
+	}
+	if anrSettings.UpgradePath != "" {
+		anrSettings.UpgradePath = utils.ExpandHome(anrSettings.UpgradePath)
+	}
+	// checks
+	if avaGoVersionSettings.UseCustomAvalanchegoVersion != "" && (avaGoVersionSettings.UseLatestAvalanchegoReleaseVersion || avaGoVersionSettings.UseLatestAvalanchegoPreReleaseVersion) {
+		return fmt.Errorf("specify either --custom-avalanchego-version or --latest-avalanchego-version")
+	}
+	if avalanchegoBinaryPath != "" && (avaGoVersionSettings.UseLatestAvalanchegoReleaseVersion || avaGoVersionSettings.UseLatestAvalanchegoPreReleaseVersion || avaGoVersionSettings.UseCustomAvalanchegoVersion != "") {
+		return fmt.Errorf("specify either --avalanchego-path or --latest-avalanchego-version or --custom-avalanchego-version")
+	}
+	if useEtnaDevnet && (globalNetworkFlags.UseDevnet || globalNetworkFlags.UseFuji) {
+		return fmt.Errorf("etna devnet can only be used with devnet")
+	}
+	if useEtnaDevnet && anrSettings.GenesisPath != "" {
+		return fmt.Errorf("etna devnet uses predefined genesis file")
+	}
+	if useEtnaDevnet && anrSettings.UpgradePath != "" {
+		return fmt.Errorf("etna devnet uses predefined upgrade file")
+	}
+	if useEtnaDevnet && (len(anrSettings.BootstrapIDs) != 0 || len(anrSettings.BootstrapIPs) != 0) {
+		return fmt.Errorf("etna devnet uses predefined bootstrap configuration")
+	}
+	if len(anrSettings.BootstrapIDs) != len(anrSettings.BootstrapIPs) {
+		return fmt.Errorf("number of bootstrap IDs and bootstrap IP:port pairs must be equal")
+	}
+	if anrSettings.GenesisPath != "" && !utils.FileExists(anrSettings.GenesisPath) {
+		return fmt.Errorf("genesis file %s does not exist", anrSettings.GenesisPath)
+	}
+	if anrSettings.UpgradePath != "" && !utils.FileExists(anrSettings.UpgradePath) {
+		return fmt.Errorf("upgrade file %s does not exist", anrSettings.UpgradePath)
+	}
+	return nil
+}
+
+func addLocalClusterConfig(app *application.Avalanche, network models.Network) error {
+	clusterName := network.ClusterName
+	clustersConfig, err := app.LoadClustersConfig()
+	if err != nil {
+		return err
+	}
+	clusterConfig := clustersConfig.Clusters[clusterName]
+	clusterConfig.Local = true
+	clusterConfig.Network = network
+	clustersConfig.Clusters[clusterName] = clusterConfig
+	return app.WriteClustersConfigFile(&clustersConfig)
+}
+
+func DestroyLocalNode(app *application.Avalanche, clusterName string) error {
+	StopLocalNode(app)
+
+	rootDir := app.GetLocalDir(clusterName)
+	if err := os.RemoveAll(rootDir); err != nil {
+		return err
+	}
+
+	if ok, err := checkClusterIsLocal(app, clusterName); err != nil || !ok {
+		return fmt.Errorf("local cluster %q not found", clusterName)
+	}
+
+	clustersConfig, err := app.LoadClustersConfig()
+	if err != nil {
+		return err
+	}
+	delete(clustersConfig.Clusters, clusterName)
+	if err := app.WriteClustersConfigFile(&clustersConfig); err != nil {
+		return err
+	}
+
+	ux.Logger.GreenCheckmarkToUser("Local node %s cleaned up.", clusterName)
+	return nil
+}
+
+func StopLocalNode(app *application.Avalanche) error {
+	cli, err := binutils.NewGRPCClientWithEndpoint(
+		binutils.LocalClusterGRPCServerEndpoint,
+		binutils.WithAvoidRPCVersionCheck(true),
+		binutils.WithDialTimeout(constants.FastGRPCDialTimeout),
+	)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := utils.GetANRContext()
+	defer cancel()
+	bootstrapped, err := localnet.CheckNetworkIsAlreadyBootstrapped(ctx, cli)
+	if err != nil {
+		return err
+	}
+	if bootstrapped {
+		if _, err = cli.Stop(ctx); err != nil {
+			return fmt.Errorf("failed to stop avalanchego: %w", err)
+		}
+	}
+	if err := binutils.KillgRPCServerProcess(
+		app,
+		binutils.LocalClusterGRPCServerEndpoint,
+		constants.ServerRunFileLocalClusterPrefix,
+	); err != nil {
+		return err
+	}
+	ux.Logger.GreenCheckmarkToUser("avalanchego stopped")
+	return nil
+}


### PR DESCRIPTION
## Why this should be merged
Integrates using local machine as bootstrap validator into subnet deploy command. 

## How this works
// create the local node connected to etna
go run main.go node local start <EtnaInstanceName> --etna-devnet --avalanchego-path <AVALANCHEGO_PATH>

// create a blockchain conf
go run main.go blockchain create <BlockchainName>

// create subnet+blockchain+convert on the blokchain
go run main.go blockchain deploy <BlockchainName> --cluster <EtnaInstanceName> 

## How this was tested
./bin/avalanche subnet deploy will have to achieve L1 set up with local machine as sole bootstrap validator in Etna Devnet

## How is this documented
NA