### PR TITLE
add l1 nodes info to local network describe

### DIFF
--- a/cmd/networkcmd/clean.go
+++ b/cmd/networkcmd/clean.go
@@ -84,7 +84,7 @@ func clean(*cobra.Command, []string) error {
 		return err
 	}
 
-	return node.DestroyCurrentIfLocalNetwork(app)
+	return node.DestroyLocalNetworkConnectedCluster(app)
 }
 
 func removeLocalDeployInfoFromSidecars() error {

--- a/cmd/networkcmd/stop.go
+++ b/cmd/networkcmd/stop.go
@@ -116,7 +116,7 @@ func stopAndSaveNetwork(flags StopFlags) error {
 		}
 	}
 
-	if err := node.StopCurrentIfLocalNetwork(app); err != nil {
+	if err := node.StopLocalNetworkConnectedCluster(app); err != nil {
 		return err
 	}
 

--- a/pkg/localnet/localnet.go
+++ b/pkg/localnet/localnet.go
@@ -33,7 +33,13 @@ func GetEndpoint() (string, error) {
 }
 
 func GetClusterInfo() (*rpcpb.ClusterInfo, error) {
-	cli, err := binutils.NewGRPCClient(
+	return GetClusterInfoWithEndpoint(binutils.LocalNetworkGRPCServerEndpoint)
+}
+
+func GetClusterInfoWithEndpoint(grpcServerEndpoint string) (*rpcpb.ClusterInfo, error) {
+	cli, err := binutils.NewGRPCClientWithEndpoint(
+		grpcServerEndpoint,
+		binutils.WithAvoidRPCVersionCheck(true),
 		binutils.WithDialTimeout(constants.FastGRPCDialTimeout),
 	)
 	if err != nil {

--- a/pkg/localnet/output.go
+++ b/pkg/localnet/output.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/ava-labs/avalanche-cli/pkg/application"
+	"github.com/ava-labs/avalanche-cli/pkg/binutils"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
@@ -34,8 +35,15 @@ func PrintEndpoints(
 			printFunc("")
 		}
 	}
-	if err := PrintNetworkEndpoints(printFunc, clusterInfo); err != nil {
+	if err := PrintNetworkEndpoints("Primary Nodes", printFunc, clusterInfo); err != nil {
 		return err
+	}
+	clusterInfo, err = GetClusterInfoWithEndpoint(binutils.LocalClusterGRPCServerEndpoint)
+	if err == nil {
+		printFunc("")
+		if err := PrintNetworkEndpoints("L1 Nodes", printFunc, clusterInfo); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -83,6 +91,7 @@ func PrintSubnetEndpoints(
 }
 
 func PrintNetworkEndpoints(
+	title string,
 	printFunc func(msg string, args ...interface{}),
 	clusterInfo *rpcpb.ClusterInfo,
 ) error {
@@ -91,7 +100,7 @@ func PrintNetworkEndpoints(
 	if insideCodespace {
 		header = append(header, "Codespace Endpoint")
 	}
-	t := ux.DefaultTable("Nodes", header)
+	t := ux.DefaultTable(title, header)
 	nodeNames := clusterInfo.NodeNames
 	sort.Strings(nodeNames)
 	nodeInfos := map[string]*rpcpb.NodeInfo{}

--- a/pkg/node/local.go
+++ b/pkg/node/local.go
@@ -758,7 +758,10 @@ func listLocalClusters(app *application.Avalanche, clusterNamesToInclude []strin
 	return localClusters, nil
 }
 
-func CurrentIsLocalNetwork(app *application.Avalanche) (bool, string, error) {
+// ConnectedToLocalNetwork returns true if a local cluster is running
+// and it is connected to a local network.
+// It also returns the name of the cluster that is connected to the local network
+func ConnectedToLocalNetwork(app *application.Avalanche) (bool, string, error) {
 	ctx, cancel := utils.GetANRContext()
 	defer cancel()
 	currentlyRunningRootDir := ""
@@ -795,8 +798,8 @@ func CurrentIsLocalNetwork(app *application.Avalanche) (bool, string, error) {
 	return false, "", nil
 }
 
-func DestroyCurrentIfLocalNetwork(app *application.Avalanche) error {
-	isLocal, clusterName, err := CurrentIsLocalNetwork(app)
+func DestroyLocalNetworkConnectedCluster(app *application.Avalanche) error {
+	isLocal, clusterName, err := ConnectedToLocalNetwork(app)
 	if err != nil {
 		return err
 	}
@@ -806,8 +809,8 @@ func DestroyCurrentIfLocalNetwork(app *application.Avalanche) error {
 	return nil
 }
 
-func StopCurrentIfLocalNetwork(app *application.Avalanche) error {
-	isLocal, _, err := CurrentIsLocalNetwork(app)
+func StopLocalNetworkConnectedCluster(app *application.Avalanche) error {
+	isLocal, _, err := ConnectedToLocalNetwork(app)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Why this should be merged
current output of local network deploy, describe, start, status is misleaving, showing only
the local primary network nodes, but not the local l1 nodes (local cluster)

## How this works

## How this was tested

## How is this documented
