### PR TITLE
add /logs/subnetName.logs to the promtail if avalanchego uses it

### DIFF
--- a/cmd/nodecmd/create.go
+++ b/cmd/nodecmd/create.go
@@ -705,7 +705,7 @@ func createNodes(cmd *cobra.Command, args []string) error {
 					ux.SpinFailWithError(spinner, "", err)
 					return
 				}
-				if err = ssh.RunSSHSetupPromtailConfig(host, monitoringNodeConfig.PublicIPs[0], constants.AvalanchegoLokiPort, cloudID, nodeID.String(), ""); err != nil {
+				if err = ssh.RunSSHSetupPromtailConfig(host, monitoringNodeConfig.PublicIPs[0], constants.AvalanchegoLokiPort, cloudID, nodeID.String(), "", ""); err != nil {
 					nodeResults.AddResult(host.NodeID, nil, err)
 					ux.SpinFailWithError(spinner, "", err)
 					return

--- a/cmd/nodecmd/load_test_start.go
+++ b/cmd/nodecmd/load_test_start.go
@@ -317,7 +317,7 @@ func startLoadTest(_ *cobra.Command, args []string) error {
 		return err
 	}
 	if len(monitoringHosts) > 0 {
-		if err := ssh.RunSSHSetupPromtailConfig(currentLoadTestHost[0], monitoringHosts[0].IP, constants.AvalanchegoLokiPort, currentLoadTestHost[0].GetCloudID(), "NodeID-Loadtest", ""); err != nil {
+		if err := ssh.RunSSHSetupPromtailConfig(currentLoadTestHost[0], monitoringHosts[0].IP, constants.AvalanchegoLokiPort, currentLoadTestHost[0].GetCloudID(), "NodeID-Loadtest", "", ""); err != nil {
 			return err
 		}
 		if err := ssh.RunSSHSetupDockerService(currentLoadTestHost[0]); err != nil {

--- a/cmd/nodecmd/sync.go
+++ b/cmd/nodecmd/sync.go
@@ -131,7 +131,6 @@ func trackSubnet(
 
 	wg := sync.WaitGroup{}
 	wgResults := models.NodeResults{}
-	subnetAliases := append([]string{blockchainName}, subnetAliases...)
 	for _, host := range hosts {
 		wg.Add(1)
 		go func(nodeResults *models.NodeResults, host *models.Host) {

--- a/cmd/nodecmd/wiz.go
+++ b/cmd/nodecmd/wiz.go
@@ -985,7 +985,7 @@ func setUpSubnetLogging(clusterName, subnetName string) error {
 				ux.SpinFailWithError(spinner, "", err)
 				return
 			}
-			if err = ssh.RunSSHSetupPromtailConfig(host, monitoringHosts[0].IP, constants.AvalanchegoLokiPort, cloudID, nodeID.String(), chainID); err != nil {
+			if err = ssh.RunSSHSetupPromtailConfig(host, monitoringHosts[0].IP, constants.AvalanchegoLokiPort, cloudID, nodeID.String(), subnetName, chainID); err != nil {
 				wgResults.AddResult(host.NodeID, nil, err)
 				ux.SpinFailWithError(spinner, "", err)
 				return

--- a/pkg/monitoring/configs/promtail.yml
+++ b/pkg/monitoring/configs/promtail.yml
@@ -54,6 +54,15 @@ scrape_configs:
         nodeID: {{ .NodeID }}
         __path__: /logs/{{ .ChainID }}.log
 {{ end }}
+{{ if .SubnetName }}
+    - targets:
+        - localhost
+      labels:
+        job: subnet
+        host: {{ .Host }}
+        nodeID: {{ .NodeID }}
+        __path__: /logs/{{ .SubnetName }}.log
+{{ end }}
   - job_name: avalanchego-loadtest
     static_configs:
     - targets:

--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -24,6 +24,7 @@ type configInputs struct {
 	Port             string
 	Host             string
 	NodeID           string
+	SubnetName       string
 	ChainID          string
 }
 
@@ -99,16 +100,17 @@ func WriteLokiConfig(filePath string, port string) error {
 	return os.WriteFile(filePath, []byte(config), constants.WriteReadReadPerms)
 }
 
-func WritePromtailConfig(filePath string, lokiIP string, lokiPort string, host string, nodeID string, chainID string) error {
+func WritePromtailConfig(filePath string, lokiIP string, lokiPort string, host string, nodeID string, subnetName string, chainID string) error {
 	if !utils.IsValidIP(lokiIP) {
 		return fmt.Errorf("invalid IP address: %s", lokiIP)
 	}
 	config, err := GenerateConfig("configs/promtail.yml", "Promtail Config", configInputs{
-		IP:      lokiIP,
-		Port:    lokiPort,
-		Host:    host,
-		NodeID:  nodeID,
-		ChainID: chainID,
+		IP:         lokiIP,
+		Port:       lokiPort,
+		Host:       host,
+		NodeID:     nodeID,
+		SubnetName: subnetName,
+		ChainID:    chainID,
 	})
 	if err != nil {
 		return err

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -360,7 +360,7 @@ func RunSSHSetupLokiConfig(host *models.Host, port int) error {
 	)
 }
 
-func RunSSHSetupPromtailConfig(host *models.Host, lokiIP string, lokiPort int, cloudID string, nodeID string, chainID string) error {
+func RunSSHSetupPromtailConfig(host *models.Host, lokiIP string, lokiPort int, cloudID string, nodeID string, subnetName string, chainID string) error {
 	for _, folder := range remoteconfig.PromtailFoldersToCreate() {
 		if err := host.MkdirAll(folder, constants.SSHDirOpsTimeout); err != nil {
 			return err
@@ -373,7 +373,7 @@ func RunSSHSetupPromtailConfig(host *models.Host, lokiIP string, lokiPort int, c
 	}
 	defer os.Remove(promtailConfig.Name())
 
-	if err := monitoring.WritePromtailConfig(promtailConfig.Name(), lokiIP, strconv.Itoa(lokiPort), cloudID, nodeID, chainID); err != nil {
+	if err := monitoring.WritePromtailConfig(promtailConfig.Name(), lokiIP, strconv.Itoa(lokiPort), cloudID, nodeID, subnetName, chainID); err != nil {
 		return err
 	}
 	return host.Upload(


### PR DESCRIPTION
## Why this should be merged
fixes missed logs in grafana from promtail for hypersdk vryx CI test
## How this works
adds another logs file to track based on subnetName

## How this was tested
`cd ava-labs/hypersdk/examples/morpheusvm &&  ./scripts/deploy.devnet.sh`

## How is this documented
