### PR TITLE
Fix subnet only

### DIFF
--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -580,7 +580,7 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 
 	deployBalance := uint64(deployBalanceAVAX * float64(units.Avax))
 	// whether user has created Avalanche Nodes when blockchain deploy command is called
-	if sidecar.Sovereign {
+	if sidecar.Sovereign && !subnetOnly {
 		if changeOwnerAddress == "" {
 			// use provided key as change owner unless already set
 			if pAddr, err := kc.PChainFormattedStrAddresses(); err == nil && len(pAddr) > 0 {
@@ -741,7 +741,6 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-
 	var (
 		savePartialTx           bool
 		blockchainID            ids.ID
@@ -786,6 +785,11 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 		); err != nil {
 			return err
 		}
+	}
+
+	// stop here if subnetOnly is true
+	if subnetOnly {
+		return nil
 	}
 
 	tracked := false


### PR DESCRIPTION
Fixing current issue when subnet only flag is used on blockchain deploy:

```
AVL-7H2W7V:avalanche-cli raymondsukanto$ ./bin/avalanche blockchain deploy testSubnet  --local --skip-icm-deploy --skip-update-check --subnet-only 
Deploying [testSubnet] to Local Network

Network has already been booted.
Using [P-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p] to be set as a change owner for leftover AVAX

A local machine L1 deploy already exists for testSubnet L1 and network Local Network
✔ Yes
✓ Local node testSubnet-local-node-local-network cleaned up.
AvalancheGo path: /Users/raymondsukanto/.avalanche-cli/bin/avalanchego/avalanchego-v1.13.0/avalanchego

✓ Local cluster testSubnet-local-node-local-network not found. Creating...
Starting local avalanchego node using root: /Users/raymondsukanto/.avalanche-cli/local/testSubnet-local-node-local-network ...
✓ Booting Network. Wait until healthy...
✓ Avalanchego started and ready to use from /Users/raymondsukanto/.avalanche-cli/local/testSubnet-local-node-local-network

Node logs directory: /Users/raymondsukanto/.avalanche-cli/local/testSubnet-local-node-local-network/<NodeID>/logs

Network ready to use.

URI: http://127.0.0.1:57414
NodeID: NodeID-Ea7BzePRn1ZYRJdaCa1ra4Gz53JUD8Wcy

bootstrapEndpoints local deploy [http://127.0.0.1:57414] 
we are at first case 
Your blockchain control keys: [P-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p]
Your blockchain auth keys for chain creation: [P-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p]
CreateSubnetTx fee: 0.000010278 AVAX
Blockchain has been created with ID: 9din8d11cDzNq4RJ31LPeCyoMGmpL4mosdJsFqV8ujmgoxWpS
+----------------------------------------------------------------+
|                       DEPLOYMENT RESULTS                       |
+------------+---------------------------------------------------+
| Chain Name | testSubnet                                        |
+------------+---------------------------------------------------+
| Subnet ID  | 9din8d11cDzNq4RJ31LPeCyoMGmpL4mosdJsFqV8ujmgoxWpS |
+------------+---------------------------------------------------+
| VM ID      | tGBrM84KQ7tZCUV3J8gk5viFD1VpPszotkgJHMncocqRYarbw |
+------------+---------------------------------------------------+
Error: 

No blockchainID found. To resolve this:
- Use 'avalanche blockchain deploy' to deploy the blockchain and generate a blockchainID.
- Or use 'avalanche blockchain import' to import an existing configuration.

```

After this PR: 
```
AVL-7H2W7V:avalanche-cli raymondsukanto$ ./bin/avalanche blockchain deploy testSubnet  --local --skip-icm-deploy --skip-update-check --subnet-only 
Deploying [testSubnet] to Local Network

Network has already been booted.
Your blockchain control keys: [P-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p]
Your blockchain auth keys for chain creation: [P-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p]
CreateSubnetTx fee: 0.000010278 AVAX
Blockchain has been created with ID: 2FFx3mdhnHR8Hsi8rnAHZVYmUN9JP81RQFdSgvWoVNutrF7y43
+-----------------------------------------------------------------+
|                        DEPLOYMENT RESULTS                       |
+------------+----------------------------------------------------+
| Chain Name | testSubnet                                         |
+------------+----------------------------------------------------+
| Subnet ID  | 2FFx3mdhnHR8Hsi8rnAHZVYmUN9JP81RQFdSgvWoVNutrF7y43 |
+------------+----------------------------------------------------+
| VM ID      | tGBrM84KQ7tZCUV3J8gk5viFD1VpPszotkgJHMncocqRYarbw  |
+------------+----------------------------------------------------+

```