### PR TITLE
[DPTN-1307] Enabling E2E test coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *~
 .DS_Store
 
+# code coverage files
+coverage/
 
 # Binaries for programs and plugins
 *.exe

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,5 +30,9 @@ if [ "${LEDGER_SIM:-}" == true ]
 then
 	extra_build_args="-tags ledger_zemu"
 fi
+if [ "${COVERAGE_MODE:-}" == true ]
+then
+	extra_build_args+=" -cover -race"
+fi
 
 go build -v -ldflags="-X 'github.com/ava-labs/avalanche-cli/cmd.Version=$VERSION' -X github.com/ava-labs/avalanche-cli/pkg/metrics.telemetryToken=$AVALANCHE_CLI_METRICS_TOKEN" $extra_build_args -o $BIN

--- a/scripts/run.e2e.sh
+++ b/scripts/run.e2e.sh
@@ -56,7 +56,16 @@ then
 	extra_build_args="-tags ledger_zemu"
 fi
 
-ACK_GINKGO_RC=true ginkgo build $extra_build_args ./tests/e2e
+ACK_GINKGO_RC=true ~/go/bin/ginkgo build $extra_build_args ./tests/e2e
+
+if [ "${COVERAGE_MODE:-}" == true ]
+then
+    export GOCOVERDIR=coverage/e2e
+	echo 'Coverage mode enabled - re-creating coverage dir $GOCOVERDIR'
+	echo 'It requires the CLI binary to be built by build.sh with COVERAGE_MODE=true too'
+	rm -rf ${GOCOVERDIR}
+	mkdir -p ${GOCOVERDIR}
+fi
 
 ./tests/e2e/e2e.test --ginkgo.v $description_filter
 
@@ -67,4 +76,11 @@ if [[ ${EXIT_CODE} -gt 0 ]]; then
   exit ${EXIT_CODE}
 else
   echo "ALL SUCCESS!"
+
+  if [ "${COVERAGE_MODE:-}" == true ]
+  then
+    echo "Generating coverage report: ${GOCOVERDIR}/profile.txt"
+    go tool covdata textfmt -i=${GOCOVERDIR} -o ${GOCOVERDIR}/profile.txt
+    # go tool cover -func ${GOCOVERDIR}/profile.txt
+  fi
 fi


### PR DESCRIPTION
## Why this should be merged
To obtain a more comprehensive code coverage of all our test cases including e2e tests (right now only UT coverage is supported), we need to add the option to generate coverage data when running e2e tests too.

Next Step: merge with UT coverage file to get a combined code coverage report (ref: https://github.com/ava-labs/analytics/pull/773)

## How this works
ref: https://github.com/ava-labs/analytics/pull/721

## How this was tested
```
COVERAGE_MODE=true ./scripts/build.sh
COVERAGE_MODE=true ./scripts/run.e2e.sh --filter "can stop and restart a deployed subnet non SOV"

```
## How is this documented
