### PR TITLE
increase mainnet timeout

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -293,6 +293,13 @@ func setupEnv() (string, error) {
 		return "", err
 	}
 
+	// Create run dir if it doesn't exist
+	runDir := filepath.Join(baseDir, constants.RunDir)
+	if err = os.MkdirAll(runDir, os.ModePerm); err != nil {
+		fmt.Printf("failed creating the run dir %s: %s\n", runDir, err)
+		return "", err
+	}
+
 	// Create custom vm dir if it doesn't exist
 	vmDir := filepath.Join(baseDir, constants.CustomVMDir)
 	if err = os.MkdirAll(vmDir, os.ModePerm); err != nil {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -59,7 +59,7 @@ const (
 	FastGRPCDialTimeout    = 100 * time.Millisecond
 
 	FujiBootstrapTimeout    = 15 * time.Minute
-	MainnetBootstrapTimeout = 4 * time.Hour
+	MainnetBootstrapTimeout = 24 * time.Hour
 
 	SSHServerStartTimeout       = 1 * time.Minute
 	SSHScriptTimeout            = 2 * time.Minute

--- a/pkg/node/local.go
+++ b/pkg/node/local.go
@@ -283,6 +283,7 @@ func StartLocalNode(
 		nodeConfig = map[string]interface{}{}
 	}
 	nodeConfig[config.NetworkAllowPrivateIPsKey] = true
+	nodeConfig[config.IndexEnabledKey] = false
 
 	nodeConfigBytes, err := json.Marshal(nodeConfig)
 	if err != nil {
@@ -333,7 +334,7 @@ func StartLocalNode(
 		case network.Kind == models.Fuji:
 			ux.Logger.PrintToUser(logging.Yellow.Wrap("Warning: Fuji Bootstrapping can take several minutes"))
 		case network.Kind == models.Mainnet:
-			ux.Logger.PrintToUser(logging.Yellow.Wrap("Warning: Mainnet Bootstrapping can take 1-2 hours"))
+			ux.Logger.PrintToUser(logging.Yellow.Wrap("Warning: Mainnet Bootstrapping can take 6-24 hours"))
 		case network.Kind == models.Local:
 			clusterInfo, err := localnet.GetClusterInfo()
 			if err != nil {


### PR DESCRIPTION
## Why this should be merged
Increases mainnet timeout to 24 hours. Also modifies user warning for expected bootstrapping time
on mainnet. 

## How this works

## How this was tested

## How is this documented
