### PR TITLE
Add error to metrics

### DIFF
--- a/cmd/blockchaincmd/create.go
+++ b/cmd/blockchaincmd/create.go
@@ -455,7 +455,7 @@ func createBlockchainConfig(cmd *cobra.Command, args []string) error {
 	}
 
 	if vmType == models.SubnetEvm {
-		err = sendMetrics(cmd, vmType.RepoName(), blockchainName)
+		err = sendMetrics(vmType.RepoName(), blockchainName)
 		if err != nil {
 			return err
 		}
@@ -486,7 +486,7 @@ func addSubnetEVMGenesisPrefundedAddress(genesisBytes []byte, address string, ba
 	return json.MarshalIndent(genesisMap, "", "  ")
 }
 
-func sendMetrics(cmd *cobra.Command, repoName, blockchainName string) error {
+func sendMetrics(repoName, blockchainName string) error {
 	flags := make(map[string]string)
 	flags[constants.SubnetType] = repoName
 	genesis, err := app.LoadEvmGenesis(blockchainName)
@@ -513,7 +513,7 @@ func sendMetrics(cmd *cobra.Command, repoName, blockchainName string) error {
 	precompilesJoined := strings.Join(precompiles, ",")
 	flags[constants.PrecompileType] = precompilesJoined
 	flags[constants.NumberOfAirdrops] = strconv.Itoa(numAirdropAddresses)
-	metrics.HandleTracking(cmd, constants.MetricsSubnetCreateCommand, app, flags)
+	metrics.HandleTracking(app, flags, nil)
 	return nil
 }
 

--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -950,7 +950,7 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 
 	flags := make(map[string]string)
 	flags[constants.MetricsNetwork] = network.Name()
-	metrics.HandleTracking(cmd, constants.MetricsSubnetDeployCommand, app, flags)
+	metrics.HandleTracking(app, flags, nil)
 
 	if network.Kind == models.Local && !simulatedPublicNetwork() {
 		ux.Logger.PrintToUser("")

--- a/cmd/blockchaincmd/export_test.go
+++ b/cmd/blockchaincmd/export_test.go
@@ -33,7 +33,7 @@ func TestExportImportSubnet(t *testing.T) {
 	mockAppDownloader := mocks.Downloader{}
 	mockAppDownloader.On("Download", mock.Anything).Return(testSubnetEVMCompat, nil)
 
-	app.Setup(testDir, logging.NoLog{}, nil, "", prompts.NewPrompter(), &mockAppDownloader)
+	app.Setup(testDir, logging.NoLog{}, nil, "", prompts.NewPrompter(), &mockAppDownloader, nil)
 	ux.NewUserLog(logging.NoLog{}, io.Discard)
 	genBytes, err := os.ReadFile("../../" + utils.SubnetEvmGenesisPath)
 	require.NoError(err)

--- a/cmd/blockchaincmd/publish_test.go
+++ b/cmd/blockchaincmd/publish_test.go
@@ -415,7 +415,7 @@ func setupTestEnv(t *testing.T) (*require.Assertions, *mocks.Prompter) {
 	ux.NewUserLog(logging.NoLog{}, io.Discard)
 	app = &application.Avalanche{}
 	mockPrompt := mocks.NewPrompter(t)
-	app.Setup(testDir, logging.NoLog{}, config.New(), "", mockPrompt, application.NewDownloader())
+	app.Setup(testDir, logging.NoLog{}, config.New(), "", mockPrompt, application.NewDownloader(), nil)
 
 	return require, mockPrompt
 }

--- a/cmd/blockchaincmd/upgradecmd/vm_test.go
+++ b/cmd/blockchaincmd/upgradecmd/vm_test.go
@@ -306,7 +306,7 @@ func TestUpdateToCustomBin(t *testing.T) {
 	ux.NewUserLog(log, os.Stdout)
 
 	app = &application.Avalanche{}
-	app.Setup(testDir, log, config.New(), "", prompts.NewPrompter(), application.NewDownloader())
+	app.Setup(testDir, log, config.New(), "", prompts.NewPrompter(), application.NewDownloader(), nil)
 
 	err = os.MkdirAll(app.GetSubnetDir(), constants.DefaultPerms755)
 	assert.NoError(err)

--- a/cmd/nodecmd/create.go
+++ b/cmd/nodecmd/create.go
@@ -791,7 +791,7 @@ func createNodes(cmd *cobra.Command, args []string) error {
 		printResults(cloudConfigMap, publicIPMap, monitoringPublicIP)
 		ux.Logger.PrintToUser(logging.Green.Wrap("AvalancheGo and Avalanche-CLI installed and node(s) are bootstrapping!"))
 	}
-	sendNodeCreateMetrics(cmd, cloudService, network.Name(), numNodesMetricsMap)
+	sendNodeCreateMetrics(cloudService, network.Name(), numNodesMetricsMap)
 	return nil
 }
 
@@ -1403,7 +1403,7 @@ func defaultAvalancheCLIPrefix(region string) (string, error) {
 	return usr.Username + "-" + region + constants.AvalancheCLISuffix, nil
 }
 
-func sendNodeCreateMetrics(cmd *cobra.Command, cloudService, network string, nodes map[string]NumNodes) {
+func sendNodeCreateMetrics(cloudService, network string, nodes map[string]NumNodes) {
 	flags := make(map[string]string)
 	totalValidatorNodes := 0
 	totalAPINodes := 0
@@ -1428,7 +1428,7 @@ func sendNodeCreateMetrics(cmd *cobra.Command, cloudService, network string, nod
 		populateSubnetVMMetrics(flags, wizSubnet)
 		flags[constants.MetricsCalledFromWiz] = strconv.FormatBool(true)
 	}
-	metrics.HandleTracking(cmd, constants.MetricsNodeCreateCommand, app, flags)
+	metrics.HandleTracking(app, flags, nil)
 }
 
 func getPrometheusTargets(clusterName string) ([]string, []string, []string, error) {

--- a/cmd/nodecmd/wiz.go
+++ b/cmd/nodecmd/wiz.go
@@ -457,7 +457,7 @@ func wiz(cmd *cobra.Command, args []string) error {
 	if err := deployClusterYAMLFile(clusterName, subnetName); err != nil {
 		return err
 	}
-	sendNodeWizMetrics(cmd)
+	sendNodeWizMetrics()
 	return nil
 }
 
@@ -889,10 +889,10 @@ func setICMRelayerSecurityGroupRule(clusterName string, awmRelayerHost *models.H
 	return nil
 }
 
-func sendNodeWizMetrics(cmd *cobra.Command) {
+func sendNodeWizMetrics() {
 	flags := make(map[string]string)
 	populateSubnetVMMetrics(flags, wizSubnet)
-	metrics.HandleTracking(cmd, constants.MetricsNodeDevnetWizCommand, app, flags)
+	metrics.HandleTracking(app, flags, nil)
 }
 
 func populateSubnetVMMetrics(flags map[string]string, subnetName string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,7 +63,6 @@ To get started, look at the documentation for the subcommands or jump right
 in with avalanche blockchain create myNewBlockchain.`,
 		PersistentPreRunE: createApp,
 		Version:           Version,
-		PersistentPostRun: handleTracking,
 		SilenceErrors:     true,
 		SilenceUsage:      true,
 	}
@@ -138,7 +137,7 @@ func createApp(cmd *cobra.Command, _ []string) error {
 	log.Info("-----------")
 	log.Info(fmt.Sprintf("cmd: %s", strings.Join(os.Args[1:], " ")))
 	cf := config.New()
-	app.Setup(baseDir, log, cf, Version, prompts.NewPrompter(), application.NewDownloader())
+	app.Setup(baseDir, log, cf, Version, prompts.NewPrompter(), application.NewDownloader(), cmd)
 
 	if err := initConfig(); err != nil {
 		return err
@@ -238,10 +237,6 @@ func checkForUpdates(cmd *cobra.Command, app *application.Avalanche) error {
 		}
 	}
 	return nil
-}
-
-func handleTracking(cmd *cobra.Command, _ []string) {
-	metrics.HandleTracking(cmd, cmd.CommandPath(), app, nil)
 }
 
 func setupEnv() (string, error) {
@@ -383,6 +378,7 @@ func Execute() {
 	app = application.New()
 	rootCmd := NewRootCmd()
 	err := rootCmd.Execute()
+	metrics.HandleTracking(app, nil, err)
 	cobrautils.HandleErrors(err)
 }
 

--- a/internal/migrations/migrations_test.go
+++ b/internal/migrations/migrations_test.go
@@ -23,7 +23,7 @@ func TestRunMigrations(t *testing.T) {
 	testDir := t.TempDir()
 
 	app := &application.Avalanche{}
-	app.Setup(testDir, logging.NoLog{}, config.New(), "", prompts.NewPrompter(), application.NewDownloader())
+	app.Setup(testDir, logging.NoLog{}, config.New(), "", prompts.NewPrompter(), application.NewDownloader(), nil)
 
 	type migTest struct {
 		migs           map[int]migrationFunc

--- a/internal/migrations/subnet_evm_rename_test.go
+++ b/internal/migrations/subnet_evm_rename_test.go
@@ -62,7 +62,7 @@ func TestSubnetEVMRenameMigration(t *testing.T) {
 			testDir := t.TempDir()
 
 			app := &application.Avalanche{}
-			app.Setup(testDir, logging.NoLog{}, config.New(), "", prompts.NewPrompter(), application.NewDownloader())
+			app.Setup(testDir, logging.NoLog{}, config.New(), "", prompts.NewPrompter(), application.NewDownloader(), nil)
 
 			err := app.CreateSidecar(tt.sc)
 			require.NoError(err)
@@ -91,7 +91,7 @@ func TestSubnetEVMRenameMigration_EmptyDir(t *testing.T) {
 	testDir := t.TempDir()
 
 	app := &application.Avalanche{}
-	app.Setup(testDir, logging.NoLog{}, config.New(), "", prompts.NewPrompter(), application.NewDownloader())
+	app.Setup(testDir, logging.NoLog{}, config.New(), "", prompts.NewPrompter(), application.NewDownloader(), nil)
 
 	emptySubnetName := "emptySubnet"
 

--- a/internal/migrations/toplevel_files_test.go
+++ b/internal/migrations/toplevel_files_test.go
@@ -25,7 +25,7 @@ func TestTopLevelFilesMigration(t *testing.T) {
 	testDir := t.TempDir()
 
 	app := &application.Avalanche{}
-	app.Setup(testDir, logging.NoLog{}, config.New(), "", prompts.NewPrompter(), application.NewDownloader())
+	app.Setup(testDir, logging.NoLog{}, config.New(), "", prompts.NewPrompter(), application.NewDownloader(), nil)
 
 	testSC1 := &models.Sidecar{
 		Name: "test1",

--- a/internal/testutils/setup.go
+++ b/internal/testutils/setup.go
@@ -24,7 +24,7 @@ func SetupTestInTempDir(t *testing.T) *application.Avalanche {
 	testDir := t.TempDir()
 
 	app := application.New()
-	app.Setup(testDir, logging.NoLog{}, &config.Config{}, "", nil, nil)
+	app.Setup(testDir, logging.NoLog{}, &config.Config{}, "", nil, nil, nil)
 	ux.NewUserLog(logging.NoLog{}, io.Discard)
 	return app
 }

--- a/pkg/apmintegration/file_test.go
+++ b/pkg/apmintegration/file_test.go
@@ -63,7 +63,7 @@ const (
 func newTestApp(t *testing.T, testDir string) *application.Avalanche {
 	tempDir := t.TempDir()
 	app := application.New()
-	app.Setup(tempDir, logging.NoLog{}, nil, "", prompts.NewPrompter(), application.NewDownloader())
+	app.Setup(tempDir, logging.NoLog{}, nil, "", prompts.NewPrompter(), application.NewDownloader(), nil)
 	app.ApmDir = testDir
 	return app
 }

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/subnet-evm/core"
 
+	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
 )
 
@@ -35,6 +36,7 @@ type Avalanche struct {
 	Apm        *apm.APM
 	ApmDir     string
 	Downloader Downloader
+	Cmd        *cobra.Command
 }
 
 func New() *Avalanche {
@@ -48,6 +50,7 @@ func (app *Avalanche) Setup(
 	version string,
 	prompt prompts.Prompter,
 	downloader Downloader,
+	cmd *cobra.Command,
 ) {
 	app.baseDir = baseDir
 	app.Log = log
@@ -55,6 +58,7 @@ func (app *Avalanche) Setup(
 	app.Version = version
 	app.Prompt = prompt
 	app.Downloader = downloader
+	app.Cmd = cmd
 }
 
 func (app *Avalanche) GetRunFile(prefix string) string {

--- a/pkg/binutils/release_test.go
+++ b/pkg/binutils/release_test.go
@@ -37,7 +37,7 @@ func setupInstallDir(require *require.Assertions) *application.Avalanche {
 	defer os.RemoveAll(rootDir)
 
 	app := application.New()
-	app.Setup(rootDir, logging.NoLog{}, &config.Config{}, "", prompts.NewPrompter(), application.NewDownloader())
+	app.Setup(rootDir, logging.NoLog{}, &config.Config{}, "", prompts.NewPrompter(), application.NewDownloader(), nil)
 	return app
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"fmt"
 
 	"github.com/ava-labs/avalanche-cli/pkg/application"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
@@ -110,9 +111,10 @@ func trackMetrics(app *application.Avalanche, commandPath string, flags map[stri
 	for propertyKey, propertyValue := range flags {
 		telemetryProperties[propertyKey] = propertyValue
 	}
-	_ = client.Enqueue(posthog.Capture{
+	err := client.Enqueue(posthog.Capture{
 		DistinctId: userID,
 		Event:      "cli-command",
 		Properties: telemetryProperties,
 	})
+	fmt.Println("METRICS DUMP", telemetryProperties, err)
 }

--- a/tests/e2e/utils/helpers.go
+++ b/tests/e2e/utils/helpers.go
@@ -695,7 +695,7 @@ func GetNodeVMVersion(nodeURI string, vmid string) (string, error) {
 
 func GetApp() *application.Avalanche {
 	app := application.New()
-	app.Setup(GetBaseDir(), logging.NoLog{}, nil, "", nil, nil)
+	app.Setup(GetBaseDir(), logging.NoLog{}, nil, "", nil, nil, nil)
 	return app
 }
 


### PR DESCRIPTION
## Why this should be merged
Current CLI metrics don't collect information on failed commands. This PR add err message collection
in a new field, error.

## How this works

## How this was tested

## How is this documented
