### PR TITLE
fix migration issues found on jtc tests

### DIFF
--- a/pkg/constants/errors.go
+++ b/pkg/constants/errors.go
@@ -8,4 +8,5 @@ var (
 	ErrNoBlockchainID                 = errors.New("\n\nNo blockchainID found. To resolve this:\n- Use 'avalanche blockchain deploy' to deploy the blockchain and generate a blockchainID.\n- Or use 'avalanche blockchain import' to import an existing configuration.\n") //nolint:stylecheck
 	ErrNoSubnetID                     = errors.New("\n\nNo subnetID found. To resolve this:\n- Use 'avalanche blockchain deploy' to create the subnet and generate a subnetID.\n- Or use 'avalanche blockchain import' to import an existing configuration.\n")             //nolint:stylecheck
 	ErrInvalidValidatorManagerAddress = errors.New("invalid validator manager address")
+	ErrKeyNotFoundOnMap               = errors.New("key not found on map")
 )

--- a/pkg/utils/json.go
+++ b/pkg/utils/json.go
@@ -72,7 +72,7 @@ func SetJSONKey(jsonBody string, k string, v interface{}) (string, error) {
 func GetJSONKey[T any](jsonMap map[string]interface{}, k string) (T, error) {
 	intf, ok := jsonMap[k]
 	if !ok {
-		return *new(T), fmt.Errorf("%s not found on map", k)
+		return *new(T), fmt.Errorf("%w: %s", constants.ErrKeyNotFoundOnMap, k)
 	}
 	v, ok := intf.(T)
 	if !ok {


### PR DESCRIPTION
## Why this should be merged
Fix for a couple of issues when migrating already existing anr local clusters into tmpnet:
```
- failure reading legacy local network conf: track-subnets not found on map
- failure migrating plugindir dir ... no such file or directory
```

## How this works
- Do not expect for all anr clusters to be tracking a subnet
- Do not expect that all node dirs will contain a plugin dir

## How this was tested

## How is this documented
