### PR TITLE
Convert: Fix assignment mismatch

### DIFF
--- a/cmd/blockchaincmd/convert.go
+++ b/cmd/blockchaincmd/convert.go
@@ -583,7 +583,7 @@ func convertBlockchain(_ *cobra.Command, args []string) error {
 			}
 
 		default:
-			bootstrapValidators, _, err = promptBootstrapValidators(
+			bootstrapValidators, err = promptBootstrapValidators(
 				network,
 				changeOwnerAddress,
 				numBootstrapValidators,


### PR DESCRIPTION
## Why this should be merged
Fixes the assignment mismatch

## How this works
Remove the _

## How this was tested

## How is this documented
