### PR TITLE
Add signature aggregator wait for healthy

### DIFF
--- a/cmd/blockchaincmd/add_validator.go
+++ b/cmd/blockchaincmd/add_validator.go
@@ -10,12 +10,6 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanche-cli/pkg/blockchain"
-
-	"github.com/ava-labs/avalanchego/config"
-	"github.com/ava-labs/avalanchego/utils/units"
-
-	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/contract"
@@ -29,12 +23,16 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanche-cli/pkg/validatormanager"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 	"github.com/ava-labs/avalanche-cli/sdk/validator"
+	"github.com/ava-labs/avalanchego/config"
 	"github.com/ava-labs/avalanchego/ids"
 	avagoconstants "github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
 	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/utils/units"
 	warpMessage "github.com/ava-labs/avalanchego/vms/platformvm/warp/message"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 )
 
@@ -502,7 +500,10 @@ func CallAddValidator(
 	if err != nil {
 		return err
 	}
+	aggregatorCtx, aggregatorCancel := sdkutils.GetTimedContext(constants.SignatureAggregatorTimeout)
+	defer aggregatorCancel()
 	signedMessage, validationID, err := validatormanager.InitValidatorRegistration(
+		aggregatorCtx,
 		app,
 		network,
 		rpcURL,
@@ -544,6 +545,7 @@ func CallAddValidator(
 	}
 
 	if err := validatormanager.FinishValidatorRegistration(
+		aggregatorCtx,
 		app,
 		network,
 		rpcURL,

--- a/cmd/blockchaincmd/convert.go
+++ b/cmd/blockchaincmd/convert.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanche-cli/pkg/vm"
 	blockchainSDK "github.com/ava-labs/avalanche-cli/sdk/blockchain"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 	validatorManagerSDK "github.com/ava-labs/avalanche-cli/sdk/validatormanager"
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/config"
@@ -330,9 +331,12 @@ func InitializeValidatorManager(blockchainName,
 	if err != nil {
 		return tracked, err
 	}
+	aggregatorCtx, aggregatorCancel := sdkutils.GetTimedContext(constants.SignatureAggregatorTimeout)
+	defer aggregatorCancel()
 	if pos {
 		ux.Logger.PrintToUser("Initializing Native Token Proof of Stake Validator Manager contract on blockchain %s ...", blockchainName)
 		if err := subnetSDK.InitializeProofOfStake(
+			aggregatorCtx,
 			network,
 			genesisPrivateKey,
 			extraAggregatorPeers,
@@ -355,6 +359,7 @@ func InitializeValidatorManager(blockchainName,
 	} else {
 		ux.Logger.PrintToUser("Initializing Proof of Authority Validator Manager contract on blockchain %s ...", blockchainName)
 		if err := subnetSDK.InitializeProofOfAuthority(
+			aggregatorCtx,
 			network,
 			genesisPrivateKey,
 			extraAggregatorPeers,

--- a/cmd/blockchaincmd/remove_validator.go
+++ b/cmd/blockchaincmd/remove_validator.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanche-cli/pkg/validatormanager"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 	validatormanagerSDK "github.com/ava-labs/avalanche-cli/sdk/validatormanager"
 	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
@@ -288,8 +289,11 @@ func removeValidatorSOV(
 		signedMessage *warp.Message
 		validationID  ids.ID
 	)
+	aggregatorCtx, aggregatorCancel := sdkutils.GetTimedContext(constants.SignatureAggregatorTimeout)
+	defer aggregatorCancel()
 	// try to remove the validator. If err is "delegator ineligible for rewards" confirm with user and force remove
 	signedMessage, validationID, err = validatormanager.InitValidatorRemoval(
+		aggregatorCtx,
 		app,
 		network,
 		rpcURL,
@@ -314,6 +318,7 @@ func removeValidatorSOV(
 			return fmt.Errorf("validator %s is not eligible for rewards. Use --force flag to force removal", nodeID)
 		}
 		signedMessage, validationID, err = validatormanager.InitValidatorRemoval(
+			aggregatorCtx,
 			app,
 			network,
 			rpcURL,
@@ -352,6 +357,7 @@ func removeValidatorSOV(
 	}
 
 	if err := validatormanager.FinishValidatorRemoval(
+		aggregatorCtx,
 		app,
 		network,
 		rpcURL,

--- a/cmd/contractcmd/init_validator_manager.go
+++ b/cmd/contractcmd/init_validator_manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanche-cli/pkg/validatormanager"
 	blockchainSDK "github.com/ava-labs/avalanche-cli/sdk/blockchain"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 	validatorManagerSDK "github.com/ava-labs/avalanche-cli/sdk/validatormanager"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
@@ -194,10 +195,13 @@ func initValidatorManager(_ *cobra.Command, args []string) error {
 		OwnerAddress:        &ownerAddress,
 		RPC:                 validatorManagerFlags.rpcEndpoint,
 	}
+	aggregatorCtx, aggregatorCancel := sdkutils.GetTimedContext(constants.SignatureAggregatorTimeout)
+	defer aggregatorCancel()
 	switch {
 	case sc.PoA(): // PoA
 		ux.Logger.PrintToUser(logging.Yellow.Wrap("Initializing Proof of Authority Validator Manager contract on blockchain %s"), blockchainName)
 		if err := validatormanager.SetupPoA(
+			aggregatorCtx,
 			subnetSDK,
 			network,
 			privateKey,
@@ -215,6 +219,7 @@ func initValidatorManager(_ *cobra.Command, args []string) error {
 			initPOSManagerFlags.rewardCalculatorAddress = validatorManagerSDK.RewardCalculatorAddress
 		}
 		if err := validatormanager.SetupPoS(
+			aggregatorCtx,
 			subnetSDK,
 			network,
 			privateKey,

--- a/cmd/nodecmd/local.go
+++ b/cmd/nodecmd/local.go
@@ -9,32 +9,31 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ava-labs/avalanchego/vms/platformvm"
-	"github.com/ava-labs/avalanchego/vms/platformvm/api"
-
-	"github.com/ava-labs/avalanchego/api/info"
-
-	"github.com/ava-labs/avalanche-cli/pkg/blockchain"
-	"github.com/ava-labs/avalanche-cli/pkg/constants"
-	"github.com/ava-labs/avalanche-cli/pkg/subnet"
-	"github.com/ava-labs/avalanche-cli/pkg/validatormanager"
-	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/utils/formatting/address"
-	warpMessage "github.com/ava-labs/avalanchego/vms/platformvm/warp/message"
-
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
+	"github.com/ava-labs/avalanche-cli/pkg/blockchain"
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
+	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/contract"
 	"github.com/ava-labs/avalanche-cli/pkg/keychain"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
 	"github.com/ava-labs/avalanche-cli/pkg/node"
 	"github.com/ava-labs/avalanche-cli/pkg/prompts"
+	"github.com/ava-labs/avalanche-cli/pkg/subnet"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	"github.com/ava-labs/avalanche-cli/pkg/validatormanager"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
+	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/config"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/formatting/address"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/vms/platformvm"
+	"github.com/ava-labs/avalanchego/vms/platformvm/api"
+	warpMessage "github.com/ava-labs/avalanchego/vms/platformvm/warp/message"
+
 	"github.com/spf13/cobra"
 )
 
@@ -541,7 +540,10 @@ func addAsValidator(network models.Network,
 		return fmt.Errorf("failure parsing BLS info: %w", err)
 	}
 
+	aggregatorCtx, aggregatorCancel := sdkutils.GetTimedContext(constants.SignatureAggregatorTimeout)
+	defer aggregatorCancel()
 	signedMessage, validationID, err := validatormanager.InitValidatorRegistration(
+		aggregatorCtx,
 		app,
 		network,
 		rpcURL,
@@ -584,6 +586,7 @@ func addAsValidator(network models.Network,
 	}
 
 	if err := validatormanager.FinishValidatorRegistration(
+		aggregatorCtx,
 		app,
 		network,
 		rpcURL,

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -344,4 +344,5 @@ const (
 	DefaultAggregatorLogLevel  = "Debug"
 	SignatureAggregatorLogName = "signature-aggregator"
 	MaxL1TotalWeightChange     = 0.2
+	SignatureAggregatorTimeout = 60 * time.Second
 )

--- a/pkg/validatormanager/registration.go
+++ b/pkg/validatormanager/registration.go
@@ -3,6 +3,7 @@
 package validatormanager
 
 import (
+	"context"
 	_ "embed"
 	"errors"
 	"fmt"
@@ -149,6 +150,7 @@ func InitializeValidatorRegistrationPoA(
 }
 
 func GetSubnetValidatorRegistrationMessage(
+	ctx context.Context,
 	rpcURL string,
 	network models.Network,
 	aggregatorLogger logging.Logger,
@@ -222,6 +224,7 @@ func GetSubnetValidatorRegistrationMessage(
 		}
 	}
 	signatureAggregator, err := interchain.NewSignatureAggregator(
+		ctx,
 		network,
 		aggregatorLogger,
 		subnetID,
@@ -258,6 +261,7 @@ func GetValidatorWeight(
 }
 
 func GetPChainSubnetValidatorRegistrationWarpMessage(
+	ctx context.Context,
 	network models.Network,
 	rpcURL string,
 	aggregatorLogger logging.Logger,
@@ -288,6 +292,7 @@ func GetPChainSubnetValidatorRegistrationWarpMessage(
 		return nil, err
 	}
 	signatureAggregator, err := interchain.NewSignatureAggregator(
+		ctx,
 		network,
 		aggregatorLogger,
 		subnetID,
@@ -329,6 +334,7 @@ func CompleteValidatorRegistration(
 }
 
 func InitValidatorRegistration(
+	ctx context.Context,
 	app *application.Avalanche,
 	network models.Network,
 	rpcURL string,
@@ -431,6 +437,7 @@ func InitValidatorRegistration(
 	}
 
 	return GetSubnetValidatorRegistrationMessage(
+		ctx,
 		rpcURL,
 		network,
 		aggregatorLogger,
@@ -451,6 +458,7 @@ func InitValidatorRegistration(
 }
 
 func FinishValidatorRegistration(
+	ctx context.Context,
 	app *application.Avalanche,
 	network models.Network,
 	rpcURL string,
@@ -472,6 +480,7 @@ func FinishValidatorRegistration(
 	}
 	managerAddress := common.HexToAddress(validatorManagerAddressStr)
 	signedMessage, err := GetPChainSubnetValidatorRegistrationWarpMessage(
+		ctx,
 		network,
 		rpcURL,
 		aggregatorLogger,

--- a/pkg/validatormanager/removal.go
+++ b/pkg/validatormanager/removal.go
@@ -3,6 +3,7 @@
 package validatormanager
 
 import (
+	"context"
 	_ "embed"
 	"errors"
 	"fmt"
@@ -81,6 +82,7 @@ func InitializeValidatorRemoval(
 }
 
 func GetUptimeProofMessage(
+	ctx context.Context,
 	network models.Network,
 	aggregatorLogger logging.Logger,
 	aggregatorQuorumPercentage uint64,
@@ -107,6 +109,7 @@ func GetUptimeProofMessage(
 		return nil, err
 	}
 	signatureAggregator, err := interchain.NewSignatureAggregator(
+		ctx,
 		network,
 		aggregatorLogger,
 		subnetID,
@@ -121,6 +124,7 @@ func GetUptimeProofMessage(
 }
 
 func GetSubnetValidatorWeightMessage(
+	ctx context.Context,
 	network models.Network,
 	aggregatorLogger logging.Logger,
 	aggregatorQuorumPercentage uint64,
@@ -157,6 +161,7 @@ func GetSubnetValidatorWeightMessage(
 		return nil, err
 	}
 	signatureAggregator, err := interchain.NewSignatureAggregator(
+		ctx,
 		network,
 		aggregatorLogger,
 		subnetID,
@@ -171,6 +176,7 @@ func GetSubnetValidatorWeightMessage(
 }
 
 func InitValidatorRemoval(
+	ctx context.Context,
 	app *application.Avalanche,
 	network models.Network,
 	rpcURL string,
@@ -224,6 +230,7 @@ func InitValidatorRemoval(
 		}
 		ux.Logger.PrintToUser("Using uptime: %ds", uptimeSec)
 		signedUptimeProof, err = GetUptimeProofMessage(
+			ctx,
 			network,
 			aggregatorLogger,
 			0,
@@ -255,6 +262,7 @@ func InitValidatorRemoval(
 
 	nonce := uint64(1)
 	signedMsg, err := GetSubnetValidatorWeightMessage(
+		ctx,
 		network,
 		aggregatorLogger,
 		0,
@@ -290,6 +298,7 @@ func CompleteValidatorRemoval(
 }
 
 func FinishValidatorRemoval(
+	ctx context.Context,
 	app *application.Avalanche,
 	network models.Network,
 	rpcURL string,
@@ -311,6 +320,7 @@ func FinishValidatorRemoval(
 		return err
 	}
 	signedMessage, err := GetPChainSubnetValidatorRegistrationWarpMessage(
+		ctx,
 		network,
 		rpcURL,
 		aggregatorLogger,

--- a/pkg/validatormanager/validatormanager.go
+++ b/pkg/validatormanager/validatormanager.go
@@ -3,6 +3,7 @@
 package validatormanager
 
 import (
+	"context"
 	_ "embed"
 	"math/big"
 	"strings"
@@ -127,6 +128,7 @@ func AddRewardCalculatorToAllocations(
 // [convertSubnetValidators], together with an evm [ownerAddress]
 // to set as the owner of the PoA manager
 func SetupPoA(
+	ctx context.Context,
 	subnet blockchainSDK.Subnet,
 	network models.Network,
 	privateKey string,
@@ -136,6 +138,7 @@ func SetupPoA(
 	validatorManagerAddressStr string,
 ) error {
 	return subnet.InitializeProofOfAuthority(
+		ctx,
 		network,
 		privateKey,
 		aggregatorExtraPeerEndpoints,
@@ -151,6 +154,7 @@ func SetupPoA(
 // [convertSubnetValidators], together with an evm [ownerAddress]
 // to set as the owner of the PoA manager
 func SetupPoS(
+	ctx context.Context,
 	subnet blockchainSDK.Subnet,
 	network models.Network,
 	privateKey string,
@@ -160,7 +164,9 @@ func SetupPoS(
 	posParams validatorManagerSDK.PoSParams,
 	validatorManagerAddressStr string,
 ) error {
-	return subnet.InitializeProofOfStake(network,
+	return subnet.InitializeProofOfStake(
+		ctx,
+		network,
 		privateKey,
 		aggregatorExtraPeerEndpoints,
 		aggregatorAllowPrivatePeers,

--- a/sdk/blockchain/blockchain.go
+++ b/sdk/blockchain/blockchain.go
@@ -5,6 +5,7 @@ package blockchain
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -342,6 +343,7 @@ func (c *Subnet) Commit(ms multisig.Multisig, wallet wallet.Wallet, waitForTxAcc
 // [convertSubnetValidators], together with an evm [ownerAddress]
 // to set as the owner of the PoA manager
 func (c *Subnet) InitializeProofOfAuthority(
+	ctx context.Context,
 	network models.Network,
 	privateKey string,
 	aggregatorExtraPeerEndpoints []info.Peer,
@@ -391,6 +393,7 @@ func (c *Subnet) InitializeProofOfAuthority(
 	}
 
 	subnetConversionSignedMessage, err := validatormanager.GetPChainSubnetConversionWarpMessage(
+		ctx,
 		network,
 		aggregatorLogger,
 		0,
@@ -422,6 +425,7 @@ func (c *Subnet) InitializeProofOfAuthority(
 }
 
 func (c *Subnet) InitializeProofOfStake(
+	ctx context.Context,
 	network models.Network,
 	privateKey string,
 	aggregatorExtraPeerEndpoints []info.Peer,
@@ -451,6 +455,7 @@ func (c *Subnet) InitializeProofOfStake(
 		ux.Logger.PrintToUser("Warning: the PoS contract is already initialized.")
 	}
 	subnetConversionSignedMessage, err := validatormanager.GetPChainSubnetConversionWarpMessage(
+		ctx,
 		network,
 		aggregatorLogger,
 		0,

--- a/sdk/interchain/signature-aggregator.go
+++ b/sdk/interchain/signature-aggregator.go
@@ -3,8 +3,10 @@
 package interchain
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
+	"time"
 
 	"github.com/ava-labs/icm-services/signature-aggregator/aggregator"
 	"github.com/ava-labs/icm-services/signature-aggregator/metrics"
@@ -13,7 +15,7 @@ import (
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/message"
-	avagoconstants "github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	apiConfig "github.com/ava-labs/icm-services/config"
@@ -33,6 +35,7 @@ type SignatureAggregator struct {
 	subnetID         ids.ID
 	quorumPercentage uint64
 	aggregator       *aggregator.SignatureAggregator
+	network          peers.AppRequestNetwork
 }
 
 // createAppRequestNetwork creates a new AppRequestNetwork for the given network and log level.
@@ -50,21 +53,27 @@ func createAppRequestNetwork(
 	registerer prometheus.Registerer,
 	allowPrivatePeers bool,
 	extraPeerEndpoints []info.Peer,
+	trackedSubnetIDs []string,
 ) (peers.AppRequestNetwork, error) {
+	networkConfig := config.Config{
+		PChainAPI: &apiConfig.APIConfig{
+			BaseURL: network.Endpoint,
+		},
+		InfoAPI: &apiConfig.APIConfig{
+			BaseURL: network.Endpoint,
+		},
+		AllowPrivateIPs:  allowPrivatePeers,
+		TrackedSubnetIDs: trackedSubnetIDs,
+	}
+	if err := networkConfig.Validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate peer network config: %w", err)
+	}
 	peerNetwork, err := peers.NewNetwork(
 		logger,
 		registerer,
-		nil,
+		networkConfig.GetTrackedSubnets(),
 		extraPeerEndpoints,
-		&config.Config{
-			PChainAPI: &apiConfig.APIConfig{
-				BaseURL: network.Endpoint,
-			},
-			InfoAPI: &apiConfig.APIConfig{
-				BaseURL: network.Endpoint,
-			},
-			AllowPrivateIPs: allowPrivatePeers,
-		},
+		&networkConfig,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create peer network: %w", err)
@@ -100,8 +109,8 @@ func initSignatureAggregator(
 	messageCreator, err := message.NewCreator(
 		logger,
 		registerer,
-		avagoconstants.DefaultNetworkCompressionType,
-		avagoconstants.DefaultNetworkMaximumInboundTimeout,
+		constants.DefaultNetworkCompressionType,
+		constants.DefaultNetworkMaximumInboundTimeout,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create message creator: %w", err)
@@ -119,6 +128,7 @@ func initSignatureAggregator(
 		return nil, fmt.Errorf("failed to create signature aggregator: %w", err)
 	}
 	sa.aggregator = signatureAggregator
+	sa.network = network
 	return sa, nil
 }
 
@@ -132,6 +142,7 @@ func initSignatureAggregator(
 //
 // Returns a new signature aggregator instance, or an error if creation fails.
 func NewSignatureAggregator(
+	ctx context.Context,
 	network models.Network,
 	logger logging.Logger,
 	subnetID ids.ID,
@@ -140,11 +151,39 @@ func NewSignatureAggregator(
 	extraPeerEndpoints []info.Peer,
 ) (*SignatureAggregator, error) {
 	registerer := prometheus.NewRegistry()
-	peerNetwork, err := createAppRequestNetwork(network, logger, registerer, allowPrivatePeers, extraPeerEndpoints)
+	trackedSubnetIDs := []string{}
+	if subnetID != constants.PrimaryNetworkID {
+		trackedSubnetIDs = append(trackedSubnetIDs, subnetID.String())
+	}
+	peerNetwork, err := createAppRequestNetwork(network, logger, registerer, allowPrivatePeers, extraPeerEndpoints, trackedSubnetIDs)
 	if err != nil {
 		return nil, err
 	}
-	return initSignatureAggregator(peerNetwork, logger, registerer, subnetID, quorumPercentage)
+	sa, err := initSignatureAggregator(peerNetwork, logger, registerer, subnetID, quorumPercentage)
+	if err != nil {
+		return sa, err
+	}
+	err = sa.waitForHealthy(ctx)
+	return sa, err
+}
+
+func (s *SignatureAggregator) waitForHealthy(ctx context.Context) error {
+	subnets := []ids.ID{}
+	if s.subnetID != constants.PrimaryNetworkID {
+		subnets = append(subnets, s.subnetID)
+	}
+	subnets = append(subnets, constants.PrimaryNetworkID)
+	healthy := peers.GetNetworkHealthFunc(s.network, subnets)
+	for {
+		if err := healthy(ctx); err == nil {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for signature aggregation being healthy: %w", ctx.Err())
+		case <-time.After(1 * time.Second):
+		}
+	}
 }
 
 // AggregateSignatures aggregates signatures for a given message and justification.

--- a/sdk/validatormanager/root.go
+++ b/sdk/validatormanager/root.go
@@ -4,6 +4,7 @@
 package validatormanager
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 
@@ -178,6 +179,7 @@ func (p PoSParams) Verify() error {
 // together with the validator's manager [managerBlockchainID],
 // [managerAddress], and the initial list of [validators]
 func GetPChainSubnetConversionWarpMessage(
+	ctx context.Context,
 	network models.Network,
 	aggregatorLogger logging.Logger,
 	aggregatorQuorumPercentage uint64,
@@ -226,6 +228,7 @@ func GetPChainSubnetConversionWarpMessage(
 		return nil, err
 	}
 	signatureAggregator, err := interchain.NewSignatureAggregator(
+		ctx,
 		network,
 		aggregatorLogger,
 		subnetID,

--- a/tests/e2e/testcases/validatormanager/suite.go
+++ b/tests/e2e/testcases/validatormanager/suite.go
@@ -213,7 +213,9 @@ var _ = ginkgo.Describe("[Validator Manager POA Set Up]", ginkgo.Ordered, func()
 			BootstrapValidators: avaGoBootstrapValidators,
 		}
 
-		err = subnetSDK.InitializeProofOfAuthority(network, k.PrivKeyHex(), extraAggregatorPeers, true, logging.NoLog{}, ProxyContractAddress)
+		ctx, cancel := utils.GetSignatureAggregatorContext()
+		defer cancel()
+		err = subnetSDK.InitializeProofOfAuthority(ctx, network, k.PrivKeyHex(), extraAggregatorPeers, true, logging.NoLog{}, ProxyContractAddress)
 		gomega.Expect(err).Should(gomega.BeNil())
 	})
 })

--- a/tests/e2e/utils/helpers.go
+++ b/tests/e2e/utils/helpers.go
@@ -1107,6 +1107,10 @@ func GetAPILargeContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), constants.APIRequestLargeTimeout)
 }
 
+func GetSignatureAggregatorContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), constants.SignatureAggregatorTimeout)
+}
+
 func GetE2EHostInstanceID() (string, error) {
 	hosts, err := ansible.GetInventoryFromAnsibleInventoryFile(path.Join(GetBaseDir(), constants.NodesDir, constants.AnsibleInventoryDir, constants.E2EClusterName))
 	if err != nil {


### PR DESCRIPTION
## Why this should be merged
Issues are being observed regarding collecting signatures that are just related to network timeouts
and not to misconfigurations or invalid warp message esp/state
This PR is first step to try to aleviate issues, by waiting for full connection to tracked subnet and
primary network before attempting to recollect signatures

## How this works

## How this was tested

## How is this documented
