### PR TITLE
do not force user to use blockchain name on tx sign or commit

### DIFF
--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -1326,7 +1326,7 @@ func ValidateSubnetNameAndGetChains(args []string) ([]string, error) {
 func SaveNotFullySignedTx(
 	txName string,
 	tx *txs.Tx,
-	chain string,
+	blockchainName string,
 	subnetAuthKeys []string,
 	remainingSubnetAuthKeys []string,
 	outputTxPath string,
@@ -1361,26 +1361,30 @@ func SaveNotFullySignedTx(
 		return err
 	}
 	if signedCount == len(subnetAuthKeys) {
-		PrintReadyToSignMsg(chain, outputTxPath)
+		PrintReadyToSignMsg(blockchainName, outputTxPath)
 	} else {
-		PrintRemainingToSignMsg(chain, remainingSubnetAuthKeys, outputTxPath)
+		PrintRemainingToSignMsg(blockchainName, remainingSubnetAuthKeys, outputTxPath)
 	}
 	return nil
 }
 
 func PrintReadyToSignMsg(
-	chain string,
+	blockchainName string,
 	outputTxPath string,
 ) {
 	ux.Logger.PrintToUser("")
 	ux.Logger.PrintToUser("Tx is fully signed, and ready to be committed")
 	ux.Logger.PrintToUser("")
 	ux.Logger.PrintToUser("Commit command:")
-	ux.Logger.PrintToUser("  avalanche transaction commit %s --input-tx-filepath %s", chain, outputTxPath)
+	cmdLine := fmt.Sprintf("  avalanche transaction commit %s --input-tx-filepath %s", blockchainName, outputTxPath)
+	if blockchainName == "" {
+		cmdLine = fmt.Sprintf("  avalanche transaction commit --input-tx-filepath %s", outputTxPath)
+	}
+	ux.Logger.PrintToUser(cmdLine)
 }
 
 func PrintRemainingToSignMsg(
-	chain string,
+	blockchainName string,
 	remainingSubnetAuthKeys []string,
 	outputTxPath string,
 ) {
@@ -1394,21 +1398,25 @@ func PrintRemainingToSignMsg(
 		"and run the signing command, or send %q to another user for signing.", outputTxPath)
 	ux.Logger.PrintToUser("")
 	ux.Logger.PrintToUser("Signing command:")
-	ux.Logger.PrintToUser("  avalanche transaction sign %s --input-tx-filepath %s", chain, outputTxPath)
+	cmdline := fmt.Sprintf("  avalanche transaction sign %s --input-tx-filepath %s", blockchainName, outputTxPath)
+	if blockchainName == "" {
+		cmdline = fmt.Sprintf("  avalanche transaction sign --input-tx-filepath %s", outputTxPath)
+	}
+	ux.Logger.PrintToUser(cmdline)
 	ux.Logger.PrintToUser("")
 }
 
-func PrintDeployResults(chain string, subnetID ids.ID, blockchainID ids.ID) error {
-	vmID, err := anrutils.VMID(chain)
+func PrintDeployResults(blockchainName string, subnetID ids.ID, blockchainID ids.ID) error {
+	vmID, err := anrutils.VMID(blockchainName)
 	if err != nil {
-		return fmt.Errorf("failed to create VM ID from %s: %w", chain, err)
+		return fmt.Errorf("failed to create VM ID from %s: %w", blockchainName, err)
 	}
 	header := []string{"Deployment results", ""}
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader(header)
 	table.SetRowLine(true)
 	table.SetAutoMergeCells(true)
-	table.Append([]string{"Chain Name", chain})
+	table.Append([]string{"Chain Name", blockchainName})
 	table.Append([]string{"Subnet ID", subnetID.String()})
 	table.Append([]string{"VM ID", vmID.String()})
 	if blockchainID != ids.Empty {

--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -1408,30 +1408,6 @@ func PrintRemainingToSignMsg(
 }
 
 func PrintDeployResults(blockchainName string, subnetID ids.ID, blockchainID ids.ID) error {
-	/*
-		header := []string{"Deployment results", ""}
-		table := tablewriter.NewWriter(os.Stdout)
-		table.SetHeader(header)
-		table.SetRowLine(true)
-		table.SetAutoMergeCells(true)
-		if blockchainName != "" {
-			table.Append([]string{"Chain Name", blockchainName})
-		}
-		table.Append([]string{"Subnet ID", subnetID.String()})
-		if blockchainName != "" {
-			vmID, err := anrutils.VMID(blockchainName)
-			if err != nil {
-				return fmt.Errorf("failed to create VM ID from %s: %w", blockchainName, err)
-			}
-			table.Append([]string{"VM ID", vmID.String()})
-		}
-		if blockchainID != ids.Empty {
-			table.Append([]string{"Blockchain ID", blockchainID.String()})
-			table.Append([]string{"P-Chain TXID", blockchainID.String()})
-		}
-		table.Render()
-	*/
-
 	t := ux.DefaultTable("Deployment results", nil)
 	t.SetColumnConfigs([]table.ColumnConfig{
 		{Number: 2, AutoMerge: true},

--- a/cmd/transactioncmd/transaction_commit.go
+++ b/cmd/transactioncmd/transaction_commit.go
@@ -128,7 +128,7 @@ func commitTx(_ *cobra.Command, args []string) error {
 
 	ux.Logger.PrintToUser("Transaction successful, transaction ID: %s", txID)
 
-	if txutils.IsCreateChainTx(tx) {
+	if isCreateChainTx {
 		if err := blockchaincmd.PrintDeployResults(blockchainName, subnetID, txID); err != nil {
 			return err
 		}
@@ -136,7 +136,7 @@ func commitTx(_ *cobra.Command, args []string) error {
 			return app.UpdateSidecarNetworks(&sc, network, subnetID, txID, "", "", sc.Networks[network.Name()].BootstrapValidators, "")
 		}
 		ux.Logger.PrintToUser("This CLI instance will not locally preserve blockchain metadata.")
-		ux.Logger.PrintToUser("Please keep a record of the subnet ID and blockchain ID information.")
+		ux.Logger.PrintToUser("Please keep a manual record of the subnet ID and blockchain ID information.")
 	}
 
 	return nil


### PR DESCRIPTION
## Why this should be merged
Some users want to follow a workflow where a tx file is send to other machine and just do the multisig signature process
+ commit.
This PR enables this flow while advising the user to follow export/import procedures of blockchain metadata
so CLI keeps a record of blockchain ids when it is needed.

## How this works

## How this was tested

## How is this documented
