### PR TITLE
hardcode foundry version to 0.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 RUN ./scripts/build.sh
 
 # ============= Release Stage ================
-FROM debian:12-slim
+FROM debian:trixie-slim
 WORKDIR /
 
 # Copy the executables into the container

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM debian:12-slim
+FROM debian:trixie-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY avalanche /
 RUN /avalanche config update disable

--- a/cmd/interchaincmd/tokentransferrercmd/deploy.go
+++ b/cmd/interchaincmd/tokentransferrercmd/deploy.go
@@ -83,7 +83,7 @@ func NewDeployCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&deployFlags.homeFlags.native, "deploy-native-home", false, "deploy a Transferrer Home for the Chain's Native Token")
 	cmd.Flags().StringVar(&deployFlags.homeFlags.erc20Address, "deploy-erc20-home", "", "deploy a Transferrer Home for the given Chain's ERC20 Token")
 	cmd.Flags().StringVar(&deployFlags.homeFlags.homeAddress, "use-home", "", "use the given Transferrer's Home Address")
-	cmd.Flags().StringVar(&deployFlags.version, "version", "", "tag/branch/commit of Avalanche Interchain Token Transfer (ICTT) to be used (defaults to main branch)")
+	cmd.Flags().StringVar(&deployFlags.version, "version", constants.ICTTVersion, "tag/branch/commit of Avalanche Interchain Token Transfer (ICTT) to be used")
 	cmd.Flags().BoolVar(&deployFlags.remoteFlags.native, "deploy-native-remote", false, "deploy a Transferrer Remote for the Chain's Native Token")
 	cmd.Flags().BoolVar(&deployFlags.remoteFlags.removeMinterAdmin, "remove-minter-admin", false, "remove the native minter precompile admin found on remote blockchain genesis")
 	deployFlags.homeFlags.privateKeyFlags.SetFlagNames("home-private-key", "home-key", "home-genesis-key")
@@ -483,11 +483,7 @@ func CallDeploy(_ []string, flags DeployFlags) error {
 
 	// Setup Contracts
 	ux.Logger.PrintToUser("Downloading Avalanche ICTT Contracts")
-	version := constants.ICTTVersion
-	if flags.version != "" {
-		version = flags.version
-	}
-	if err := ictt.DownloadRepo(app, version); err != nil {
+	if err := ictt.DownloadRepo(app, flags.version); err != nil {
 		return err
 	}
 	ux.Logger.PrintToUser("Compiling Avalanche ICTT Contracts")

--- a/cmd/interchaincmd/tokentransferrercmd/deploy.go
+++ b/cmd/interchaincmd/tokentransferrercmd/deploy.go
@@ -532,7 +532,7 @@ func CallDeploy(_ []string, flags DeployFlags) error {
 			tokenHomeDecimals,
 		)
 		if err != nil {
-			return err
+			return fmt.Errorf("failure deploying ERC20 Home: %w", err)
 		}
 		ux.Logger.PrintToUser("Home Deployed to %s", homeRPCEndpoint)
 		ux.Logger.PrintToUser("Home Address: %s", homeAddress)
@@ -553,7 +553,7 @@ func CallDeploy(_ []string, flags DeployFlags) error {
 			nativeTokenSymbol,
 		)
 		if err != nil {
-			return err
+			return fmt.Errorf("failure deploying Wrapped Native Token: %w", err)
 		}
 		ux.Logger.PrintToUser("Wrapped Native Token Deployed to %s", homeRPCEndpoint)
 		ux.Logger.PrintToUser("%s Address: %s", nativeTokenSymbol, wrappedNativeTokenAddress)
@@ -567,7 +567,7 @@ func CallDeploy(_ []string, flags DeployFlags) error {
 			wrappedNativeTokenAddress,
 		)
 		if err != nil {
-			return err
+			return fmt.Errorf("failure deploying Native Home: %w", err)
 		}
 		ux.Logger.PrintToUser("Home Deployed to %s", homeRPCEndpoint)
 		ux.Logger.PrintToUser("Home Address: %s", homeAddress)
@@ -642,7 +642,7 @@ func CallDeploy(_ []string, flags DeployFlags) error {
 			remoteDecimals,
 		)
 		if err != nil {
-			return err
+			return fmt.Errorf("failure deploying ERC20 Remote: %w", err)
 		}
 	} else {
 		nativeTokenSymbol, err := getNativeTokenSymbol(
@@ -674,7 +674,7 @@ func CallDeploy(_ []string, flags DeployFlags) error {
 			big.NewInt(0),
 		)
 		if err != nil {
-			return err
+			return fmt.Errorf("failure deploying Native Remote: %w", err)
 		}
 	}
 	ux.Logger.PrintToUser("Remote Deployed to %s", remoteRPCEndpoint)

--- a/pkg/ictt/foundry.go
+++ b/pkg/ictt/foundry.go
@@ -14,6 +14,7 @@ import (
 )
 
 var (
+	foundryVersion   = "v0.2.1"
 	foundryupPath    = utils.ExpandHome("~/.foundry/bin/foundryup")
 	defaultForgePath = utils.ExpandHome("~/.foundry/bin/forge")
 )
@@ -36,7 +37,11 @@ func GetForgePath() (string, error) {
 
 func InstallFoundry() error {
 	ux.Logger.PrintToUser("Installing Foundry")
-	downloadCmd := exec.Command("curl", "-L", "https://foundry.paradigm.xyz")
+	downloadCmd := exec.Command(
+		"curl",
+		"-L",
+		fmt.Sprintf("https://raw.githubusercontent.com/ava-labs/foundry/%s/foundryup/install", foundryVersion),
+	)
 	installCmd := exec.Command("bash")
 	var downloadOutbuf, downloadErrbuf strings.Builder
 	downloadCmdStdoutPipe, err := downloadCmd.StdoutPipe()
@@ -71,7 +76,7 @@ func InstallFoundry() error {
 		return err
 	}
 	ux.Logger.PrintToUser(strings.TrimSuffix(installOutbuf.String(), "\n"))
-	out, err := exec.Command(foundryupPath).CombinedOutput()
+	out, err := exec.Command(foundryupPath, "-v", foundryVersion).CombinedOutput()
 	ux.Logger.PrintToUser(string(out))
 	if err != nil {
 		ux.Logger.PrintToUser("")


### PR DESCRIPTION
## Why this should be merged
Closes https://github.com/ava-labs/avalanche-cli/issues/2667

latest foundry version, which is actually installed by CLI, is found to generate
unoptimized contract binaries with too much a large size.

## How this works
hardcode foundry version to v0.2.1

## How this was tested
`avalanche ictt deploy`

## How is this documented
