### PR TITLE
Use available flags on some key transfer flows

### DIFF
--- a/cmd/keycmd/transfer.go
+++ b/cmd/keycmd/transfer.go
@@ -270,27 +270,50 @@ func transferF(*cobra.Command, []string) error {
 	}
 	amount := uint64(amountFlt * float64(units.Avax))
 
-	if destinationAddrStr == "" && !receiverChainFlags.XChain &&
-		!(senderChainFlags.CChain && receiverChainFlags.PChain) {
-		format := prompts.EVMFormat
-		if receiverChainFlags.PChain {
-			format = prompts.PChainFormat
-		}
-		if receiverChainFlags.XChain {
-			format = prompts.XChainFormat
-		}
-		destinationAddrStr, err = prompts.PromptAddress(
-			app.Prompt,
-			"destination address",
-			app.GetKeyDir(),
-			app.GetKey,
-			"",
-			network,
-			format,
-			"destination address",
-		)
-		if err != nil {
-			return err
+	if destinationAddrStr == "" && !receiverChainFlags.XChain && !(senderChainFlags.CChain && receiverChainFlags.PChain) {
+		if destinationKeyName != "" {
+			k, err := app.GetKey(destinationKeyName, network, false)
+			if err != nil {
+				return err
+			}
+			if receiverChainFlags.CChain {
+				destinationAddrStr = k.C()
+			}
+			if receiverChainFlags.PChain {
+				addrs := k.P()
+				if len(addrs) == 0 {
+					return fmt.Errorf("unexpected null number of P-Chain addresses for key")
+				}
+				destinationAddrStr = addrs[0]
+			}
+			if receiverChainFlags.XChain {
+				addrs := k.X()
+				if len(addrs) == 0 {
+					return fmt.Errorf("unexpected null number of X-Chain addresses for key")
+				}
+				destinationAddrStr = addrs[0]
+			}
+		} else {
+			format := prompts.EVMFormat
+			if receiverChainFlags.PChain {
+				format = prompts.PChainFormat
+			}
+			if receiverChainFlags.XChain {
+				format = prompts.XChainFormat
+			}
+			destinationAddrStr, err = prompts.PromptAddress(
+				app.Prompt,
+				"destination address",
+				app.GetKeyDir(),
+				app.GetKey,
+				"",
+				network,
+				format,
+				"destination address",
+			)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -352,41 +375,64 @@ func intraEvmSend(
 	network models.Network,
 	senderChain contract.ChainSpec,
 ) error {
-	privateKey, err := prompts.PromptPrivateKey(
-		app.Prompt,
-		"sender private key",
-		app.GetKeyDir(),
-		app.GetKey,
-		"",
-		"",
+	var (
+		err        error
+		privateKey string
 	)
-	if err != nil {
-		return err
+	if keyName != "" {
+		k, err := app.GetKey(keyName, network, false)
+		if err != nil {
+			return err
+		}
+		privateKey = k.PrivKeyHex()
+	} else {
+		privateKey, err = prompts.PromptPrivateKey(
+			app.Prompt,
+			"sender private key",
+			app.GetKeyDir(),
+			app.GetKey,
+			"",
+			"",
+		)
+		if err != nil {
+			return err
+		}
 	}
-	destinationAddr, err := prompts.PromptAddress(
-		app.Prompt,
-		"destination address",
-		app.GetKeyDir(),
-		app.GetKey,
-		"",
-		network,
-		prompts.EVMFormat,
-		"destination address",
-	)
-	if err != nil {
-		return err
+	if destinationKeyName != "" {
+		k, err := app.GetKey(destinationKeyName, network, false)
+		if err != nil {
+			return err
+		}
+		destinationAddrStr = k.C()
 	}
-	amountFlt, err := app.Prompt.CaptureFloat(
-		"Amount to transfer",
-		func(f float64) error {
-			if f <= 0 {
-				return fmt.Errorf("not positive")
-			}
-			return nil
-		},
-	)
-	if err != nil {
-		return err
+	if destinationAddrStr == "" {
+		destinationAddrStr, err = prompts.PromptAddress(
+			app.Prompt,
+			"destination address",
+			app.GetKeyDir(),
+			app.GetKey,
+			"",
+			network,
+			prompts.EVMFormat,
+			"destination address",
+		)
+		if err != nil {
+			return err
+		}
+	}
+	if amountFlt == 0 {
+		amountFlt, err = app.Prompt.CaptureFloat(
+			"Amount to transfer",
+			func(f float64) error {
+				if f <= 0 {
+					return fmt.Errorf("not positive")
+				}
+				return nil
+			},
+		)
+		if err != nil {
+			return err
+		}
 	}
 	amountBigFlt := new(big.Float).SetFloat64(amountFlt)
 	amountBigFlt = amountBigFlt.Mul(amountBigFlt, new(big.Float).SetInt(vm.OneAvax))
@@ -405,7 +451,7 @@ func intraEvmSend(
 	if err != nil {
 		return err
 	}
-	return clievm.FundAddress(client, privateKey, destinationAddr, amount)
+	return clievm.FundAddress(client, privateKey, destinationAddrStr, amount)
 }
 
 func interEvmSend(


### PR DESCRIPTION
## Why this should be merged
Currently key transfer has flags that are not used on all flows, and should, causing ux issues on cmdline. Eg there is no way to specify a C->C transfer just by using cmdline flags, avoiding prompts at all.
- C->C and L1->L1: --key, --mount, --destination-key, --destination-addr
- P->P and P->C: --destination-key

## How this works

## How this was tested

## How is this documented
