### PR TITLE
Build CLI binary on 22.04 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
   release:
     needs: [lint, unit_test]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Closes #2723 

Enables CLI binary compatibility with 22.04 ubuntu. It is still compatible with 24.04.

If we build CLI on 24.04, users won't be able to install CLI binary on ubuntu 22.04

````
ubuntu@ip-172-31-29-94:~$ /home/ubuntu/bin/avalanche --version
avalanche version 1.8.9-rc4
ubuntu@ip-172-31-29-94:~$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.5 LTS
Release:        22.04
Codename:       jammy
````


````
ubuntu@ip-172-31-16-118:~$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 24.04.2 LTS
Release:        24.04
Codename:       noble
ubuntu@ip-172-31-16-118:~$ /home/ubuntu/bin/avalanche --version
avalanche version 1.8.9-rc4
````