### PR TITLE
Default to avago 1.12.2 for local network

### DIFF
--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -124,7 +124,7 @@ so you can take your locally tested Blockchain and deploy it on Fuji or Mainnet.
 	cmd.Flags().StringVar(
 		&userProvidedAvagoVersion,
 		"avalanchego-version",
-		constants.DefaultAvalancheGoVersion,
+		"v1.12.2",
 		"use this version of avalanchego (ex: v1.17.12)",
 	)
 	cmd.Flags().StringVarP(&keyName, "key", "k", "", "select the key to use [fuji/devnet deploy only]")


### PR DESCRIPTION
Defaults to `avago 1.12.2` until issue with `avago 1.13.0` is resolved in CLI for local network

`avago 1.13.0` issue: 
```

Backend controller started, pid: 72760, output at: /Users/raymondsukanto/.avalanche-cli/local/newSubnet-local-node-local-network/server.log

AvalancheGo path: /Users/raymondsukanto/.avalanche-cli/bin/avalanchego/avalanchego-v1.13.0/avalanchego

✓ Local cluster newSubnet-local-node-local-network not found. Creating...
Starting local avalanchego node using root: /Users/raymondsukanto/.avalanche-cli/local/newSubnet-local-node-local-network ...
✓ avalanchego stopped
Error: failed to start local avalanchego: rpc error: code = DeadlineExceeded desc = context deadline exceeded

```