### PR TITLE
use lint script

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,11 +21,7 @@ jobs:
           go-version-file: 'go.mod'
         
       - name: Lint Golang
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: v1.56.2
-          working-directory: .
-          args: --timeout 5m
+        run: ./scripts/lint.sh
 
       - name: Check License
         run:  |

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+# See the file LICENSE for licensing terms.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CLI_PATH=$(
+    cd "$(dirname "${BASH_SOURCE[0]}")"
+    cd .. && pwd
+)
+
+GOLANGCI_LINT_VERSION=v1.56.2
+
+go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+golangci-lint run --config=$CLI_PATH/.golangci.yml ./... --timeout 5m


### PR DESCRIPTION
## Why this should be merged
To ensure lint tool version unification between local host and CI executions

## How this works

## How this was tested

## How is this documented
