### PR TITLE
add recovery to the validator remove command

### DIFF
--- a/pkg/validatormanager/registration.go
+++ b/pkg/validatormanager/registration.go
@@ -409,7 +409,7 @@ func InitValidatorRegistration(
 			if !errors.Is(err, validatorManagerSDK.ErrNodeAlreadyRegistered) {
 				return nil, ids.Empty, evm.TransactionError(tx, err, "failure initializing validator registration")
 			}
-			ux.Logger.PrintToUser(logging.Blue.Wrap("The validator registration was already initialized. Proceeding to the next step"))
+			ux.Logger.PrintToUser(logging.LightBlue.Wrap("The validator registration was already initialized. Proceeding to the next step"))
 			alreadyInitialized = true
 		}
 	} else {

--- a/pkg/validatormanager/removal.go
+++ b/pkg/validatormanager/removal.go
@@ -5,6 +5,7 @@ package validatormanager
 import (
 	_ "embed"
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/ava-labs/avalanche-cli/pkg/application"
@@ -207,6 +208,9 @@ func InitValidatorRemoval(
 	if err != nil {
 		return nil, ids.Empty, err
 	}
+	if validationID == ids.Empty {
+		return nil, ids.Empty, fmt.Errorf("node %s is not a L1 validator", nodeID)
+	}
 
 	aggregatorLogLevel, err := logging.ToLevel(aggregatorLogLevelStr)
 	if err != nil {
@@ -251,7 +255,7 @@ func InitValidatorRemoval(
 		if !errors.Is(err, validatorManagerSDK.ErrInvalidValidatorStatus) {
 			return nil, ids.Empty, evm.TransactionError(tx, err, "failure initializing validator removal")
 		}
-		ux.Logger.PrintToUser("the validator removal process was already initialized. Proceeding to the next step")
+		ux.Logger.PrintToUser(logging.LightBlue.Wrap("The validator removal process was already initialized. Proceeding to the next step"))
 	}
 
 	nonce := uint64(1)


### PR DESCRIPTION
## Why this should be merged
Currently there is no way to continue a removal from where it failed, for all removal steps (eg aggregation).
This PR add recovery from P-Chain Tx removal already completed. Also adds nicer msgs.

## How this works

## How this was tested

## How is this documented
