### PR TITLE
Fix node local bug for fuji for v1.13.0

### DIFF
--- a/cmd/blockchaincmd/convert.go
+++ b/cmd/blockchaincmd/convert.go
@@ -234,8 +234,6 @@ func StartLocalMachine(
 			anrSettings,
 			avagoVersionSettings,
 			network,
-			networkoptions.NetworkFlags{},
-			nil,
 		); err != nil {
 			return false, err
 		}

--- a/cmd/networkcmd/start.go
+++ b/cmd/networkcmd/start.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/interchain"
 	"github.com/ava-labs/avalanche-cli/pkg/localnet"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
-	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
 	"github.com/ava-labs/avalanche-cli/pkg/node"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
@@ -273,8 +272,6 @@ func startLocalCluster(avalancheGoBinPath string) error {
 				node.ANRSettings{},
 				node.AvalancheGoVersionSettings{},
 				models.NewLocalNetwork(),
-				networkoptions.NetworkFlags{},
-				nil,
 			); err != nil {
 				return err
 			}

--- a/cmd/nodecmd/local.go
+++ b/cmd/nodecmd/local.go
@@ -185,8 +185,22 @@ func localStartNode(_ *cobra.Command, args []string) error {
 		StakingCertKeyPath:   stakingCertKeyPath,
 		StakingTLSKeyPath:    stakingTLSKeyPath,
 	}
+
+	network, err := networkoptions.GetNetworkFromCmdLineFlags(
+		app,
+		"",
+		globalNetworkFlags,
+		false,
+		true,
+		networkoptions.DefaultSupportedNetworkOptions,
+		"",
+	)
+	if err != nil {
+		return err
+	}
+
 	// TODO: remove this check for releases above v1.8.7, once v1.13.0-fuji avalanchego is latest release
-	if globalNetworkFlags.UseFuji && useCustomAvalanchegoVersion == "" {
+	if network.Kind == models.Fuji && useCustomAvalanchegoVersion == "" {
 		latestAvagoVersion, err := app.Downloader.GetLatestReleaseVersion(
 			constants.AvaLabsOrg,
 			constants.AvalancheGoRepoName,
@@ -228,9 +242,7 @@ func localStartNode(_ *cobra.Command, args []string) error {
 		nodeConfig,
 		anrSettings,
 		avaGoVersionSetting,
-		models.Network{},
-		globalNetworkFlags,
-		networkoptions.DefaultSupportedNetworkOptions,
+		network,
 	)
 }
 

--- a/pkg/node/local.go
+++ b/pkg/node/local.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/localnet"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
-	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
@@ -182,11 +181,8 @@ func StartLocalNode(
 	anrSettings ANRSettings,
 	avaGoVersionSetting AvalancheGoVersionSettings,
 	network models.Network,
-	networkFlags networkoptions.NetworkFlags,
-	supportedNetworkOptions []networkoptions.NetworkOption,
 ) error {
 	var err error
-
 	// ensure data consistency
 	localClusterExists := false
 	if clusterExists, err := CheckClusterExists(app, clusterName); err != nil {
@@ -298,20 +294,6 @@ func StartLocalNode(
 		}
 	} else {
 		ux.Logger.GreenCheckmarkToUser("Local cluster %s not found. Creating...", clusterName)
-		if network.Kind == models.Undefined {
-			network, err = networkoptions.GetNetworkFromCmdLineFlags(
-				app,
-				"",
-				networkFlags,
-				false,
-				true,
-				supportedNetworkOptions,
-				"",
-			)
-			if err != nil {
-				return err
-			}
-		}
 		network.ClusterName = clusterName
 
 		if err := preLocalChecks(anrSettings, avaGoVersionSetting); err != nil {


### PR DESCRIPTION
Fixes bug from https://github.com/ava-labs/avalanche-cli/pull/2674.

avalanche node local is supposed to use `v1.13.0` for fuji. This also cleans up `StartLocalNode` interface