### PR TITLE
make network start to not download new snapshots

### DIFF
--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -372,7 +372,7 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 			userProvidedAvagoVersion = avagoVersion
 		}
 
-		deployer := subnet.NewLocalDeployer(app, userProvidedAvagoVersion, avagoBinaryPath, vmBin)
+		deployer := subnet.NewLocalDeployer(app, userProvidedAvagoVersion, avagoBinaryPath, vmBin, true)
 		deployInfo, err := deployer.DeployToLocalNetwork(chain, genesisPath, icmSpec, subnetIDStr)
 		if err != nil {
 			if deployer.BackendStartedHere() {

--- a/cmd/networkcmd/clean.go
+++ b/cmd/networkcmd/clean.go
@@ -47,7 +47,7 @@ func clean(*cobra.Command, []string) error {
 
 	configSingleNodeEnabled := app.Conf.GetConfigBoolValue(constants.ConfigSingleNodeEnabledKey)
 
-	if _, err := subnet.SetDefaultSnapshot(app.GetSnapshotsDir(), true, "", configSingleNodeEnabled); err != nil {
+	if _, err := subnet.SetDefaultSnapshot(app.GetSnapshotsDir(), true, true, "", configSingleNodeEnabled); err != nil {
 		app.Log.Warn("failed resetting default snapshot", zap.Error(err))
 	}
 

--- a/cmd/networkcmd/start.go
+++ b/cmd/networkcmd/start.go
@@ -66,7 +66,7 @@ func StartNetwork(*cobra.Command, []string) error {
 			return err
 		}
 	}
-	sd := subnet.NewLocalDeployer(app, avagoVersion, avagoBinaryPath, "")
+	sd := subnet.NewLocalDeployer(app, avagoVersion, avagoBinaryPath, "", false)
 
 	if err := sd.StartServer(); err != nil {
 		return err

--- a/pkg/subnet/local_test.go
+++ b/pkg/subnet/local_test.go
@@ -194,6 +194,6 @@ func getTestClientFunc(...binutils.GRPCClientOpOption) (client.Client, error) {
 	return c, nil
 }
 
-func fakeSetDefaultSnapshot(string, bool, string, bool) (bool, error) {
+func fakeSetDefaultSnapshot(string, bool, bool, string, bool) (bool, error) {
 	return false, nil
 }

--- a/pkg/subnet/public.go
+++ b/pkg/subnet/public.go
@@ -45,7 +45,7 @@ type PublicDeployer struct {
 
 func NewPublicDeployer(app *application.Avalanche, kc *keychain.Keychain, network models.Network) *PublicDeployer {
 	return &PublicDeployer{
-		LocalDeployer: *NewLocalDeployer(app, "", "", ""),
+		LocalDeployer: *NewLocalDeployer(app, "", "", "", false),
 		app:           app,
 		kc:            kc,
 		network:       network,


### PR DESCRIPTION
## Why this should be merged
An issue in avacloud devnets. When a new snapshot is released, and a devnet is restarted, the new snapshot 
is installed and the persistent state is lost.

## How this works
It ensures network start will not download new snapshots (but network clean and blockchain deploy will)

## How this was tested

## How is this documented
