### PR TITLE
icm relayer

### DIFF
--- a/.github/packer/aws-ubuntu-docker.pkr.hcl
+++ b/.github/packer/aws-ubuntu-docker.pkr.hcl
@@ -130,8 +130,8 @@ build {
             "docker pull prom/node-exporter:v1.7.0",
             "docker pull grafana/grafana:10.4.1",
             "docker pull prom/prometheus:v2.51.2",
-            "docker pull avaplatform/awm-relayer",
-            "docker pull golang:1.22.1-bullseye"
+            "docker pull avaplatform/icm-relayer:v2.0.0-fuji",
+            "docker pull golang:1.22.8-bullseye"
         ]
    }
 

--- a/cmd/nodecmd/wiz.go
+++ b/cmd/nodecmd/wiz.go
@@ -328,7 +328,7 @@ func wiz(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			// get awm-relayer latest version
+			// get icm-relayer latest version
 			relayerVersion, err := teleporter.GetLatestRelayerReleaseVersion()
 			if err != nil {
 				return err

--- a/pkg/docker/templates/awmrelayer.docker-compose.yml
+++ b/pkg/docker/templates/awmrelayer.docker-compose.yml
@@ -1,11 +1,11 @@
 name: avalanche-cli
 services:
-  awm-relayer:
-    image: avaplatform/awm-relayer:{{ .ICMRelayerVersion }}
-    container_name: awm-relayer
+  icm-relayer:
+    image: avaplatform/icm-relayer:{{ .ICMRelayerVersion }}
+    container_name: icm-relayer
     restart: unless-stopped
     user: "1000:1000"  # ubuntu user
     network_mode: "host"
     volumes:
-      - /home/ubuntu/.avalanche-cli/services/awm-relayer:/.awm-relayer:rw
-    command: 'awm-relayer --config-file /.awm-relayer/awm-relayer-config.json'
+      - /home/ubuntu/.avalanche-cli/services/icm-relayer:/.icm-relayer:rw
+    command: 'icm-relayer --config-file /.icm-relayer/icm-relayer-config.json'

--- a/pkg/remoteconfig/avalanche.go
+++ b/pkg/remoteconfig/avalanche.go
@@ -123,6 +123,6 @@ func AvalancheFolderToCreate() []string {
 		"/home/ubuntu/.avalanchego/configs/chains/C",
 		"/home/ubuntu/.avalanchego/staking",
 		"/home/ubuntu/.avalanchego/plugins",
-		"/home/ubuntu/.avalanche-cli/services/awm-relayer",
+		"/home/ubuntu/.avalanche-cli/services/icm-relayer",
 	}
 }

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -164,17 +164,17 @@ func ComposeSSHSetupICMRelayer(host *models.Host, relayerVersion string) error {
 	if err := docker.ComposeSSHSetupICMRelayer(host, relayerVersion); err != nil {
 		return err
 	}
-	return docker.StartDockerComposeService(host, utils.GetRemoteComposeFile(), "awm-relayer", constants.SSHLongRunningScriptTimeout)
+	return docker.StartDockerComposeService(host, utils.GetRemoteComposeFile(), "icm-relayer", constants.SSHLongRunningScriptTimeout)
 }
 
 // RunSSHStartICMRelayerService runs script to start an AWM Relayer Service
 func RunSSHStartICMRelayerService(host *models.Host) error {
-	return docker.StartDockerComposeService(host, utils.GetRemoteComposeFile(), "awm-relayer", constants.SSHLongRunningScriptTimeout)
+	return docker.StartDockerComposeService(host, utils.GetRemoteComposeFile(), "icm-relayer", constants.SSHLongRunningScriptTimeout)
 }
 
 // RunSSHStopICMRelayerService runs script to start an AWM Relayer Service
 func RunSSHStopICMRelayerService(host *models.Host) error {
-	return docker.StopDockerComposeService(host, utils.GetRemoteComposeFile(), "awm-relayer", constants.SSHLongRunningScriptTimeout)
+	return docker.StopDockerComposeService(host, utils.GetRemoteComposeFile(), "icm-relayer", constants.SSHLongRunningScriptTimeout)
 }
 
 // RunSSHUpgradeAvalanchego runs script to upgrade avalanchego


### PR DESCRIPTION
## Why this should be merged
rename awm-relayer to icm-relayer for docker images 

## How this works

## How this was tested
`./bin/avalanche node devnet wiz r0 r0 --num-validators=1 --num-apis=1  --region us-east-1 --aws --node-type default  --use-static-ip=false  --enable-monitoring=false`
## How is this documented
n/a