### PR TITLE
Validate convert txs

### DIFF
--- a/cmd/blockchaincmd/convert.go
+++ b/cmd/blockchaincmd/convert.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanche-cli/pkg/blockchain"
+	"github.com/ava-labs/avalanche-cli/pkg/clierrors"
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/contract"
@@ -419,6 +420,15 @@ func convertSubnetToL1(
 	subnetAuthKeysList []string,
 	validatorManagerAddressStr string,
 ) ([]*txs.ConvertSubnetToL1Validator, bool, error) {
+	if subnetID == ids.Empty {
+		return nil, false, clierrors.ErrNoSubnetID
+	}
+	if blockchainID == ids.Empty {
+		return nil, false, clierrors.ErrNoBlockchainID
+	}
+	if !common.IsHexAddress(validatorManagerAddressStr) {
+		return nil, false, clierrors.ErrInvalidValidatorManagerAddress
+	}
 	avaGoBootstrapValidators, err := ConvertToAvalancheGoSubnetValidator(bootstrapValidators)
 	if err != nil {
 		return avaGoBootstrapValidators, false, err
@@ -525,6 +535,13 @@ func convertBlockchain(_ *cobra.Command, args []string) error {
 
 	subnetID := sidecar.Networks[network.Name()].SubnetID
 	blockchainID := sidecar.Networks[network.Name()].BlockchainID
+
+	if subnetID == ids.Empty {
+		return clierrors.ErrNoSubnetID
+	}
+	if blockchainID == ids.Empty {
+		return clierrors.ErrNoBlockchainID
+	}
 
 	if !convertOnly {
 		if validatorManagerAddress == "" {

--- a/cmd/blockchaincmd/helpers.go
+++ b/cmd/blockchaincmd/helpers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ava-labs/avalanche-cli/pkg/application"
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
+	"github.com/ava-labs/avalanche-cli/pkg/clierrors"
 	"github.com/ava-labs/avalanche-cli/pkg/contract"
 	"github.com/ava-labs/avalanche-cli/pkg/keychain"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
@@ -85,7 +86,7 @@ func UpdateKeychainWithSubnetControlKeys(
 	}
 	subnetID := sc.Networks[network.Name()].SubnetID
 	if subnetID == ids.Empty {
-		return errNoSubnetID
+		return clierrors.ErrNoSubnetID
 	}
 	_, controlKeys, _, err := txutils.GetOwners(network, subnetID)
 	if err != nil {

--- a/cmd/blockchaincmd/remove_validator.go
+++ b/cmd/blockchaincmd/remove_validator.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/ava-labs/avalanche-cli/pkg/blockchain"
+	"github.com/ava-labs/avalanche-cli/pkg/clierrors"
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/contract"
@@ -117,7 +118,7 @@ func removeValidator(_ *cobra.Command, args []string) error {
 	scNetwork := sc.Networks[network.Name()]
 	subnetID := scNetwork.SubnetID
 	if subnetID == ids.Empty {
-		return errNoSubnetID
+		return clierrors.ErrNoSubnetID
 	}
 
 	var nodeID ids.NodeID

--- a/cmd/nodecmd/status.go
+++ b/cmd/nodecmd/status.go
@@ -8,18 +8,19 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ava-labs/avalanche-cli/pkg/node"
-
 	"github.com/ava-labs/avalanche-cli/cmd/blockchaincmd"
 	"github.com/ava-labs/avalanche-cli/pkg/ansible"
+	"github.com/ava-labs/avalanche-cli/pkg/clierrors"
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanche-cli/pkg/node"
 	"github.com/ava-labs/avalanche-cli/pkg/ssh"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
+
 	"github.com/olekukonko/tablewriter"
 	"github.com/pborman/ansi"
 	"github.com/spf13/cobra"
@@ -71,7 +72,7 @@ func statusNode(_ *cobra.Command, args []string) error {
 		}
 		blockchainID = sc.Networks[clusterConf.Network.Name()].BlockchainID
 		if blockchainID == ids.Empty {
-			return ErrNoBlockchainID
+			return clierrors.ErrNoBlockchainID
 		}
 	}
 

--- a/cmd/nodecmd/validate_primary.go
+++ b/cmd/nodecmd/validate_primary.go
@@ -43,8 +43,6 @@ var (
 	useCustomDuration            bool
 	ErrMutuallyExlusiveKeyLedger = errors.New("--key and --ledger,--ledger-addrs are mutually exclusive")
 	ErrStoredKeyOnMainnet        = errors.New("--key is not available for mainnet operations")
-	ErrNoBlockchainID            = errors.New("failed to find the blockchain ID for this subnet, has it been deployed/created on this network?")
-	ErrNoSubnetID                = errors.New("failed to find the subnet ID for this subnet, has it been deployed/created on this network?")
 )
 
 func newValidatePrimaryCmd() *cobra.Command {

--- a/cmd/nodecmd/validate_subnet.go
+++ b/cmd/nodecmd/validate_subnet.go
@@ -12,6 +12,7 @@ import (
 
 	blockchaincmd "github.com/ava-labs/avalanche-cli/cmd/blockchaincmd"
 	"github.com/ava-labs/avalanche-cli/pkg/ansible"
+	"github.com/ava-labs/avalanche-cli/pkg/clierrors"
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/keychain"
@@ -255,7 +256,7 @@ func validateSubnet(_ *cobra.Command, args []string) error {
 	if !avoidSubnetValidationChecks {
 		blockchainID = sc.Networks[network.Name()].BlockchainID
 		if blockchainID == ids.Empty {
-			return ErrNoBlockchainID
+			return clierrors.ErrNoBlockchainID
 		}
 	}
 	nodeErrors := map[string]error{}

--- a/cmd/nodecmd/wiz.go
+++ b/cmd/nodecmd/wiz.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/cmd/blockchaincmd"
 	"github.com/ava-labs/avalanche-cli/cmd/interchaincmd/messengercmd"
 	"github.com/ava-labs/avalanche-cli/pkg/ansible"
+	"github.com/ava-labs/avalanche-cli/pkg/clierrors"
 	awsAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/aws"
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
@@ -308,7 +309,7 @@ func wiz(cmd *cobra.Command, args []string) error {
 	}
 	subnetID := sc.Networks[network.Name()].SubnetID
 	if subnetID == ids.Empty {
-		return ErrNoSubnetID
+		return clierrors.ErrNoSubnetID
 	}
 
 	ux.Logger.PrintToUser("")
@@ -366,7 +367,7 @@ func wiz(cmd *cobra.Command, args []string) error {
 	}
 	blockchainID := sc.Networks[network.Name()].BlockchainID
 	if blockchainID == ids.Empty {
-		return ErrNoBlockchainID
+		return clierrors.ErrNoBlockchainID
 	}
 	// update logging
 	if addMonitoring {
@@ -503,7 +504,7 @@ func updateProposerVMs(
 			ux.Logger.PrintToUser("Updating proposerVM on %s", deployedSubnetName)
 			blockchainID := deployedSubnetSc.Networks[network.Name()].BlockchainID
 			if blockchainID == ids.Empty {
-				return ErrNoBlockchainID
+				return clierrors.ErrNoBlockchainID
 			}
 			if err := interchain.SetProposerVM(app, network, blockchainID.String(), deployedSubnetSc.TeleporterKey); err != nil {
 				return err

--- a/cmd/transactioncmd/helpers.go
+++ b/cmd/transactioncmd/helpers.go
@@ -1,0 +1,36 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+package transactioncmd
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func validateConvertOperation(tx *txs.Tx, action string) (bool, error) {
+	convertToL1Tx, ok := tx.Unsigned.(*txs.ConvertSubnetToL1Tx)
+	if !ok {
+		return false, fmt.Errorf("expected tx to be of type txs.ConvertSubnetToL1Tx, found %T", tx.Unsigned)
+	}
+	ux.Logger.PrintToUser("You are about to %s a txs.ConvertSubnetToL1Tx with the following content:", action)
+	ux.Logger.PrintToUser("  Subnet ID: %s", convertToL1Tx.Subnet)
+	ux.Logger.PrintToUser("  Blockchain ID: %s", convertToL1Tx.BlockchainID)
+	ux.Logger.PrintToUser("  Manager Address: %s", common.BytesToAddress(convertToL1Tx.Address).Hex())
+	ux.Logger.PrintToUser("  Validators:")
+	for _, val := range convertToL1Tx.Validators {
+		nodeID, err := ids.ToNodeID(val.NodeID)
+		if err != nil {
+			return false, fmt.Errorf("unexpected node ID on tx")
+		}
+		ux.Logger.PrintToUser("    %s", nodeID)
+	}
+	ux.Logger.PrintToUser("")
+	ux.Logger.PrintToUser("Please review details and decide if it is safe to continue")
+	ux.Logger.PrintToUser("")
+	return app.Prompt.CaptureYesNo(fmt.Sprintf("Do you want to %s the transaction?", action))
+}

--- a/cmd/transactioncmd/transaction_commit.go
+++ b/cmd/transactioncmd/transaction_commit.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanche-cli/cmd/blockchaincmd"
+	"github.com/ava-labs/avalanche-cli/pkg/clierrors"
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/keychain"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
@@ -15,6 +16,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
 	"github.com/spf13/cobra"
 )
 
@@ -48,6 +50,15 @@ func commitTx(_ *cobra.Command, args []string) error {
 	isCreateChainTx := txutils.IsCreateChainTx(tx)
 
 	isConvertToL1Tx := txutils.IsConvertToL1Tx(tx)
+	if isConvertToL1Tx {
+		doContinue, err := validateConvertOperation(tx, "commit")
+		if err != nil {
+			return err
+		}
+		if !doContinue {
+			return nil
+		}
+	}
 
 	network, err := txutils.GetNetwork(tx)
 	if err != nil {
@@ -72,7 +83,7 @@ func commitTx(_ *cobra.Command, args []string) error {
 			}
 			subnetID = sc.Networks[network.Name()].SubnetID
 			if subnetID == ids.Empty {
-				return errNoSubnetID
+				return clierrors.ErrNoSubnetID
 			}
 		}
 	} else if isCreateChainTx {

--- a/cmd/transactioncmd/transaction_sign.go
+++ b/cmd/transactioncmd/transaction_sign.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/ava-labs/avalanche-cli/cmd/blockchaincmd"
+	"github.com/ava-labs/avalanche-cli/pkg/clierrors"
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/keychain"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
@@ -15,6 +16,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/txutils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanchego/ids"
+
 	"github.com/spf13/cobra"
 )
 
@@ -25,8 +27,6 @@ var (
 	keyName         string
 	useLedger       bool
 	ledgerAddresses []string
-
-	errNoSubnetID = errors.New("failed to find the subnet ID for this subnet, has it been deployed/created on this network?")
 )
 
 // avalanche transaction sign
@@ -57,6 +57,17 @@ func signTx(_ *cobra.Command, args []string) error {
 	tx, err := txutils.LoadFromDisk(inputTxPath)
 	if err != nil {
 		return err
+	}
+
+	isConvertToL1Tx := txutils.IsConvertToL1Tx(tx)
+	if isConvertToL1Tx {
+		doContinue, err := validateConvertOperation(tx, "sign")
+		if err != nil {
+			return err
+		}
+		if !doContinue {
+			return nil
+		}
 	}
 
 	if len(ledgerAddresses) > 0 {
@@ -112,7 +123,7 @@ func signTx(_ *cobra.Command, args []string) error {
 			}
 			subnetID = sc.Networks[network.Name()].SubnetID
 			if subnetID == ids.Empty {
-				return errNoSubnetID
+				return clierrors.ErrNoSubnetID
 			}
 		}
 	}

--- a/pkg/clierrors/clierrors.go
+++ b/pkg/clierrors/clierrors.go
@@ -1,0 +1,11 @@
+// Copyright (C) 2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+package clierrors
+
+import "errors"
+
+var (
+	ErrNoBlockchainID                 = errors.New("failed to find the blockchain ID for this subnet, has it been deployed/created on this network?")
+	ErrNoSubnetID                     = errors.New("failed to find the subnet ID for this subnet, has it been deployed/created on this network?")
+	ErrInvalidValidatorManagerAddress = errors.New("invalid validator manager address")
+)


### PR DESCRIPTION
## Why this should be merged
- It adds validation of blockchain ID, subnet ID, manager address before generating
a convert tx.
- It gives details on the tx about to be signed or committed before deciding to do so, on
multisig management commands

## How this works

## How this was tested

## How is this documented
