### PR TITLE
Fix metrics for codespace

### DIFF
--- a/cmd/blockchaincmd/export_test.go
+++ b/cmd/blockchaincmd/export_test.go
@@ -33,7 +33,7 @@ func TestExportImportSubnet(t *testing.T) {
 	mockAppDownloader := mocks.Downloader{}
 	mockAppDownloader.On("Download", mock.Anything).Return(testSubnetEVMCompat, nil)
 
-	app.Setup(testDir, logging.NoLog{}, nil, prompts.NewPrompter(), &mockAppDownloader)
+	app.Setup(testDir, logging.NoLog{}, nil, "", prompts.NewPrompter(), &mockAppDownloader)
 	ux.NewUserLog(logging.NoLog{}, io.Discard)
 	genBytes, err := os.ReadFile("../../" + utils.SubnetEvmGenesisPath)
 	require.NoError(err)

--- a/cmd/blockchaincmd/publish_test.go
+++ b/cmd/blockchaincmd/publish_test.go
@@ -415,7 +415,7 @@ func setupTestEnv(t *testing.T) (*require.Assertions, *mocks.Prompter) {
 	ux.NewUserLog(logging.NoLog{}, io.Discard)
 	app = &application.Avalanche{}
 	mockPrompt := mocks.NewPrompter(t)
-	app.Setup(testDir, logging.NoLog{}, config.New(), mockPrompt, application.NewDownloader())
+	app.Setup(testDir, logging.NoLog{}, config.New(), "", mockPrompt, application.NewDownloader())
 
 	return require, mockPrompt
 }

--- a/cmd/blockchaincmd/upgradecmd/vm_test.go
+++ b/cmd/blockchaincmd/upgradecmd/vm_test.go
@@ -306,7 +306,7 @@ func TestUpdateToCustomBin(t *testing.T) {
 	ux.NewUserLog(log, os.Stdout)
 
 	app = &application.Avalanche{}
-	app.Setup(testDir, log, config.New(), prompts.NewPrompter(), application.NewDownloader())
+	app.Setup(testDir, log, config.New(), "", prompts.NewPrompter(), application.NewDownloader())
 
 	err = os.MkdirAll(app.GetSubnetDir(), constants.DefaultPerms755)
 	assert.NoError(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -143,7 +143,7 @@ func createApp(cmd *cobra.Command, _ []string) error {
 	log.Info("-----------")
 	log.Info(fmt.Sprintf("cmd: %s", strings.Join(os.Args[1:], " ")))
 	cf := config.New()
-	app.Setup(baseDir, log, cf, prompts.NewPrompter(), application.NewDownloader())
+	app.Setup(baseDir, log, cf, Version, prompts.NewPrompter(), application.NewDownloader())
 
 	initConfig()
 

--- a/internal/migrations/migrations_test.go
+++ b/internal/migrations/migrations_test.go
@@ -23,7 +23,7 @@ func TestRunMigrations(t *testing.T) {
 	testDir := t.TempDir()
 
 	app := &application.Avalanche{}
-	app.Setup(testDir, logging.NoLog{}, config.New(), prompts.NewPrompter(), application.NewDownloader())
+	app.Setup(testDir, logging.NoLog{}, config.New(), "", prompts.NewPrompter(), application.NewDownloader())
 
 	type migTest struct {
 		migs           map[int]migrationFunc

--- a/internal/migrations/subnet_evm_rename_test.go
+++ b/internal/migrations/subnet_evm_rename_test.go
@@ -62,7 +62,7 @@ func TestSubnetEVMRenameMigration(t *testing.T) {
 			testDir := t.TempDir()
 
 			app := &application.Avalanche{}
-			app.Setup(testDir, logging.NoLog{}, config.New(), prompts.NewPrompter(), application.NewDownloader())
+			app.Setup(testDir, logging.NoLog{}, config.New(), "", prompts.NewPrompter(), application.NewDownloader())
 
 			err := app.CreateSidecar(tt.sc)
 			require.NoError(err)
@@ -91,7 +91,7 @@ func TestSubnetEVMRenameMigration_EmptyDir(t *testing.T) {
 	testDir := t.TempDir()
 
 	app := &application.Avalanche{}
-	app.Setup(testDir, logging.NoLog{}, config.New(), prompts.NewPrompter(), application.NewDownloader())
+	app.Setup(testDir, logging.NoLog{}, config.New(), "", prompts.NewPrompter(), application.NewDownloader())
 
 	emptySubnetName := "emptySubnet"
 

--- a/internal/migrations/toplevel_files_test.go
+++ b/internal/migrations/toplevel_files_test.go
@@ -25,7 +25,7 @@ func TestTopLevelFilesMigration(t *testing.T) {
 	testDir := t.TempDir()
 
 	app := &application.Avalanche{}
-	app.Setup(testDir, logging.NoLog{}, config.New(), prompts.NewPrompter(), application.NewDownloader())
+	app.Setup(testDir, logging.NoLog{}, config.New(), "", prompts.NewPrompter(), application.NewDownloader())
 
 	testSC1 := &models.Sidecar{
 		Name: "test1",

--- a/internal/testutils/setup.go
+++ b/internal/testutils/setup.go
@@ -24,7 +24,7 @@ func SetupTestInTempDir(t *testing.T) *application.Avalanche {
 	testDir := t.TempDir()
 
 	app := application.New()
-	app.Setup(testDir, logging.NoLog{}, &config.Config{}, nil, nil)
+	app.Setup(testDir, logging.NoLog{}, &config.Config{}, "", nil, nil)
 	ux.NewUserLog(logging.NoLog{}, io.Discard)
 	return app
 }

--- a/pkg/apmintegration/file_test.go
+++ b/pkg/apmintegration/file_test.go
@@ -63,7 +63,7 @@ const (
 func newTestApp(t *testing.T, testDir string) *application.Avalanche {
 	tempDir := t.TempDir()
 	app := application.New()
-	app.Setup(tempDir, logging.NoLog{}, nil, prompts.NewPrompter(), application.NewDownloader())
+	app.Setup(tempDir, logging.NoLog{}, nil, "", prompts.NewPrompter(), application.NewDownloader())
 	app.ApmDir = testDir
 	return app
 }

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -29,6 +29,7 @@ type Avalanche struct {
 	Log        logging.Logger
 	baseDir    string
 	Conf       *config.Config
+	Version    string
 	Prompt     prompts.Prompter
 	Apm        *apm.APM
 	ApmDir     string
@@ -39,10 +40,18 @@ func New() *Avalanche {
 	return &Avalanche{}
 }
 
-func (app *Avalanche) Setup(baseDir string, log logging.Logger, conf *config.Config, prompt prompts.Prompter, downloader Downloader) {
+func (app *Avalanche) Setup(
+	baseDir string,
+	log logging.Logger,
+	conf *config.Config,
+	version string,
+	prompt prompts.Prompter,
+	downloader Downloader,
+) {
 	app.baseDir = baseDir
 	app.Log = log
 	app.Conf = conf
+	app.Version = version
 	app.Prompt = prompt
 	app.Downloader = downloader
 }

--- a/pkg/binutils/release_test.go
+++ b/pkg/binutils/release_test.go
@@ -37,7 +37,7 @@ func setupInstallDir(require *require.Assertions) *application.Avalanche {
 	defer os.RemoveAll(rootDir)
 
 	app := application.New()
-	app.Setup(rootDir, logging.NoLog{}, &config.Config{}, prompts.NewPrompter(), application.NewDownloader())
+	app.Setup(rootDir, logging.NoLog{}, &config.Config{}, "", prompts.NewPrompter(), application.NewDownloader())
 	return app
 }
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -241,6 +241,8 @@ const (
 	// #nosec G101
 	GithubAPITokenEnvVarName = "AVALANCHE_CLI_GITHUB_TOKEN"
 
+	MetricsAPITokenEnvVarName = "AVALANCHE_CLI_METRICS_TOKEN"
+
 	ReposDir                    = "repos"
 	SubnetDir                   = "subnets"
 	NodesDir                    = "nodes"

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -52,7 +52,7 @@ func HandleTracking(cmd *cobra.Command, commandPath string, app *application.Ava
 		return
 	}
 	if !cmd.HasSubCommands() && CheckCommandIsNotCompletion(cmd) {
-		TrackMetrics(commandPath, flags)
+		trackMetrics(app, commandPath, flags)
 	}
 }
 
@@ -64,7 +64,10 @@ func CheckCommandIsNotCompletion(cmd *cobra.Command) bool {
 	return true
 }
 
-func TrackMetrics(commandPath string, flags map[string]string) {
+func trackMetrics(app *application.Avalanche, commandPath string, flags map[string]string) {
+	if telemetryToken == "" {
+		telemetryToken = os.Getenv(constants.MetricsAPITokenEnvVarName)
+	}
 	if telemetryToken == "" || utils.IsE2E() {
 		return
 	}
@@ -72,12 +75,17 @@ func TrackMetrics(commandPath string, flags map[string]string) {
 
 	defer client.Close()
 
+	version := app.Version
+	if version == "" {
+		version = GetCLIVersion()
+	}
+
 	usr, _ := user.Current() // use empty string if err
 	hash := sha256.Sum256([]byte(fmt.Sprintf("%s%s", usr.Username, usr.Uid)))
 	userID := base64.StdEncoding.EncodeToString(hash[:])
 	telemetryProperties := make(map[string]interface{})
 	telemetryProperties["command"] = commandPath
-	telemetryProperties["version"] = GetCLIVersion()
+	telemetryProperties["version"] = version
 	telemetryProperties["os"] = runtime.GOOS
 	if utils.InsideCodespace() {
 		telemetryProperties["codespace"] = os.Getenv(constants.CodespaceNameEnvVar)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -83,12 +83,18 @@ func trackMetrics(app *application.Avalanche, commandPath string, flags map[stri
 	usr, _ := user.Current() // use empty string if err
 	hash := sha256.Sum256([]byte(fmt.Sprintf("%s%s", usr.Username, usr.Uid)))
 	userID := base64.StdEncoding.EncodeToString(hash[:])
+
 	telemetryProperties := make(map[string]interface{})
 	telemetryProperties["command"] = commandPath
 	telemetryProperties["version"] = version
 	telemetryProperties["os"] = runtime.GOOS
-	if utils.InsideCodespace() {
-		telemetryProperties["codespace"] = os.Getenv(constants.CodespaceNameEnvVar)
+	insideCodespace := utils.InsideCodespace()
+	telemetryProperties["insideCodespace"] = insideCodespace
+	if insideCodespace {
+		codespaceName := os.Getenv(constants.CodespaceNameEnvVar)
+		telemetryProperties["codespace"] = codespaceName
+		hash := sha256.Sum256([]byte(codespaceName))
+		userID = base64.StdEncoding.EncodeToString(hash[:])
 	}
 	for propertyKey, propertyValue := range flags {
 		telemetryProperties[propertyKey] = propertyValue

--- a/tests/e2e/testcases/upgrade/non-sov/suite.go
+++ b/tests/e2e/testcases/upgrade/non-sov/suite.go
@@ -69,7 +69,7 @@ var _ = ginkgo.Describe("[Upgrade expect network failure non SOV]", ginkgo.Order
 		// the code would detect it hasn't been deployed yet so report that error first
 		// therefore we can just manually edit the file to fake it had been deployed
 		app := application.New()
-		app.Setup(utils.GetBaseDir(), logging.NoLog{}, nil, nil, nil)
+		app.Setup(utils.GetBaseDir(), logging.NoLog{}, nil, "", nil, nil)
 		sc := models.Sidecar{
 			Name:     subnetName,
 			Subnet:   subnetName,
@@ -105,7 +105,7 @@ var _ = ginkgo.Describe("[Upgrade public network non SOV]", ginkgo.Ordered, func
 		// simulate as if this had already been deployed to fuji
 		// by just entering fake data into the struct
 		app := application.New()
-		app.Setup(utils.GetBaseDir(), logging.NoLog{}, nil, nil, nil)
+		app.Setup(utils.GetBaseDir(), logging.NoLog{}, nil, "", nil, nil)
 
 		sc, err := app.LoadSidecar(subnetName)
 		gomega.Expect(err).Should(gomega.BeNil())
@@ -210,7 +210,7 @@ var _ = ginkgo.Describe("[Upgrade local network non SOV]", ginkgo.Ordered, func(
 		gomega.Expect(err).Should(gomega.BeNil())
 
 		app := application.New()
-		app.Setup(utils.GetBaseDir(), logging.NoLog{}, nil, nil, nil)
+		app.Setup(utils.GetBaseDir(), logging.NoLog{}, nil, "", nil, nil)
 
 		stripped := stripWhitespaces(string(upgradeBytes))
 		lockUpgradeBytes, err := app.ReadLockUpgradeFile(subnetName)

--- a/tests/e2e/testcases/upgrade/sov/suite.go
+++ b/tests/e2e/testcases/upgrade/sov/suite.go
@@ -69,7 +69,7 @@ var _ = ginkgo.Describe("[Upgrade expect network failure SOV]", ginkgo.Ordered, 
 		// the code would detect it hasn't been deployed yet so report that error first
 		// therefore we can just manually edit the file to fake it had been deployed
 		app := application.New()
-		app.Setup(utils.GetBaseDir(), logging.NoLog{}, nil, nil, nil)
+		app.Setup(utils.GetBaseDir(), logging.NoLog{}, nil, "", nil, nil)
 		sc := models.Sidecar{
 			Name:     subnetName,
 			Subnet:   subnetName,
@@ -105,7 +105,7 @@ var _ = ginkgo.Describe("[Upgrade public network SOV]", ginkgo.Ordered, func() {
 		// simulate as if this had already been deployed to fuji
 		// by just entering fake data into the struct
 		app := application.New()
-		app.Setup(utils.GetBaseDir(), logging.NoLog{}, nil, nil, nil)
+		app.Setup(utils.GetBaseDir(), logging.NoLog{}, nil, "", nil, nil)
 
 		sc, err := app.LoadSidecar(subnetName)
 		gomega.Expect(err).Should(gomega.BeNil())
@@ -210,7 +210,7 @@ var _ = ginkgo.Describe("[Upgrade local network SOV]", ginkgo.Ordered, func() {
 		gomega.Expect(err).Should(gomega.BeNil())
 
 		app := application.New()
-		app.Setup(utils.GetBaseDir(), logging.NoLog{}, nil, nil, nil)
+		app.Setup(utils.GetBaseDir(), logging.NoLog{}, nil, "", nil, nil)
 
 		stripped := stripWhitespaces(string(upgradeBytes))
 		lockUpgradeBytes, err := app.ReadLockUpgradeFile(subnetName)


### PR DESCRIPTION
## Why this should be merged
- base user id on current codespace, which enables better estimation of unique users
-  adds a boolean for codespace set or not, which enables easiest discrimination on posthog insights 
- fixes app version (it was always empty...)
- adds a env var to set posthog token, to ease testing activities
 
## How this works

## How this was tested

## How is this documented
