### PR TITLE
hardcode evm version so e2e passes with current avago

### DIFF
--- a/tests/e2e/testcases/validatormanager/suite.go
+++ b/tests/e2e/testcases/validatormanager/suite.go
@@ -52,6 +52,8 @@ func createEtnaSubnetEvmConfig() error {
 		"blockchain",
 		"create",
 		subnetName,
+		"--vm-version",
+		"v0.6.11",
 		"--evm",
 		"--proof-of-authority",
 		"--poa-manager-owner",


### PR DESCRIPTION
## Why this should be merged

## How this works

## How this was tested

## How is this documented
