### PR TITLE
Acp77 fix

### DIFF
--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -804,11 +804,8 @@ func (app *Avalanche) ClusterExists(clusterName string) (bool, error) {
 
 func (app *Avalanche) GetClusterConfig(clusterName string) (models.ClusterConfig, error) {
 	exists, err := app.ClusterExists(clusterName)
-	if err != nil {
+	if err != nil || !exists {
 		return models.ClusterConfig{}, err
-	}
-	if !exists {
-		return models.ClusterConfig{}, fmt.Errorf("cluster %q does not exist", clusterName)
 	}
 	clustersConfig, err := app.LoadClustersConfig()
 	if err != nil {


### PR DESCRIPTION
## Why this should be merged
fixes getClusterconfig behavior so it returns empty clusterConfig
to make it similar to if ok:=clustersConfig.Cluster[ClusterName]; !ok 
it fixes node create command
## How this works
one liner

## How this was tested
node create 
## How is this documented
n/a