### PR TITLE
Added bls-public-key and  bls-proof-of-possession cli options to blockchain changeWeight and removeValidator

### DIFF
--- a/cmd/blockchaincmd/change_weight.go
+++ b/cmd/blockchaincmd/change_weight.go
@@ -64,6 +64,8 @@ The L1 has to be a Proof of Authority L1.`,
 	cmd.Flags().Uint64Var(&newWeight, "weight", 0, "set the new staking weight of the validator")
 	cmd.Flags().BoolVarP(&useEwoq, "ewoq", "e", false, "use ewoq key [fuji/devnet only]")
 	cmd.Flags().StringVar(&nodeIDStr, "node-id", "", "node-id of the validator")
+	cmd.Flags().StringVar(&publicKey, "bls-public-key", "", "set the BLS public key of the validator to add")
+	cmd.Flags().StringVar(&pop, "bls-proof-of-possession", "", "set the BLS proof of possession of the validator to add")
 	cmd.Flags().StringVar(&nodeEndpoint, "node-endpoint", "", "gather node id/bls from publicly available avalanchego apis on the given endpoint")
 	cmd.Flags().BoolVarP(&useLedger, "ledger", "g", false, "use ledger instead of key (always true on mainnet, defaults to false on fuji/devnet)")
 	cmd.Flags().StringSliceVar(&ledgerAddresses, "ledger-addrs", []string{}, "use the given ledger addresses")

--- a/cmd/blockchaincmd/remove_validator.go
+++ b/cmd/blockchaincmd/remove_validator.go
@@ -68,6 +68,8 @@ these prompts by providing the values with flags.`,
 	cmd.Flags().BoolVarP(&useLedger, "ledger", "g", false, "use ledger instead of key (always true on mainnet, defaults to false on fuji)")
 	cmd.Flags().StringSliceVar(&ledgerAddresses, "ledger-addrs", []string{}, "use the given ledger addresses")
 	cmd.Flags().StringVar(&nodeIDStr, "node-id", "", "node-id of the validator")
+	cmd.Flags().StringVar(&publicKey, "bls-public-key", "", "set the BLS public key of the validator to add")
+	cmd.Flags().StringVar(&pop, "bls-proof-of-possession", "", "set the BLS proof of possession of the validator to add")
 	cmd.Flags().StringVar(&nodeEndpoint, "node-endpoint", "", "remove validator that responds to the given endpoint")
 	cmd.Flags().Uint64Var(&uptimeSec, "uptime", 0, "validator's uptime in seconds. If not provided, it will be automatically calculated")
 	cmd.Flags().BoolVar(&force, "force", false, "force validator removal even if it's not getting rewarded")


### PR DESCRIPTION
avalanche blockchain <name> changeWeight and removeValidator lacked option to add bls public key and proof of possessio via cli args.

## Why this should be merged
It allows for remote changeWeight and validator removal without the need to open port 9650 and configured rpc access as validators are isolated and normally do not allow rpc access

## How this works

## How this was tested
I have performed a rebalancing of testnet environment for the client with single 100 weight node and rebalanced to 5 validator nodes all  of weight 100 by using addValidator, changeWeight and removeValidator. 

## How is this documented
The fixes are trivial so no additional documentation is needed.
