### PR TITLE
fix empty node id in validator list

### DIFF
--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanche-cli/pkg/vm"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 	validatorManagerSDK "github.com/ava-labs/avalanche-cli/sdk/validatormanager"
 	"github.com/ava-labs/avalanche-cli/sdk/validatormanager/validatormanagertypes"
 	"github.com/ava-labs/avalanchego/api/info"
@@ -940,7 +941,7 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 					if err != nil {
 						return err
 					}
-					deployRelayerFlags.BlockchainsToRelay = utils.Unique(utils.Map(blockchains, func(i localnet.BlockchainInfo) string { return i.Name }))
+					deployRelayerFlags.BlockchainsToRelay = utils.Unique(sdkutils.Map(blockchains, func(i localnet.BlockchainInfo) string { return i.Name }))
 				}
 				if network.Kind == models.Local || useLocalMachine {
 					deployRelayerFlags.Key = constants.ICMRelayerKeyName
@@ -1234,7 +1235,7 @@ func ConvertURIToPeers(uris []string) ([]info.Peer, error) {
 	if err != nil {
 		return nil, err
 	}
-	nodeIDs := utils.Map(aggregatorPeers, func(peer info.Peer) ids.NodeID {
+	nodeIDs := sdkutils.Map(aggregatorPeers, func(peer info.Peer) ids.NodeID {
 		return peer.Info.ID
 	})
 	nodeIDsSet := set.Of(nodeIDs...)

--- a/cmd/interchaincmd/relayercmd/configList.go
+++ b/cmd/interchaincmd/relayercmd/configList.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/prompts"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/olekukonko/tablewriter"
 )
@@ -261,7 +262,7 @@ func removeSource(
 		return configSpec, true, nil
 	}
 	prompt := "Select the source you want to remove"
-	options := utils.Map(configSpec.sources, func(s SourceSpec) string { return s.blockchainDesc })
+	options := sdkutils.Map(configSpec.sources, func(s SourceSpec) string { return s.blockchainDesc })
 	options = append(options, cancelOption)
 	opt, err := app.Prompt.CaptureList(prompt, options)
 	if err != nil {
@@ -283,7 +284,7 @@ func removeDestination(
 		return configSpec, true, nil
 	}
 	prompt := "Select the destination you want to remove"
-	options := utils.Map(configSpec.destinations, func(d DestinationSpec) string { return d.blockchainDesc })
+	options := sdkutils.Map(configSpec.destinations, func(d DestinationSpec) string { return d.blockchainDesc })
 	options = append(options, cancelOption)
 	opt, err := app.Prompt.CaptureList(prompt, options)
 	if err != nil {

--- a/cmd/interchaincmd/relayercmd/logs.go
+++ b/cmd/interchaincmd/relayercmd/logs.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
-	sdkUtils "github.com/ava-labs/avalanche-cli/sdk/utils"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 	"github.com/ava-labs/avalanchego/utils/logging"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -128,12 +128,12 @@ func logs(_ *cobra.Command, _ []string) error {
 			}
 			logMsg := wordwrap.WrapString(msg, 80)
 			logMsgLines := strings.Split(logMsg, "\n")
-			logMsgLines = utils.Map(logMsgLines, func(s string) string { return logging.Green.Wrap(s) })
+			logMsgLines = sdkutils.Map(logMsgLines, func(s string) string { return logging.Green.Wrap(s) })
 			logMsg = strings.Join(logMsgLines, "\n")
 			keys := maps.Keys(logMap)
 			sort.Strings(keys)
 			for _, k := range keys {
-				if !sdkUtils.Belongs([]string{"logger", "caller", "level", "timestamp", "msg"}, k) {
+				if !sdkutils.Belongs([]string{"logger", "caller", "level", "timestamp", "msg"}, k) {
 					logMsg = addAditionalInfo(
 						logMsg,
 						logMap,

--- a/cmd/interchaincmd/tokentransferrercmd/deploy.go
+++ b/cmd/interchaincmd/tokentransferrercmd/deploy.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/prompts"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -226,7 +227,7 @@ func CallDeploy(_ []string, flags DeployFlags) error {
 		if err != nil {
 			return err
 		}
-		popularTokensDesc := utils.Map(
+		popularTokensDesc := sdkutils.Map(
 			popularTokensInfo,
 			func(i PopularTokenInfo) string {
 				return i.Desc()

--- a/cmd/nodecmd/create.go
+++ b/cmd/nodecmd/create.go
@@ -14,27 +14,25 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ava-labs/avalanche-cli/pkg/node"
-
-	awsAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/aws"
-	"github.com/ava-labs/avalanche-cli/pkg/docker"
-
-	"github.com/ava-labs/avalanche-cli/pkg/metrics"
-
 	"github.com/ava-labs/avalanche-cli/cmd/flags"
 	"github.com/ava-labs/avalanche-cli/pkg/ansible"
+	awsAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/aws"
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
+	"github.com/ava-labs/avalanche-cli/pkg/docker"
+	"github.com/ava-labs/avalanche-cli/pkg/metrics"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
+	"github.com/ava-labs/avalanche-cli/pkg/node"
 	"github.com/ava-labs/avalanche-cli/pkg/ssh"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanche-cli/pkg/vm"
-	sdkUtils "github.com/ava-labs/avalanche-cli/sdk/utils"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/staking"
 	"github.com/ava-labs/avalanchego/utils/logging"
+
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
@@ -1010,7 +1008,7 @@ func generateNodeCertAndKeys(stakerCertFilePath, stakerKeyFilePath, blsKeyFilePa
 
 func provideStakingCertAndKey(host *models.Host) error {
 	keyPath := app.GetNodeStakingDir(host.IP)
-	if sdkUtils.DirExists(keyPath) && !overrideExisting {
+	if sdkutils.DirExists(keyPath) && !overrideExisting {
 		yes, err := app.Prompt.CaptureNoYes(fmt.Sprintf("Directory %s alreday exists. Do you want to override it?", keyPath))
 		if err != nil {
 			return err
@@ -1349,11 +1347,11 @@ func getRegionsNodeNum(cloudName string) (
 		nodes[userRegion] = NumNodes{int(numNodes), int(numAPINodes)}
 		var currentInput []string
 		if globalNetworkFlags.UseDevnet || globalNetworkFlags.UseFuji {
-			currentInput = utils.Map(maps.Keys(nodes), func(region string) string {
+			currentInput = sdkutils.Map(maps.Keys(nodes), func(region string) string {
 				return fmt.Sprintf("[%s]: %d validator(s) %d api(s)", region, nodes[region].numValidators, nodes[region].numAPI)
 			})
 		} else {
-			currentInput = utils.Map(maps.Keys(nodes), func(region string) string {
+			currentInput = sdkutils.Map(maps.Keys(nodes), func(region string) string {
 				return fmt.Sprintf("[%s]: %d validator(s)", region, nodes[region].numValidators)
 			})
 		}
@@ -1376,7 +1374,7 @@ func setSSHIdentity() (string, error) {
 		return "", err
 	}
 	yubikeyRegexp := regexp.MustCompile(yubikeyPattern)
-	sshIdentities = utils.Map(sshIdentities, func(id string) string {
+	sshIdentities = sdkutils.Map(sshIdentities, func(id string) string {
 		if len(yubikeyRegexp.FindStringSubmatch(id)) > 0 {
 			return fmt.Sprintf("%s%s", id, yubikeyMark)
 		}

--- a/cmd/nodecmd/create_devnet.go
+++ b/cmd/nodecmd/create_devnet.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/ssh"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 	"github.com/ava-labs/avalanchego/config"
 	avago_upgrade "github.com/ava-labs/avalanchego/upgrade"
 	avago_constants "github.com/ava-labs/avalanchego/utils/constants"
@@ -223,7 +224,7 @@ func setupDevnet(clusterName string, hosts []*models.Host, apiNodeIPMap map[stri
 	hostsWithoutAPI := utils.Filter(hosts, func(h *models.Host) bool {
 		return !slices.Contains(maps.Keys(apiNodeIPMap), h.GetCloudID())
 	})
-	hostsWithoutAPIIDs := utils.Map(hostsWithoutAPI, func(h *models.Host) string { return h.NodeID })
+	hostsWithoutAPIIDs := sdkutils.Map(hostsWithoutAPI, func(h *models.Host) string { return h.NodeID })
 
 	// create genesis file at each node dir
 	genesisBytes, err := generateCustomGenesis(network.ID, walletAddrStr, stakingAddrStr, hostsWithoutAPI)

--- a/cmd/nodecmd/dynamic_ips.go
+++ b/cmd/nodecmd/dynamic_ips.go
@@ -6,16 +6,14 @@ import (
 	"context"
 	"fmt"
 
-	nodePkg "github.com/ava-labs/avalanche-cli/pkg/node"
-
+	"github.com/ava-labs/avalanche-cli/pkg/ansible"
 	awsAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/aws"
 	gcpAPI "github.com/ava-labs/avalanche-cli/pkg/cloud/gcp"
-
-	"github.com/ava-labs/avalanche-cli/pkg/ansible"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
-	"github.com/ava-labs/avalanche-cli/pkg/utils"
+	nodePkg "github.com/ava-labs/avalanche-cli/pkg/node"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 )
 
 func getNodesWithDynamicIP(clusterNodes []string) ([]models.NodeConfig, error) {
@@ -98,7 +96,7 @@ func updatePublicIPs(clusterName string) error {
 		return err
 	}
 	if len(nodesWithDynamicIP) > 0 {
-		nodeIDs := utils.Map(nodesWithDynamicIP, func(c models.NodeConfig) string { return c.NodeID })
+		nodeIDs := sdkutils.Map(nodesWithDynamicIP, func(c models.NodeConfig) string { return c.NodeID })
 		ux.Logger.PrintToUser("Nodes with dynamic IPs in cluster: %s", nodeIDs)
 		publicIPMap, err := getPublicIPsForNodesWithDynamicIP(nodesWithDynamicIP)
 		if err != nil {

--- a/cmd/nodecmd/import.go
+++ b/cmd/nodecmd/import.go
@@ -95,7 +95,7 @@ func importFile(_ *cobra.Command, args []string) error {
 	}
 	// add inventory
 	inventoryPath := app.GetAnsibleInventoryDirPath(clusterName)
-	nodes := utils.Map(importCluster.Nodes, func(node models.ExportNode) models.NodeConfig { return node.NodeConfig })
+	nodes := sdkutils.Map(importCluster.Nodes, func(node models.ExportNode) models.NodeConfig { return node.NodeConfig })
 	if err := ansible.WriteNodeConfigsToAnsibleInventory(inventoryPath, nodes); err != nil {
 		ux.Logger.RedXToUser("error writing inventory file: %v", err)
 		return err

--- a/cmd/nodecmd/ssh.go
+++ b/cmd/nodecmd/ssh.go
@@ -172,7 +172,7 @@ func sshHosts(hosts []*models.Host, cmd string, clusterConf models.ClusterConfig
 		// open shell
 		switch {
 		case len(hosts) > 1:
-			return fmt.Errorf("cannot open ssh shell on multiple nodes: %s", strings.Join(utils.Map(hosts, func(h *models.Host) string { return h.GetCloudID() }), ", "))
+			return fmt.Errorf("cannot open ssh shell on multiple nodes: %s", strings.Join(sdkutils.Map(hosts, func(h *models.Host) string { return h.GetCloudID() }), ", "))
 		case len(hosts) == 0:
 			return fmt.Errorf("no nodes found")
 		default:

--- a/cmd/validatorcmd/list.go
+++ b/cmd/validatorcmd/list.go
@@ -4,21 +4,14 @@ package validatorcmd
 
 import (
 	"fmt"
-	"sort"
 
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/contract"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
-	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanche-cli/sdk/validator"
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/units"
-	"github.com/ava-labs/avalanchego/vms/platformvm"
-	"github.com/ava-labs/avalanchego/vms/platformvm/api"
-	"golang.org/x/exp/maps"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 )
@@ -58,24 +51,8 @@ func list(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	if sc.Networks[network.Name()].ValidatorManagerAddress == "" {
-		return fmt.Errorf("unable to find Validator Manager address")
-	}
-	validatorManagerAddress = sc.Networks[network.Name()].ValidatorManagerAddress
-
 	chainSpec := contract.ChainSpec{
 		BlockchainName: blockchainName,
-	}
-
-	rpcURL, _, err := contract.GetBlockchainEndpoints(
-		app,
-		network,
-		chainSpec,
-		true,
-		false,
-	)
-	if err != nil {
-		return err
 	}
 
 	subnetID, err := contract.GetSubnetID(app, network, chainSpec)
@@ -83,41 +60,24 @@ func list(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	pClient := platformvm.NewClient(network.Endpoint)
-	ctx, cancel := utils.GetAPIContext()
-	defer cancel()
-	validators, err := pClient.GetValidatorsAt(ctx, subnetID, api.ProposedHeight)
+	validators, err := validator.GetCurrentValidators(network.SDKNetwork(), subnetID)
 	if err != nil {
 		return err
 	}
-	managerAddress := common.HexToAddress(validatorManagerAddress)
 
 	t := ux.DefaultTable(
 		fmt.Sprintf("%s Validators", blockchainName),
 		table.Row{"Node ID", "Validation ID", "Weight", "Remaining Balance (AVAX)"},
 	)
-
-	nodeIDs := maps.Keys(validators)
-	nodeIDStrs := utils.Map(nodeIDs, func(nodeID ids.NodeID) string { return nodeID.String() })
-	sort.Strings(nodeIDStrs)
-
-	for _, nodeIDStr := range nodeIDStrs {
-		nodeID, err := ids.NodeIDFromString(nodeIDStr)
-		if err != nil {
-			return err
-		}
-		balance := uint64(0)
-		validationID, err := validator.GetValidationID(rpcURL, managerAddress, nodeID)
-		if err != nil {
-			ux.Logger.RedXToUser("could not get validation ID for node %s due to %s", nodeID, err)
-		} else {
-			balance, err = validator.GetValidatorBalance(network.SDKNetwork(), validationID)
-			if err != nil {
-				ux.Logger.RedXToUser("could not get balance for node %s due to %s", nodeID, err)
-			}
-		}
-		t.AppendRow(table.Row{nodeID, validationID, validators[nodeID].Weight, float64(balance) / float64(units.Avax)})
+	for _, validator := range validators {
+		t.AppendRow(table.Row{
+			validator.NodeID,
+			validator.ValidationID,
+			validator.Weight,
+			float64(validator.Balance) / float64(units.Avax),
+		})
 	}
 	fmt.Println(t.Render())
+
 	return nil
 }

--- a/pkg/cloud/aws/aws.go
+++ b/pkg/cloud/aws/aws.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -248,7 +249,7 @@ func (c *AwsCloud) CreateEC2Instances(prefix string, count int, amiID, instanceT
 	case 0:
 		return nil, fmt.Errorf("no instances created")
 	case count:
-		instanceIDs := utils.Map(runResult.Instances, func(instance types.Instance) string {
+		instanceIDs := sdkutils.Map(runResult.Instances, func(instance types.Instance) string {
 			return *instance.InstanceId
 		})
 		return instanceIDs, nil

--- a/pkg/cloud/gcp/gcp.go
+++ b/pkg/cloud/gcp/gcp.go
@@ -11,17 +11,15 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/exp/rand"
-
-	"golang.org/x/exp/slices"
-	"golang.org/x/sync/errgroup"
-
-	"google.golang.org/api/compute/v1"
-
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
-	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
+
+	"golang.org/x/exp/rand"
+	"golang.org/x/exp/slices"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/api/compute/v1"
 )
 
 const (
@@ -606,7 +604,7 @@ func (c *GcpCloud) IsInstanceTypeSupported(machineType string, zone string) (boo
 	if err != nil {
 		return false, err
 	}
-	supportedMachineTypes := utils.Map(machineTypes.Items, func(mt *compute.MachineType) string {
+	supportedMachineTypes := sdkutils.Map(machineTypes.Items, func(mt *compute.MachineType) string {
 		return mt.Name
 	})
 	return slices.Contains(supportedMachineTypes, machineType), nil

--- a/pkg/localnet/localcluster.go
+++ b/pkg/localnet/localcluster.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ava-labs/avalanche-cli/pkg/application"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
-	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
@@ -327,7 +326,7 @@ func GetFilteredLocalClusters(
 				if err != nil {
 					return nil, err
 				}
-				blockchainNames := utils.Map(blockchains, func(i BlockchainInfo) string { return i.Name })
+				blockchainNames := sdkutils.Map(blockchains, func(i BlockchainInfo) string { return i.Name })
 				if !sdkutils.Belongs(blockchainNames, blockchainName) {
 					continue
 				}

--- a/pkg/localnet/output.go
+++ b/pkg/localnet/output.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 )
@@ -153,7 +154,7 @@ func PrintL1Endpoints(
 		if err != nil {
 			return err
 		}
-		trackedBlockchains := utils.Map(trackedBlockchainsInfo, func(i BlockchainInfo) string { return i.Name })
+		trackedBlockchains := sdkutils.Map(trackedBlockchainsInfo, func(i BlockchainInfo) string { return i.Name })
 		networkDir := GetLocalClusterDir(app, clusterName)
 		network, err := GetTmpNetNetworkWithURIFix(networkDir)
 		if err != nil {

--- a/pkg/localnet/tmpnet.go
+++ b/pkg/localnet/tmpnet.go
@@ -739,7 +739,7 @@ func TmpNetTrackBlockchainOnNodes(
 			return err
 		}
 	}
-	nodeIDs := utils.Map(nodes, func(node *tmpnet.Node) ids.NodeID { return node.NodeID })
+	nodeIDs := sdkutils.Map(nodes, func(node *tmpnet.Node) ids.NodeID { return node.NodeID })
 	for nodeID, blockchainConfig := range perNodeBlockchainConfig {
 		if !sdkutils.Belongs(nodeIDs, nodeID) {
 			continue
@@ -878,7 +878,7 @@ func GetNewTmpNetNodes(
 			node.Flags[config.StakingPortKey] = 0
 		}
 		if len(trackedSubnets) > 0 {
-			trackedSubnetsStr := utils.Map(trackedSubnets, func(i ids.ID) string { return i.String() })
+			trackedSubnetsStr := sdkutils.Map(trackedSubnets, func(i ids.ID) string { return i.String() })
 			node.Flags[config.TrackSubnetsKey] = strings.Join(trackedSubnetsStr, ",")
 		}
 		if err := node.EnsureKeys(); err != nil {
@@ -1120,7 +1120,7 @@ func GetTmpNetNodeURIsWithFix(
 	if err != nil {
 		return nil, err
 	}
-	return utils.Map(network.GetNodeURIs(), func(nodeURI tmpnet.NodeURI) string { return nodeURI.URI }), nil
+	return sdkutils.Map(network.GetNodeURIs(), func(nodeURI tmpnet.NodeURI) string { return nodeURI.URI }), nil
 }
 
 // Get paths for most important avalanchego logs that are present on the network nodes

--- a/pkg/networkoptions/network_options.go
+++ b/pkg/networkoptions/network_options.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 	"github.com/ava-labs/avalanchego/api/info"
 
 	"github.com/spf13/cobra"
@@ -230,8 +231,8 @@ func GetNetworkFromCmdLineFlags(
 		if err != nil {
 			return models.UndefinedNetwork, err
 		}
-		supportedNetworkOptionsStrs = strings.Join(utils.Map(supportedNetworkOptions, func(s NetworkOption) string { return s.String() }), ", ")
-		filteredSupportedNetworkOptionsStrs = strings.Join(utils.Map(filteredSupportedNetworkOptions, func(s NetworkOption) string { return s.String() }), ", ")
+		supportedNetworkOptionsStrs = strings.Join(sdkutils.Map(supportedNetworkOptions, func(s NetworkOption) string { return s.String() }), ", ")
+		filteredSupportedNetworkOptionsStrs = strings.Join(sdkutils.Map(filteredSupportedNetworkOptions, func(s NetworkOption) string { return s.String() }), ", ")
 		if len(filteredSupportedNetworkOptions) == 0 {
 			return models.UndefinedNetwork, fmt.Errorf("no supported deployed networks available on blockchain %q. please deploy to one of: [%s]", subnetName, supportedNetworkOptionsStrs)
 		}
@@ -245,7 +246,7 @@ func GetNetworkFromCmdLineFlags(
 		Mainnet: "--mainnet",
 		Cluster: "--cluster",
 	}
-	supportedNetworksFlags := strings.Join(utils.Map(supportedNetworkOptions, func(n NetworkOption) string { return networkFlagsMap[n] }), ", ")
+	supportedNetworksFlags := strings.Join(sdkutils.Map(supportedNetworkOptions, func(n NetworkOption) string { return networkFlagsMap[n] }), ", ")
 	// received option
 	networkOption := Undefined
 	switch {
@@ -318,7 +319,7 @@ func GetNetworkFromCmdLineFlags(
 		}
 		networkOptionStr, err := app.Prompt.CaptureList(
 			promptStr,
-			utils.Map(supportedNetworkOptionsToPrompt, func(n NetworkOption) string { return n.String() }),
+			sdkutils.Map(supportedNetworkOptionsToPrompt, func(n NetworkOption) string { return n.String() }),
 		)
 		if err != nil {
 			return models.UndefinedNetwork, err

--- a/pkg/node/helper.go
+++ b/pkg/node/helper.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanche-cli/pkg/vm"
-	sdkUtils "github.com/ava-labs/avalanche-cli/sdk/utils"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 	"github.com/ava-labs/avalanchego/api/info"
 )
 
@@ -174,9 +174,9 @@ func getPublicEndpoints(
 		publicNodes = clusterConfig.Nodes
 	}
 	publicTrackers := utils.Filter(trackers, func(tracker *models.Host) bool {
-		return sdkUtils.Belongs(publicNodes, tracker.GetCloudID())
+		return sdkutils.Belongs(publicNodes, tracker.GetCloudID())
 	})
-	endpoints := utils.Map(publicTrackers, func(tracker *models.Host) string {
+	endpoints := sdkutils.Map(publicTrackers, func(tracker *models.Host) string {
 		return GetAvalancheGoEndpoint(tracker.IP)
 	})
 	return endpoints, nil

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -16,7 +16,9 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 	"github.com/ava-labs/avalanchego/ids"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
@@ -585,7 +587,7 @@ func (*realPrompter) CaptureAddresses(promptStr string) ([]common.Address, error
 			validated = true
 		}
 	}
-	addresses := utils.Map(
+	addresses := sdkutils.Map(
 		strings.Split(addressesStr, ","),
 		func(s string) common.Address {
 			return common.HexToAddress(strings.TrimSpace(s))
@@ -1029,7 +1031,7 @@ func PromptChain(
 		subnetOptions = append(subnetOptions, cChainOption)
 	}
 	subnetNames = utils.RemoveFromSlice(subnetNames, avoidBlockchainName)
-	subnetOptions = append(subnetOptions, utils.Map(subnetNames, func(s string) string { return "Blockchain " + s })...)
+	subnetOptions = append(subnetOptions, sdkutils.Map(subnetNames, func(s string) string { return "Blockchain " + s })...)
 	if includeCustom {
 		subnetOptions = append(subnetOptions, customOption)
 	} else {

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -144,14 +144,6 @@ func Filter[T any](input []T, f func(T) bool) []T {
 	return output
 }
 
-func Map[T, U any](input []T, f func(T) U) []U {
-	output := make([]U, 0, len(input))
-	for _, e := range input {
-		output = append(output, f(e))
-	}
-	return output
-}
-
 func MapWithError[T, U any](input []T, f func(T) (U, error)) ([]U, error) {
 	output := make([]U, 0, len(input))
 	for _, e := range input {

--- a/pkg/utils/ssh.go
+++ b/pkg/utils/ssh.go
@@ -9,10 +9,11 @@ import (
 	"regexp"
 	"strings"
 
-	"golang.org/x/exp/slices"
-
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
+	"github.com/ava-labs/avalanche-cli/sdk/utils"
+
 	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/exp/slices"
 )
 
 // GetSSHConnectionString returns the SSH connection string for the given public IP and certificate file path.
@@ -108,7 +109,7 @@ func ListSSHAgentIdentities() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	identityList := Map(sshIDs, func(id *agent.Key) string { return id.Comment })
+	identityList := utils.Map(sshIDs, func(id *agent.Key) string { return id.Comment })
 	return identityList, nil
 }
 

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -8,16 +8,18 @@ import (
 	"math/big"
 	"strconv"
 	"strings"
+
+	"github.com/ava-labs/avalanche-cli/sdk/utils"
 )
 
 // SplitComaSeparatedString splits and trims a comma-separated string into a slice of strings.
 func SplitComaSeparatedString(s string) []string {
-	return Map(strings.Split(s, ","), strings.TrimSpace)
+	return utils.Map(strings.Split(s, ","), strings.TrimSpace)
 }
 
 // SplitComaSeparatedInt splits a comma-separated string into a slice of integers.
 func SplitComaSeparatedInt(s string) []int {
-	return Map(SplitComaSeparatedString(s), func(item string) int {
+	return utils.Map(SplitComaSeparatedString(s), func(item string) int {
 		num, _ := strconv.Atoi(item)
 		return num
 	})
@@ -36,7 +38,7 @@ func SplitStringWithQuotes(str string, r rune) []string {
 
 // AddSingleQuotes adds single quotes to each string in the given slice.
 func AddSingleQuotes(s []string) []string {
-	return Map(s, func(item string) string {
+	return utils.Map(s, func(item string) string {
 		if item == "" {
 			return "''"
 		}
@@ -60,7 +62,7 @@ func CleanupString(s string) string {
 
 // CleanupStrings cleans up a slice of strings by trimming \r and \n characters.
 func CleanupStrings(s []string) []string {
-	return Map(s, CleanupString)
+	return utils.Map(s, CleanupString)
 }
 
 // Formats an amount of base units as a string representing the amount in the given denomination.

--- a/pkg/validatormanager/registration.go
+++ b/pkg/validatormanager/registration.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanche-cli/sdk/evm"
 	"github.com/ava-labs/avalanche-cli/sdk/interchain"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 	"github.com/ava-labs/avalanche-cli/sdk/validator"
 	"github.com/ava-labs/avalanche-cli/sdk/validatormanager"
 	"github.com/ava-labs/avalanchego/api/info"
@@ -62,13 +63,13 @@ func InitializeValidatorRegistrationPoSNative(
 
 	balanceOwnersAux := PChainOwner{
 		Threshold: balanceOwners.Threshold,
-		Addresses: utils.Map(balanceOwners.Addresses, func(addr ids.ShortID) common.Address {
+		Addresses: sdkutils.Map(balanceOwners.Addresses, func(addr ids.ShortID) common.Address {
 			return common.BytesToAddress(addr[:])
 		}),
 	}
 	disableOwnersAux := PChainOwner{
 		Threshold: disableOwners.Threshold,
-		Addresses: utils.Map(disableOwners.Addresses, func(addr ids.ShortID) common.Address {
+		Addresses: sdkutils.Map(disableOwners.Addresses, func(addr ids.ShortID) common.Address {
 			return common.BytesToAddress(addr[:])
 		}),
 	}
@@ -117,13 +118,13 @@ func InitializeValidatorRegistrationPoA(
 	}
 	balanceOwnersAux := PChainOwner{
 		Threshold: balanceOwners.Threshold,
-		Addresses: utils.Map(balanceOwners.Addresses, func(addr ids.ShortID) common.Address {
+		Addresses: sdkutils.Map(balanceOwners.Addresses, func(addr ids.ShortID) common.Address {
 			return common.BytesToAddress(addr[:])
 		}),
 	}
 	disableOwnersAux := PChainOwner{
 		Threshold: disableOwners.Threshold,
-		Addresses: utils.Map(disableOwners.Addresses, func(addr ids.ShortID) common.Address {
+		Addresses: sdkutils.Map(disableOwners.Addresses, func(addr ids.ShortID) common.Address {
 			return common.BytesToAddress(addr[:])
 		}),
 	}

--- a/pkg/vm/allowlist.go
+++ b/pkg/vm/allowlist.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ava-labs/avalanche-cli/pkg/application"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
-	sdkUtils "github.com/ava-labs/avalanche-cli/sdk/utils"
+	sdkutils "github.com/ava-labs/avalanche-cli/sdk/utils"
 	"github.com/ava-labs/avalanchego/utils/logging"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -43,7 +43,7 @@ func addRoleToPreviewTable(table *tablewriter.Table, name string, addresses []co
 	if len(addresses) == 0 {
 		table.Append([]string{name, strings.Repeat(" ", 11)})
 	} else {
-		addressesStr := strings.Join(utils.Map(addresses, func(a common.Address) string { return a.Hex() }), "\n")
+		addressesStr := strings.Join(sdkutils.Map(addresses, func(a common.Address) string { return a.Hex() }), "\n")
 		table.Append([]string{name, addressesStr})
 	}
 }
@@ -59,11 +59,11 @@ func getNewAddresses(
 	}
 	for _, address := range addresses {
 		switch {
-		case sdkUtils.Belongs(allowList.AdminAddresses, address):
+		case sdkutils.Belongs(allowList.AdminAddresses, address):
 			fmt.Println(address.Hex() + " is already allowed as admin role")
-		case sdkUtils.Belongs(allowList.ManagerAddresses, address):
+		case sdkutils.Belongs(allowList.ManagerAddresses, address):
 			fmt.Println(address.Hex() + " is already allowed as manager role")
-		case sdkUtils.Belongs(allowList.EnabledAddresses, address):
+		case sdkutils.Belongs(allowList.EnabledAddresses, address):
 			fmt.Println(address.Hex() + " is already allowed as enabled role")
 		default:
 			newAddresses = append(newAddresses, address)
@@ -84,7 +84,7 @@ func removeAddress(
 	}
 	cancelOption := "Cancel"
 	prompt := "Select the address you want to remove"
-	options := utils.Map(addresses, func(a common.Address) string { return a.Hex() })
+	options := sdkutils.Map(addresses, func(a common.Address) string { return a.Hex() })
 	options = append(options, cancelOption)
 	opt, err := app.Prompt.CaptureList(prompt, options)
 	if err != nil {

--- a/sdk/utils/utils.go
+++ b/sdk/utils/utils.go
@@ -34,6 +34,14 @@ func Belongs[T comparable](input []T, elem T) bool {
 	return false
 }
 
+func Map[T, U any](input []T, f func(T) U) []U {
+	output := make([]U, 0, len(input))
+	for _, e := range input {
+		output = append(output, f(e))
+	}
+	return output
+}
+
 func Uint32Sort(arr []uint32) {
 	sort.Slice(arr, func(i, j int) bool { return arr[i] < arr[j] })
 }

--- a/sdk/validator/validator.go
+++ b/sdk/validator/validator.go
@@ -3,15 +3,17 @@
 package validator
 
 import (
+	"encoding/json"
+
 	"github.com/ava-labs/avalanche-cli/pkg/contract"
 	"github.com/ava-labs/avalanche-cli/sdk/network"
 	"github.com/ava-labs/avalanche-cli/sdk/utils"
 	"github.com/ava-labs/avalanchego/ids"
+	avalanchegojson "github.com/ava-labs/avalanchego/utils/json"
+	"github.com/ava-labs/avalanchego/utils/rpc"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
-	"github.com/ava-labs/avalanchego/vms/platformvm/api"
 
 	"github.com/ethereum/go-ethereum/common"
-	"golang.org/x/exp/maps"
 )
 
 type ValidatorKind int64
@@ -23,30 +25,32 @@ const (
 	NonSovereignValidator
 )
 
-func GetTotalWeight(net network.Network, subnetID ids.ID) (uint64, error) {
-	pClient := platformvm.NewClient(net.Endpoint)
-	ctx, cancel := utils.GetAPIContext()
-	defer cancel()
-	validators, err := pClient.GetValidatorsAt(ctx, subnetID, api.ProposedHeight)
+// To enable querying validation IDs from P-Chain
+type CurrentValidatorInfo struct {
+	Weight       avalanchegojson.Uint64 `json:"weight"`
+	NodeID       ids.NodeID             `json:"nodeID"`
+	ValidationID ids.ID                 `json:"validationID"`
+	Balance      avalanchegojson.Uint64 `json:"balance"`
+}
+
+func GetTotalWeight(network network.Network, subnetID ids.ID) (uint64, error) {
+	validators, err := GetCurrentValidators(network, subnetID)
 	if err != nil {
 		return 0, err
 	}
 	weight := uint64(0)
 	for _, vdr := range validators {
-		weight += vdr.Weight
+		weight += uint64(vdr.Weight)
 	}
 	return weight, nil
 }
 
-func IsValidator(net network.Network, subnetID ids.ID, nodeID ids.NodeID) (bool, error) {
-	pClient := platformvm.NewClient(net.Endpoint)
-	ctx, cancel := utils.GetAPIContext()
-	defer cancel()
-	validators, err := pClient.GetValidatorsAt(ctx, subnetID, api.ProposedHeight)
+func IsValidator(network network.Network, subnetID ids.ID, nodeID ids.NodeID) (bool, error) {
+	validators, err := GetCurrentValidators(network, subnetID)
 	if err != nil {
 		return false, err
 	}
-	nodeIDs := maps.Keys(validators)
+	nodeIDs := utils.Map(validators, func(v CurrentValidatorInfo) ids.NodeID { return v.NodeID })
 	return utils.Belongs(nodeIDs, nodeID), nil
 }
 
@@ -109,4 +113,36 @@ func IsSovereignValidator(
 		}
 	}
 	return NonValidator, nil
+}
+
+// Enables querying the validation IDs from P-Chain
+func GetCurrentValidators(network network.Network, subnetID ids.ID) ([]CurrentValidatorInfo, error) {
+	ctx, cancel := utils.GetAPIContext()
+	defer cancel()
+	requester := rpc.NewEndpointRequester(network.Endpoint + "/ext/P")
+	res := &platformvm.GetCurrentValidatorsReply{}
+	if err := requester.SendRequest(
+		ctx,
+		"platform.getCurrentValidators",
+		&platformvm.GetCurrentValidatorsArgs{
+			SubnetID: subnetID,
+			NodeIDs:  nil,
+		},
+		res,
+	); err != nil {
+		return nil, err
+	}
+	validators := make([]CurrentValidatorInfo, 0, len(res.Validators))
+	for _, vI := range res.Validators {
+		vBytes, err := json.Marshal(vI)
+		if err != nil {
+			return nil, err
+		}
+		var v CurrentValidatorInfo
+		if err := json.Unmarshal(vBytes, &v); err != nil {
+			return nil, err
+		}
+		validators = append(validators, v)
+	}
+	return validators, nil
 }


### PR DESCRIPTION
## Why this should be merged
Fixes cases of empty node ID in `avalanche validator list` when the node uses all the balance.
Also makes the following command to not need to use the validator manager:
- avalanche validator list
- avalanche validator getBalance
- avalanche validator increaseBalance

## How this works

## How this was tested

## How is this documented
