### PR TITLE
use latest golangci-lint to avoid issue with pkg cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
           go-version-file: 'go.mod'
         
       - name: Lint Golang
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: v1.56.2
           working-directory: .


### PR DESCRIPTION
## Why this should be merged
fixes issue with golang-ci-lint pkg cache
## How this works
updates https://github.com/golangci/golangci-lint-action to v6 as per changelog

## How this was tested
github CI
## How is this documented
n/a