### PR TITLE
Custom endpoint etna

### DIFF
--- a/pkg/networkoptions/network_options.go
+++ b/pkg/networkoptions/network_options.go
@@ -358,7 +358,11 @@ func GetNetworkFromCmdLineFlags(
 				return models.UndefinedNetwork, err
 			}
 		}
-		network = models.NewDevnetNetwork(networkFlags.Endpoint, networkID)
+		if networkFlags.Endpoint == constants.EtnaDevnetEndpoint {
+			network = models.NewEtnaDevnetNetwork()
+		} else {
+			network = models.NewDevnetNetwork(networkFlags.Endpoint, networkID)
+		}
 	case Fuji:
 		network = models.NewFujiNetwork()
 	case Mainnet:


### PR DESCRIPTION
## Why this should be merged
When users enters https://etna.avax-dev.network/ in custom endpoint for network prompt, it should lead to etna 