### PR TITLE
reduce debug trace dependency on add validator

### DIFF
--- a/pkg/validatormanager/registration.go
+++ b/pkg/validatormanager/registration.go
@@ -417,8 +417,19 @@ func InitValidatorRegistration(
 	}
 	managerAddress := common.HexToAddress(validatorManagerAddressStr)
 	ownerAddress := common.HexToAddress(ownerAddressStr)
-	var receipt *types.Receipt
+
 	alreadyInitialized := initiateTxHash != ""
+	if validationID, err := validator.GetValidationID(
+		rpcURL,
+		managerAddress,
+		nodeID,
+	); err != nil {
+		return nil, ids.Empty, nil, err
+	} else if validationID != ids.Empty {
+		alreadyInitialized = true
+	}
+
+	var receipt *types.Receipt
 	if !alreadyInitialized {
 		var tx *types.Transaction
 		if isPos {


### PR DESCRIPTION
## Why this should be merged
currently, add validator finds out if a validator was already initialized, based on a debug trace
obtained after calling add validator on the manager. but a much easier way is available,
which consists in querying the validator manager for the NodeID -> ValidationID map.

## How this works
It query the validator manager for the NodeID, to see if it is already initialized, if it is,
continue with the remaining add validator steps.

## How this was tested
Follow up failed add validator flows due to lack of proper debug trace conf on the l1.

## How is this documented
