### PR TITLE
[DPTN-1569] Fixing validate earliest ts no upcoming UT

### DIFF
--- a/cmd/blockchaincmd/upgradecmd/validate_test.go
+++ b/cmd/blockchaincmd/upgradecmd/validate_test.go
@@ -101,10 +101,12 @@ func TestEarliestTimestamp(t *testing.T) {
 		t.Run(tt.name, func(_ *testing.T) {
 			upgrades, err := getAllUpgrades(tt.upgradesFile)
 			require.NoError(err)
+
+			// give some time so timestamps are def before now
+			time.Sleep(1 * time.Second)
+
 			earliest, err := getEarliestUpcomingTimestamp(upgrades)
 			if tt.expectedErr != nil {
-				// give some time so timestamps are defo before now
-				time.Sleep(1 * time.Second)
 				require.ErrorIs(err, tt.expectedErr)
 			} else {
 				require.NoError(err)


### PR DESCRIPTION
## Why this should be merged
Time waiting was called at wrong step of the UT, and it may fail the condition at the line below when block timestamp is at the same second of `time.Now()`:
https://github.com/ava-labs/avalanche-cli/blob/main/cmd/blockchaincmd/upgradecmd/apply.go#L492

## How this works

## How this was tested
- [X] `./scripts/unit_test.sh`

## How is this documented
