### PR TITLE
reset log colors so main CLI error can be easily visualized after the node error logs

### DIFF
--- a/pkg/subnet/errors.go
+++ b/pkg/subnet/errors.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	"github.com/ava-labs/avalanchego/utils/logging"
 )
 
 const (
@@ -97,7 +98,8 @@ func FindErrorLogs(rootDirs ...string) {
 		})
 	}
 	if len(foundErrors) > 0 {
-		ux.Logger.PrintToUser("================!!! end of errors in logs !!! ========================")
+		ux.Logger.PrintToUser(logging.Reset.Wrap("================!!! end of errors in logs !!! ========================"))
+		ux.Logger.PrintToUser("")
 	}
 }
 


### PR DESCRIPTION
## Why this should be merged
Improves ux in case of local network errors

## How this works

## How this was tested

## How is this documented
