### PR TITLE
limit number of keys to be listed on mainnet

### DIFF
--- a/cmd/keycmd/list.go
+++ b/cmd/keycmd/list.go
@@ -289,6 +289,12 @@ func listKeys(*cobra.Command, []string) error {
 		}
 		networks = append(networks, network)
 	}
+	mainnetIsIncluded := len(utils.Filter(networks, func(n models.Network) bool { return n.Kind == models.Mainnet })) > 0
+	if mainnetIsIncluded && len(keys) != 1 {
+		ux.Logger.PrintToUser("For mainnet you need to specify the key name to be listed by using the --keys flag")
+		return nil
+	}
+
 	if len(subnets) == 0 {
 		subnets = []string{"p", "x", "c"}
 	}


### PR DESCRIPTION
## Why this should be merged
Currently CLI hits mainnet api rate limits when trying to query a medium set of user keys.
Afterwards all key commands, and many others, become unavailable.

## How this works

## How this was tested

## How is this documented
