### PR TITLE
Fix  get peer error on add validator

### DIFF
--- a/cmd/blockchaincmd/add_validator.go
+++ b/cmd/blockchaincmd/add_validator.go
@@ -151,6 +151,10 @@ func addValidator(_ *cobra.Command, args []string) error {
 		network = models.ConvertClusterToNetwork(network)
 	}
 
+	if sc.Networks[network.Name()].ClusterName != "" {
+		clusterNameFlagValue = sc.Networks[network.Name()].ClusterName
+	}
+
 	fee := network.GenesisParams().TxFeeConfig.StaticFeeConfig.AddSubnetValidatorFee
 	kc, err := keychain.GetKeychainFromCmdLineFlags(
 		app,


### PR DESCRIPTION
Prevents `get peers` error for addValidator when not using --cluster  flag
