### PR TITLE
Handle fuji v113

### DIFF
--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"golang.org/x/mod/semver"
+
 	validatorManagerSDK "github.com/ava-labs/avalanche-cli/sdk/validatormanager"
 
 	"github.com/ava-labs/avalanche-cli/pkg/blockchain"
@@ -471,6 +473,22 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 	}
 
 	ux.Logger.PrintToUser("Deploying %s to %s", chains, network.Name())
+
+	if network.Kind == models.Fuji && userProvidedAvagoVersion == "" {
+		latestAvagoVersion, err := app.Downloader.GetLatestReleaseVersion(
+			constants.AvaLabsOrg,
+			constants.AvalancheGoRepoName,
+			"",
+		)
+		if err != nil {
+			return err
+		}
+		versionComparison := semver.Compare(constants.FujiAvalancheGoV113, latestAvagoVersion)
+		if versionComparison == 1 {
+			userProvidedAvagoVersion = constants.FujiAvalancheGoV113
+		}
+		return nil
+	}
 
 	if network.Kind == models.Local {
 		app.Log.Debug("Deploy local")

--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -474,10 +474,7 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 
 	ux.Logger.PrintToUser("Deploying %s to %s", chains, network.Name())
 
-	fmt.Printf("we are here first network.Kind %s,  userProvidedAvagoVersion %s \n", network.Kind, userProvidedAvagoVersion)
-
 	if network.Kind == models.Fuji && userProvidedAvagoVersion == constants.DefaultAvalancheGoVersion {
-		fmt.Printf("we are here \n")
 		latestAvagoVersion, err := app.Downloader.GetLatestReleaseVersion(
 			constants.AvaLabsOrg,
 			constants.AvalancheGoRepoName,
@@ -491,7 +488,6 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 			userProvidedAvagoVersion = constants.FujiAvalancheGoV113
 		}
 	}
-	fmt.Printf("userProvidedAvagoVersion %s \n", userProvidedAvagoVersion)
 	if network.Kind == models.Local {
 		app.Log.Debug("Deploy local")
 

--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -474,7 +474,10 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 
 	ux.Logger.PrintToUser("Deploying %s to %s", chains, network.Name())
 
-	if network.Kind == models.Fuji && userProvidedAvagoVersion == "" {
+	fmt.Printf("we are here first network.Kind %s,  userProvidedAvagoVersion %s \n", network.Kind, userProvidedAvagoVersion)
+
+	if network.Kind == models.Fuji && userProvidedAvagoVersion == constants.DefaultAvalancheGoVersion {
+		fmt.Printf("we are here \n")
 		latestAvagoVersion, err := app.Downloader.GetLatestReleaseVersion(
 			constants.AvaLabsOrg,
 			constants.AvalancheGoRepoName,
@@ -488,7 +491,7 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 			userProvidedAvagoVersion = constants.FujiAvalancheGoV113
 		}
 	}
-
+	fmt.Printf("userProvidedAvagoVersion %s \n", userProvidedAvagoVersion)
 	if network.Kind == models.Local {
 		app.Log.Debug("Deploy local")
 

--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -487,7 +487,6 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 		if versionComparison == 1 {
 			userProvidedAvagoVersion = constants.FujiAvalancheGoV113
 		}
-		return nil
 	}
 
 	if network.Kind == models.Local {

--- a/cmd/nodecmd/local.go
+++ b/cmd/nodecmd/local.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/mod/semver"
+
 	"github.com/ava-labs/avalanche-cli/pkg/binutils"
 	"github.com/ava-labs/avalanche-cli/pkg/blockchain"
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
@@ -182,6 +184,21 @@ func localStartNode(_ *cobra.Command, args []string) error {
 		StakingSignerKeyPath: stakingTLSKeyPath,
 		StakingCertKeyPath:   stakingCertKeyPath,
 		StakingTLSKeyPath:    stakingTLSKeyPath,
+	}
+	// TODO: remove this check for releases above v1.8.7, once v1.13.0-fuji avalanchego is latest release
+	if globalNetworkFlags.UseFuji && useCustomAvalanchegoVersion == "" {
+		latestAvagoVersion, err := app.Downloader.GetLatestReleaseVersion(
+			constants.AvaLabsOrg,
+			constants.AvalancheGoRepoName,
+			"",
+		)
+		if err != nil {
+			return err
+		}
+		versionComparison := semver.Compare(constants.FujiAvalancheGoV113, latestAvagoVersion)
+		if versionComparison == 1 {
+			useCustomAvalanchegoVersion = constants.FujiAvalancheGoV113
+		}
 	}
 	if useCustomAvalanchegoVersion != "" {
 		latestAvagoPreReleaseVersion = false

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -81,7 +81,7 @@ const (
 
 	LatestPreReleaseVersionTag = "latest-prerelease"
 	LatestReleaseVersionTag    = "latest"
-	DefaultAvalancheGoVersion  = LatestPreReleaseVersionTag
+	DefaultAvalancheGoVersion  = LatestReleaseVersionTag
 
 	FujiAPIEndpoint    = "https://api.avax-test.network"
 	MainnetAPIEndpoint = "https://api.avax.network"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -292,6 +292,7 @@ const (
 	NotAvailableLabel         = "Not available"
 	BackendCmd                = "avalanche-cli-backend"
 
+	FujiAvalancheGoV113          = "v1.13.0-fuji"
 	AvalancheGoCompatibilityURL  = "https://raw.githubusercontent.com/ava-labs/avalanchego/master/version/compatibility.json"
 	SubnetEVMRPCCompatibilityURL = "https://raw.githubusercontent.com/ava-labs/subnet-evm/master/compatibility.json"
 


### PR DESCRIPTION
Uses https://github.com/ava-labs/avalanchego/releases/tag/v1.13.0-fuji if no avalanche go version is provided for Fuji deploy and node local start
