### PR TITLE
Update release-public-ami.yml

### DIFF
--- a/.github/workflows/release-public-ami.yml
+++ b/.github/workflows/release-public-ami.yml
@@ -44,7 +44,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Clean up old AMIs
-        run: npx aws-amicleaner --include-name 'public-avalanchecli-ubuntu-*' --exclude-newest 1 --exclude-days 2 --region="*" --force
+        run: npx aws-amicleaner --include-name 'public-avalanchecli-ubuntu-*' --exclude-newest 1 --region="*" --force
         env:
           AWS_REGION: us-east-1
 


### PR DESCRIPTION
## Why this should be merged
fixes issues with ami building 
```
==> Some builds didn't complete successfully and had errors:
--> docker.amazon-ebs.ubuntu_amd64: Error modify AMI attributes: ResourceLimitExceeded: You have reached your quota of 5 for the number of public images allowed in this Region. Deregister unused public images or make them private, or request an increase in your public AMIs quota.
	status code: 400, request id: 919be340-caea-4fd6-8539-edecdb2bbf85
--> docker.amazon-ebs.ubuntu_arm64: Error modify AMI attributes: ResourceLimitExceeded: You have reached your quota of 5 for the number of public images allowed in this Region. Deregister unused public images or make them private, or request an increase in your public AMIs quota.
	status code: 400, request id: 2e7276d6-217b-4e96-be0e-492481ef5254
``` 
## How this works
we should not use ami age, but only leave latest AMI as we only use latest. It should also reduce cost 
## How this was tested
CI
## How is this documented
n/a