### PR TITLE
Acp77 remote enta cluster fixes

### DIFF
--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -498,10 +498,7 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 						}
 					}
 					network = models.NewNetworkFromCluster(network, clusterName)
-				} else {
-					// get bootrstrap endpoints from  remote cluster
 				}
-
 			}
 			// ask user if we wants to use local machine if cluster is not provided
 			if !useLocalMachine && globalNetworkFlags.ClusterName == "" {

--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -550,7 +550,8 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 				}
 			}
 		}
-		if len(bootstrapEndpoints) > 0 {
+		switch {
+		case len(bootstrapEndpoints) > 0:
 			var changeAddr string
 			for _, endpoint := range bootstrapEndpoints {
 				infoClient := info.NewClient(endpoint)
@@ -575,13 +576,15 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 					ChangeOwnerAddr:      changeAddr,
 				})
 			}
-		} else if globalNetworkFlags.ClusterName != "" {
+
+		case globalNetworkFlags.ClusterName != "":
 			// for remote clusters we don't need to ask for bootstrap validators and can read it from filesystem
 			bootstrapValidators, err = getClusterBootstrapValidators(globalNetworkFlags.ClusterName, network)
 			if err != nil {
 				return fmt.Errorf("error getting bootstrap validators from cluster %s: %w", globalNetworkFlags.ClusterName, err)
 			}
-		} else {
+
+		default:
 			bootstrapValidators, err = promptBootstrapValidators(network)
 			if err != nil {
 				return err

--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -1272,6 +1272,15 @@ func GetAggregatorNetworkUris(network models.Network) ([]string, error) {
 			for _, nodeInfo := range status.ClusterInfo.NodeInfos {
 				aggregatorExtraPeerEndpointsUris = append(aggregatorExtraPeerEndpointsUris, nodeInfo.Uri)
 			}
+		} else { // remote cluster case
+			hostIDs := utils.Filter(clusterConfig.GetCloudIDs(), clusterConfig.IsAvalancheGoHost)
+			for _, hostID := range hostIDs {
+				if nodeConfig, err := app.LoadClusterNodeConfig(hostID); err != nil {
+					return nil, err
+				} else {
+					aggregatorExtraPeerEndpointsUris = append(aggregatorExtraPeerEndpointsUris, fmt.Sprintf("http://%s:%d", nodeConfig.ElasticIP, constants.AvalanchegoAPIPort))
+				}
+			}
 		}
 	}
 	return aggregatorExtraPeerEndpointsUris, nil


### PR DESCRIPTION
## Why this should be merged
adds automatic bls info if cluster name provided 

## How this works
it reads nodeiD and bls info from staking and node bls keys as we created the, in advance and provide them to cluster nodes 

## How this was tested
```
./bin/avalanche node create remote0
 ./bin/avalanche blockchain deploy remote0 --cluster remote0
./bin/avalanche node sync remote0 remote0