### PR TITLE
Nomenclature to match ACP-77

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Avalanche-CLI
 
-Avalanche CLI is a command line tool that gives developers access to everything Avalanche. This release specializes in helping developers develop and test subnets.
+Avalanche CLI is a command line tool that gives developers access to everything Avalanche. This release specializes in helping developers develop and test L1s.
 
 ## Installation
 
@@ -30,9 +30,13 @@ To add it to your path permanently, add an export command to your shell initiali
 
 To download the binary into a specific directory, run:
 
-```
+```sh
 curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-cli/main/scripts/install.sh | sh -s -- -b <relative directory>
 ```
+
+## Documentation
+
+Documentation of all available commands can be found in the [Avalanche Documentation](https://docs.avax.network/tooling/avalanche-cli).
 
 ## Dev Container & Codespace
 
@@ -40,11 +44,11 @@ To get started easily, we provide a Dev Container specification, that can be use
 
 ## Quickstart
 
-After installing, launch your own custom subnet:
+After installing, launch your own custom layer 1:
 
 ```bash
-avalanche subnet create <subnetName>
-avalanche subnet deploy <subnetName>
+avalanche blockchain create <L1Name>
+avalanche blockchain deploy <L1Name>
 ```
 
 Shut down your local deployment with:
@@ -63,12 +67,12 @@ avalanche network start
 
 - Creation of Subnet-EVM, and custom virtual machine subnet configurations
 - Precompile integration and configuration
-- Local deployment of subnets for development and rapid prototyping
-- Fuji Testnet and Avalanche Mainnet deployment of subnets
+- Local deployment of L1s for development and rapid prototyping
+- Fuji Testnet and Avalanche Mainnet deployment of L1s
 - Ledger support
 - Avalanche Package Manager Integration
 
-## Modifying your Subnet Deployment
+## Modifying your L1 Deployment
 
 You can provide a global node config to edit the way your local avalanchego nodes perform under the hood. To provide such a config, you need to create an avalanche-cli config file. By default, a config file is read in from $HOME/.avalanche-cli/config.json If none exists, no error will occur. To provide a config from a custom location, run any command with the flag `--config <pathToConfig>`.
 
@@ -76,19 +80,19 @@ To specify the global node config, provide it as a body for the `node-config` ke
 
 ```json
 {
-  "network-peer-list-gossip-frequency":"250ms",
-  "network-max-reconnect-delay":"1s",
-  "public-ip":"127.0.0.1",
-  "health-check-frequency":"2s",
-  "api-admin-enabled":true,
-  "api-ipcs-enabled":true,
-  "index-enabled":true
+  "network-peer-list-gossip-frequency": "250ms",
+  "network-max-reconnect-delay": "1s",
+  "public-ip": "127.0.0.1",
+  "health-check-frequency": "2s",
+  "api-admin-enabled": true,
+  "api-ipcs-enabled": true,
+  "index-enabled": true
 }
 ```
 
-### Accessing your local subnet remotely
+### Accessing your local L1 remotely
 
-You may wish to deploy your subnet on a cloud instance and access it remotely. If you'd like to do so, use this as your node config:
+You may wish to deploy your l1 on a cloud instance and access it remotely. If you'd like to do so, use this as your node config:
 
 ```json
 {
@@ -137,38 +141,38 @@ To run the tests, execute the following command from the repo's root directory:
 
 Network snapshots are used by the CLI in order to keep track of blockchain state, and to improve performance of local deployments.
 
-They are the main way to persist subnets, blockchains, and blockchain operations, among different executions of the tool.
+They are the main way to persist blockchains and blockchain operations, among different executions of the tool.
 
 Three different kinds of snapshots are used:
 
 - The `bootstrap snapshot` is provided as the starting network state. It is never modified by CLI usage.
-Designed for fast deploys. Enables full reset of the blockchain state.
+  Designed for fast deploys. Enables full reset of the blockchain state.
 - The `default snapshot` is the main way to keep track of blockchain state. Used by default in the tools.
-It is initialized from the `bootstrap snapshot`, and after that is updated from CLI operations.
+  It is initialized from the `bootstrap snapshot`, and after that is updated from CLI operations.
 - `custom snapshots` can be specified by the user, to save and restore particular states. Only changed if
-explicitly asked to do so.
+  explicitly asked to do so.
 
 ### Local networks
 
 Usage of local networks:
 
 - The local network will be started in the background only if it is not already running
-- If the network is not running, both `network start` and `subnet deploy` will start it from the `default snapshot`.
-`subnet deploy` will also do the deploy on the started network.
-- If the network is running, `network start` will do nothing, and `subnet deploy` will use the running one to do the deploy.
+- If the network is not running, both `network start` and `blockchain deploy` will start it from the `default snapshot`.
+  `blockchain deploy` will also do the deploy on the started network.
+- If the network is running, `network start` will do nothing, and `blockchain deploy` will use the running one to do the deploy.
 - The local network will run until calling `network stop`, `network clean`, or until machine reboot
 
 ### Default snapshot
 
 How the CLI commands affect the `default snapshot`:
 
-- First call of `network start` or `subnet deploy` will initialize `default snapshot` from the `bootstrap snapshot`
-- Subsequent calls to `subnet deploy` do not change the snapshot, only the running network
+- First call of `network start` or `blockchain deploy` will initialize `default snapshot` from the `bootstrap snapshot`
+- Subsequent calls to `blockchain deploy` do not change the snapshot, only the running network
 - `network stop` persist the running network into the `default snapshot`
 - `network clean` copy again the `bootstrap snapshot` into the `default snapshot`, doing a reset of the state
 
 So typically a user will want to do the deploy she needs, change the blockchain state in a specific way, and
-after that execute `network stop` to preserve all the state. In a different session, `network start` or `subnet deploy`
+after that execute `network stop` to preserve all the state. In a different session, `network start` or `blockchain deploy`
 will recover that state.
 
 ### Custom snapshots
@@ -177,14 +181,14 @@ How the CLI commands affect the `custom snapshots`:
 
 - `network stop` can be given an optional snapshot name. This will then be used instead of the default one to save the state
 - `network start` can be given an optional snapshot name. This will then be used instead of the default one to save the state
-- `subnet deploy` will take a running network if it is available, so there is a need to use `network start` previously to do
-deploys, if wanting to use custom snapshots
+- `blockchain deploy` will take a running network if it is available, so there is a need to use `network start` previously to do
+  deploys, if wanting to use custom snapshots
 - `network clean` does not change custom snapshots
 
 So typically a user who wants to use a custom snapshot will do the deploy she needs, change the blockchain state in a specific way, and
 after that execute `network stop` with `--snapshot-name` flag to preserve all the state into the desired snapshot.
 In a different session, `network start` with `--snapshot-name` flag will be called to load that specific snapshot, and after that
-`subnet deploy` can be used on top of it. Notice that you need to continue giving `--snapshot-name` flag to those commands if you
+`blockchain deploy` can be used on top of it. Notice that you need to continue giving `--snapshot-name` flag to those commands if you
 continue saving/restoring to it, if not, `default snapshot will be used`.
 
 ### Snapshots dir
@@ -193,4 +197,4 @@ continue saving/restoring to it, if not, `default snapshot will be used`.
 
 ## Detailed Usage
 
-More detailed information on how to use Avalanche CLI can be found at [here](https://docs.avax.network/subnets/create-a-local-subnet#subnet).
+More detailed information on how to use Avalanche CLI can be found [here](https://docs.avax.network/tooling/avalanche-cli).

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,7 +4,7 @@ metadata:
   name: avalanche-cli
   description: |
     Avalanche-CLI is a command-line interface for building, deploying, and maintaining Avalanche
-    Subnets. It can be used to support the entire Subnet development lifecycle from initial
+    Layer 1s. It can be used to support the entire L1 development lifecycle from initial
     prototyping to production deployments. Avalanche-CLI is available for Linux and Mac, and is open
     source on GitHub.
   annotations:

--- a/cmd/blockchaincmd/add_validator.go
+++ b/cmd/blockchaincmd/add_validator.go
@@ -76,14 +76,12 @@ var (
 func newAddValidatorCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "addValidator [blockchainName]",
-		Short: "Allow a validator to validate your blockchain's subnet",
-		Long: `The blockchain addValidator command whitelists a primary network validator to
-validate the subnet of the provided deployed Blockchain.
-
-To add the validator to the Subnet's allow list, you first need to provide
-the blockchainName and the validator's unique NodeID. The command then prompts
-for the validation start time, duration, and stake weight. You can bypass
-these prompts by providing the values with flags.
+		Short: "Add a validator to an L1",
+		Long: `The blockchain addValidator command adds a node as a validator to
+an L1 of the user provided deployed network. If the network is proof of 
+authority, the owner of the validator manager contract must sign the 
+transaction. If the network is proof of stake, the node must stake the L1's
+staking token. Both processes will issue a RegisterL1ValidatorTx on the P-Chain.
 
 This command currently only works on Blockchains deployed to either the Fuji
 Testnet or Mainnet.`,

--- a/cmd/blockchaincmd/add_validator.go
+++ b/cmd/blockchaincmd/add_validator.go
@@ -389,7 +389,7 @@ func CallAddValidator(
 	if err != nil {
 		return err
 	}
-	ux.Logger.PrintToUser("RegisterSubnetValidatorTx ID: %s", txID)
+	ux.Logger.PrintToUser("RegisterL1ValidatorTx ID: %s", txID)
 
 	if err := UpdatePChainHeight(
 		"Waiting for P-Chain to update validator information ...",

--- a/pkg/subnet/public.go
+++ b/pkg/subnet/public.go
@@ -708,7 +708,7 @@ func (d *PublicDeployer) createConvertL1Tx(
 		return nil, fmt.Errorf("error building tx: %w", err)
 	}
 	if unsignedTx != nil {
-		if err := printFee("ConvertSubnetTX", wallet, unsignedTx); err != nil {
+		if err := printFee("ConvertSubnetToL1Tx", wallet, unsignedTx); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/subnet/public.go
+++ b/pkg/subnet/public.go
@@ -195,7 +195,7 @@ func (*PublicDeployer) createRegisterSubnetValidatorTx(
 		return nil, fmt.Errorf("error building tx: %w", err)
 	}
 	if unsignedTx != nil {
-		if err := printFee("RegisterSubnetValidatorTX", wallet, unsignedTx); err != nil {
+		if err := printFee("RegisterL1ValidatorTx", wallet, unsignedTx); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/validatormanager/validatormanager.go
+++ b/pkg/validatormanager/validatormanager.go
@@ -102,7 +102,7 @@ func AddRewardCalculatorToAllocations(
 }
 
 // setups PoA manager after a successful execution of
-// ConvertSubnetTx on P-Chain
+// ConvertSubnetToL1Tx on P-Chain
 // needs the list of validators for that tx,
 // [convertSubnetValidators], together with an evm [ownerAddress]
 // to set as the owner of the PoA manager
@@ -121,7 +121,7 @@ func SetupPoA(
 }
 
 // setups PoA manager after a successful execution of
-// ConvertSubnetTx on P-Chain
+// ConvertSubnetToL1Tx on P-Chain
 // needs the list of validators for that tx,
 // [convertSubnetValidators], together with an evm [ownerAddress]
 // to set as the owner of the PoA manager

--- a/sdk/blockchain/blockchain.go
+++ b/sdk/blockchain/blockchain.go
@@ -337,7 +337,7 @@ func (c *Subnet) Commit(ms multisig.Multisig, wallet wallet.Wallet, waitForTxAcc
 }
 
 // InitializeProofOfAuthority setups PoA manager after a successful execution of
-// ConvertSubnetTx on P-Chain
+// ConvertSubnetToL1Tx on P-Chain
 // needs the list of validators for that tx,
 // [convertSubnetValidators], together with an evm [ownerAddress]
 // to set as the owner of the PoA manager

--- a/sdk/validatormanager/root.go
+++ b/sdk/validatormanager/root.go
@@ -235,7 +235,7 @@ func GetPChainSubnetConversionWarpMessage(
 
 // InitializeValidatorsSet calls poa manager validators set init method,
 // passing to it the p-chain signed [subnetConversionSignedMessage]
-// to verify p-chain already processed the associated ConvertSubnetTx
+// to verify p-chain already processed the associated ConvertSubnetToL1Tx
 func InitializeValidatorsSet(
 	rpcURL string,
 	managerAddress common.Address,


### PR DESCRIPTION
## Why this should be merged

CLI is in some instances still output messages to the user with obsolete vocabulary

## How this works

Changes CLI ReadMe
Changes comments and strings output by certain CLI commands.

## How this was tested

i.e.:

```zsh
avalanche blockchain deploy <>
...
Now calling ConvertL1 Tx...
ConvertSubnetTX fee: 0.000036992 AVAX
ConvertL1Tx ID: 2mS4dQVXF8xGe59AU3z55x6CtzFqYUanT2gmdHEyxeG2mKT4DT
Waiting for L1 to be converted into sovereign blockchain ... 100% [===============]
```

should be 

```zsh
avalanche blockchain deploy <>
...
Now calling ConvertSubnetToL1Tx...
ConvertSubnetToL1Tx fee: 0.000036992 AVAX
ConvertSubnetToL1Tx ID: 2mS4dQVXF8xGe59AU3z55x6CtzFqYUanT2gmdHEyxeG2mKT4DT
Waiting for Subnet to be converted to sovereign L1 ... 100% [===============]
```

## How is this documented

NA
