### PR TITLE
fix: install script location

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -21,10 +21,9 @@ EOF
 RUN_COMPLETIONS=true
 
 parse_args() {
-  #BINDIR is ./bin unless set be ENV
-  # over-ridden by flag below
-
-  BINDIR=${BINDIR:-~/bin}
+  # BINDIR is ~/.local/bin unless set be overridden by the -b flag (trailing slash is removed) 
+  BINDIR=${BINDIR%/}
+  BINDIR=${BINDIR:-~/.local/bin}
   while getopts "b:ndh?x" arg; do
     case "$arg" in
       b) BINDIR="$OPTARG" ;;


### PR DESCRIPTION
## Why this should be merged

- Sets default location to `~/.local/bin` (standard location on Linux, macOS, etc)

- Removes trailing slash from install path (prevents cases like `install.sh -b /usr/local/bin/` producing `ava-labs/avalanche-cli info installed /usr/local/bin//avalanche`)

## How this works

- Sets `BINDIR` to itself but with trailing slash removed if it exists
- Then sets `BINDIR` to default (`~/.local/bin`) if it's an empty string

## How this was tested

- Ran install script

## How is this documented

- Code comments