### PR TITLE
at ictt, sleep between approve and add collateral, to avoid issues due to connecting to different API nodes

### DIFF
--- a/pkg/ictt/operate.go
+++ b/pkg/ictt/operate.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/ava-labs/avalanche-cli/pkg/contract"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
@@ -449,6 +450,8 @@ func ERC20TokenHomeAddCollateral(
 	); err != nil {
 		return err
 	}
+	// TODO: use the same API node connection for this two operations
+	time.Sleep(5 * time.Second)
 	_, _, err = contract.TxToMethod(
 		rpcURL,
 		false,


### PR DESCRIPTION
## Why this should be merged
Closes https://github.com/ava-labs/avalanche-cli/issues/2721

## How this works
Adds a wait of 5 secs between ERC20 spent approval and add the collateral to the Home. This
to avoid issues for hitting another outdated API node on the second operation.

## How this was tested
ictt deploy executions on fuji

## How is this documented
