### PR TITLE
don't require permissioned state in tx multisig ops

### DIFF
--- a/cmd/transactioncmd/transaction_commit.go
+++ b/cmd/transactioncmd/transaction_commit.go
@@ -108,13 +108,11 @@ func commitTx(_ *cobra.Command, args []string) error {
 		}
 	}
 
-	isPermissioned, controlKeys, _, err := txutils.GetOwners(network, subnetID)
+	_, controlKeys, _, err := txutils.GetOwners(network, subnetID)
 	if err != nil {
 		return err
 	}
-	if !isPermissioned {
-		return blockchaincmd.ErrNotPermissionedSubnet
-	}
+
 	subnetAuthKeys, remainingSubnetAuthKeys, err := txutils.GetRemainingSigners(tx, controlKeys)
 	if err != nil {
 		return err

--- a/cmd/transactioncmd/transaction_sign.go
+++ b/cmd/transactioncmd/transaction_sign.go
@@ -128,12 +128,9 @@ func signTx(_ *cobra.Command, args []string) error {
 		}
 	}
 
-	isPermissioned, controlKeys, _, err := txutils.GetOwners(network, subnetID)
+	_, controlKeys, _, err := txutils.GetOwners(network, subnetID)
 	if err != nil {
 		return err
-	}
-	if !isPermissioned {
-		return blockchaincmd.ErrNotPermissionedSubnet
 	}
 
 	// get the remaining tx signers so as to check that the wallet does contain an expected signer


### PR DESCRIPTION
## Why this should be merged
There are multisig txs that can be executed for SOV subnets. Most important example: removing
old validators from a SOV subnet. 

## How this works
This PR removes the requirement of the subnet being permissioned, from transaction sign and transaction commit. 

## How this was tested

## How is this documented
