### PR TITLE
allow dbs already indexed

### DIFF
--- a/pkg/node/local.go
+++ b/pkg/node/local.go
@@ -284,6 +284,7 @@ func StartLocalNode(
 	}
 	nodeConfig[config.NetworkAllowPrivateIPsKey] = true
 	nodeConfig[config.IndexEnabledKey] = false
+	nodeConfig[config.IndexAllowIncompleteKey] = true
 
 	nodeConfigBytes, err := json.Marshal(nodeConfig)
 	if err != nil {


### PR DESCRIPTION
## Why this should be merged
Latest CLI release disables indexing on local cluster nodes. But a conflict happen when
trying to start local cluster nodes created with previous CLI release. This PR 
fix the issue with a flag that enables accepting previous dbs.

## How this works

## How this was tested

## How is this documented
