### PR TITLE
demo - JSONize cobra arguments

### DIFF
--- a/cmd/blockchaincmd/add_validator.json
+++ b/cmd/blockchaincmd/add_validator.json
@@ -1,0 +1,32 @@
+{
+  "command": {
+    "use": "addValidator [blockchainName]",
+    "short": "Add a validator to an L1",
+    "long": "The blockchain addValidator command adds a node as a validator to an L1 of the user provided deployed network. If the network is proof of authority, the owner of the validator manager contract must sign the transaction. If the network is proof of stake, the node must stake the L1's staking token. Both processes will issue a RegisterL1ValidatorTx on the P-Chain.\nThis command currently only works on Blockchains deployed to either the Fuji Testnet or Mainnet."
+  },
+  "flags": [
+    {
+      "var": "keyName",
+      "type": "string",
+      "name": "key",
+      "shorthand": "k",
+      "default": "",
+      "usage": "select the key to use [fuji/devnet only]"
+    },
+    {
+      "var": "useEwoq",
+      "type": "bool",
+      "name": "ewoq",
+      "shorthand": "e",
+      "default": false,
+      "usage": "use ewoq key [fuji/devnet only]"
+    },
+    {
+      "var": "httpPort",
+      "type": "uint32",
+      "name": "http-port",
+      "default": 0,
+      "usage": "http port for node"
+    }
+  ]
+}

--- a/cmd/flags-meta/flags-loader.go
+++ b/cmd/flags-meta/flags-loader.go
@@ -1,0 +1,97 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+package flagsmeta
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type JSONFlags struct {
+	// loaded from JSON
+	flagsMap map[string]any
+	// for cobra to capture values
+	cobraStore map[string]any
+}
+
+func LoadCommandFlagsFromJSON(jsonStr string) (*JSONFlags, error) {
+	flagsMap := make(map[string]any)
+	err := json.Unmarshal([]byte(jsonStr), &flagsMap)
+	if err != nil {
+		return nil, err
+	}
+
+	cobraStore := make(map[string]any)
+	return &JSONFlags{
+		flagsMap,
+		cobraStore,
+	}, nil
+}
+
+// Load command meta info
+func (j *JSONFlags) GetCommandMeta(propName string) (string, error) {
+	cmdMetaMap := j.flagsMap["command"].(map[string]any)
+	if val, ok := cmdMetaMap[propName].(string); ok {
+		return val, nil
+	}
+	return "", fmt.Errorf("failed to return command meta value: %s", propName)
+}
+
+// Load flags config value with given flag name
+func GetValue[T any](j *JSONFlags, flagName string) (T, error) {
+	if value, ok := j.cobraStore[flagName]; ok {
+		if confValue, ok := value.(*T); ok {
+			return *confValue, nil
+		}
+	}
+	return *new(T), errors.New("failed to return value")
+}
+
+// register flags to cobra command
+func (j *JSONFlags) RegisterToCOBRA(
+	cmd *cobra.Command,
+) error {
+	for _, flag := range j.flagsMap["flags"].([]any) {
+		flagMap := flag.(map[string]any)
+		switch flagMap["type"] {
+		case "bool":
+			var bval bool
+			j.cobraStore[flagMap["var"].(string)] = &bval
+			cmd.Flags().BoolVarP(
+				&bval,
+				flagMap["name"].(string),
+				flagMap["shorthand"].(string),
+				flagMap["default"].(bool),
+				flagMap["usage"].(string),
+			)
+			// fmt.Printf("registering bool flag: %s\n", flagMap["name"].(string))
+		case "string":
+			var sval string
+			j.cobraStore[flagMap["var"].(string)] = &sval
+			cmd.Flags().StringVarP(
+				&sval,
+				flagMap["name"].(string),
+				flagMap["shorthand"].(string),
+				flagMap["default"].(string),
+				flagMap["usage"].(string),
+			)
+			// fmt.Printf("registering string flag: %s\n", flagMap["name"].(string))
+		case "uint32":
+			var u32val uint32
+			j.cobraStore[flagMap["var"].(string)] = &u32val
+			cmd.Flags().Uint32Var(
+				&u32val,
+				flagMap["name"].(string),
+				uint32(flagMap["default"].(float64 /* JSON number type*/)),
+				flagMap["usage"].(string),
+			)
+			// fmt.Printf("registering uint32 flag: %s\n", flagMap["name"].(string))
+		default:
+			panic(fmt.Sprintf("unsupported flag type: %T", flag))
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
As a quick PR demo to show how cobra arguments configs can be moved to JSON files.

**Pros**
- `cmd/*.go` can be cleaner
- Easier cobra argument configuration

**Cons**
- extra runtime cost at command initialization (JSON ops)
- some more complex argument logics, like shared args, conditional arguments are not directly supported