### PR TITLE
enable change owner for sov

### DIFF
--- a/cmd/blockchaincmd/change_owner.go
+++ b/cmd/blockchaincmd/change_owner.go
@@ -3,7 +3,6 @@
 package blockchaincmd
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
@@ -15,6 +14,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanchego/ids"
+
 	"github.com/spf13/cobra"
 )
 
@@ -90,21 +90,14 @@ func changeOwner(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	if sc.Sovereign {
-		return errors.New("avalanche blockchain changeOwner is not applicable to sovereign blockchains")
-	}
-
 	subnetID := sc.Networks[network.Name()].SubnetID
 	if subnetID == ids.Empty {
 		return errNoSubnetID
 	}
 
-	isPermissioned, currentControlKeys, currentThreshold, err := txutils.GetOwners(network, subnetID)
+	_, currentControlKeys, currentThreshold, err := txutils.GetOwners(network, subnetID)
 	if err != nil {
 		return err
-	}
-	if !isPermissioned {
-		return ErrNotPermissionedSubnet
 	}
 
 	// add control keys to the keychain whenever possible

--- a/cmd/blockchaincmd/describe.go
+++ b/cmd/blockchaincmd/describe.go
@@ -149,13 +149,11 @@ func PrintSubnetInfo(blockchainName string, onlyLocalnetInfo bool) error {
 		}
 		if data.SubnetID != ids.Empty {
 			t.AppendRow(table.Row{net, "SubnetID", data.SubnetID.String()})
-			isPermissioned, owners, threshold, err := txutils.GetOwners(network, data.SubnetID)
+			_, owners, threshold, err := txutils.GetOwners(network, data.SubnetID)
 			if err != nil {
 				return err
 			}
-			if isPermissioned {
-				t.AppendRow(table.Row{net, fmt.Sprintf("Owners (Threhold=%d)", threshold), strings.Join(owners, "\n")})
-			}
+			t.AppendRow(table.Row{net, fmt.Sprintf("Owners (Threhold=%d)", threshold), strings.Join(owners, "\n")})
 		}
 		if data.BlockchainID != ids.Empty {
 			hexEncoding := "0x" + hex.EncodeToString(data.BlockchainID[:])


### PR DESCRIPTION
## Why this should be merged
P-Chain change owner is a valid op for a sov l1. Some groups request being able to change it even for l1s

## How this works

## How this was tested

## How is this documented
