### PR TITLE
enable metrics by default, and set random user id

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -165,6 +165,7 @@ const (
 	ConfigAPMCredentialsFileKey   = "credentials-file"
 	ConfigAPMAdminAPIEndpointKey  = "admin-api-endpoint"
 	ConfigNodeConfigKey           = "node-config"
+	ConfigMetricsUserIDKey        = "MetricsUserID"
 	ConfigMetricsEnabledKey       = "MetricsEnabled"
 	ConfigUpdatesDisabledKey      = "UpdatesDisabled"
 	ConfigAuthorizeCloudAccessKey = "AuthorizeCloudAccess"


### PR DESCRIPTION
## Why this should be merged
Improve CLI metrics collection

## How this works

## How this was tested

## How is this documented
