### PR TITLE
[no op] trigger new avago docker

### DIFF
--- a/cmd/nodecmd/local.go
+++ b/cmd/nodecmd/local.go
@@ -185,7 +185,6 @@ func localStartNode(_ *cobra.Command, args []string) error {
 		StakingCertKeyPath:   stakingCertKeyPath,
 		StakingTLSKeyPath:    stakingTLSKeyPath,
 	}
-
 	network, err := networkoptions.GetNetworkFromCmdLineFlags(
 		app,
 		"",


### PR DESCRIPTION
## Why this should be merged

## How this works

## How this was tested

## How is this documented
