### PR TITLE
Fix release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 RUN ./scripts/build.sh
 
 # ============= Release Stage ================
-FROM debian:12-slim
+FROM debian:sid-slim
 WORKDIR /
 
 # Copy the executables into the container


### PR DESCRIPTION
Fixes error during release 

```
 > [4/4] RUN /avalanche config update disable:
0.053 /avalanche: /lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.38' not found (required by /avalanche)
------
Dockerfile:4
--------------------
   2 |     RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
   3 |     COPY avalanche /
   4 | >>> RUN /avalanche config update disable
   5 |     ENTRYPOINT [ "/avalanche" ]
   6 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c /avalanche config update disable" did not complete successfully: exit code: 1
```