### PR TITLE
hardcode goreleaser version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           distribution: goreleaser
-          version: latest
+          version: 'v2.3.2'
           args: release --clean
         env:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret


### PR DESCRIPTION
## Why this should be merged
making gorelease github action to use latest goreleaser is not compatible anymore 
with our building toolkit. in particular, it assumes clang used to build arm64 will 
receive the flag --arch arm64, and that is not
the case. fixing goreleaser version is not a bad idea as the flow works and the 
tool is mainly used to execute the underlying build flow. 

## How this works

## How this was tested

## How is this documented
