### PR TITLE
bug fixes needed by https://github.com/ava-labs/avalanche-cli/pull/2776

### DIFF
--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/contract"
+	"github.com/ava-labs/avalanche-cli/pkg/interchain/relayer"
 	"github.com/ava-labs/avalanche-cli/pkg/keychain"
 	"github.com/ava-labs/avalanche-cli/pkg/localnet"
 	"github.com/ava-labs/avalanche-cli/pkg/metrics"
@@ -944,7 +945,11 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 					deployRelayerFlags.BlockchainsToRelay = utils.Unique(sdkutils.Map(blockchains, func(i localnet.BlockchainInfo) string { return i.Name }))
 				}
 				if network.Kind == models.Local || useLocalMachine {
-					deployRelayerFlags.Key = constants.ICMRelayerKeyName
+					relayerKeyName, _, _, err := relayer.GetDefaultRelayerKeyInfo(app)
+					if err != nil {
+						return err
+					}
+					deployRelayerFlags.Key = relayerKeyName
 					deployRelayerFlags.Amount = constants.DefaultRelayerAmount
 					deployRelayerFlags.BlockchainFundingKey = constants.ICMKeyName
 				}

--- a/cmd/nodecmd/wiz.go
+++ b/cmd/nodecmd/wiz.go
@@ -569,7 +569,7 @@ func chooseICMRelayerHost(clusterName string) (*models.Host, error) {
 }
 
 func updateICMRelayerFunds(network models.Network, sc models.Sidecar, blockchainID ids.ID) error {
-	relayerKey, err := app.GetKey(constants.ICMRelayerKeyName, network, true)
+	_, relayerAddress, _, err := relayer.GetDefaultRelayerKeyInfo(app)
 	if err != nil {
 		return err
 	}
@@ -580,7 +580,7 @@ func updateICMRelayerFunds(network models.Network, sc models.Sidecar, blockchain
 	if err := relayer.FundRelayer(
 		network.BlockchainEndpoint(blockchainID.String()),
 		icmKey.PrivKeyHex(),
-		relayerKey.C(),
+		relayerAddress,
 	); err != nil {
 		return nil
 	}
@@ -591,7 +591,7 @@ func updateICMRelayerFunds(network models.Network, sc models.Sidecar, blockchain
 	return relayer.FundRelayer(
 		network.BlockchainEndpoint("C"),
 		ewoqKey.PrivKeyHex(),
-		relayerKey.C(),
+		relayerAddress,
 	)
 }
 
@@ -968,7 +968,7 @@ func setUpSubnetLogging(clusterName, subnetName string) error {
 }
 
 func addBlockchainToRelayerConf(network models.Network, cloudNodeID string, blockchainName string) error {
-	relayerAddress, relayerPrivateKey, err := relayer.GetRelayerKeyInfo(app)
+	_, relayerAddress, relayerPrivateKey, err := relayer.GetDefaultRelayerKeyInfo(app)
 	if err != nil {
 		return err
 	}

--- a/pkg/ictt/foundry.go
+++ b/pkg/ictt/foundry.go
@@ -3,9 +3,9 @@
 package ictt
 
 import (
-	_ "embed"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -42,7 +42,9 @@ func InstallFoundry() error {
 		"-L",
 		fmt.Sprintf("https://raw.githubusercontent.com/ava-labs/foundry/%s/foundryup/install", foundryVersion),
 	)
+	cmdsEnv := append(os.Environ(), "XDG_CONFIG_HOME=")
 	installCmd := exec.Command("bash")
+	installCmd.Env = cmdsEnv
 	var downloadOutbuf, downloadErrbuf strings.Builder
 	downloadCmdStdoutPipe, err := downloadCmd.StdoutPipe()
 	if err != nil {
@@ -76,7 +78,9 @@ func InstallFoundry() error {
 		return err
 	}
 	ux.Logger.PrintToUser(strings.TrimSuffix(installOutbuf.String(), "\n"))
-	out, err := exec.Command(foundryupPath, "-v", foundryVersion).CombinedOutput()
+	foundryupCmd := exec.Command(foundryupPath, "-v", foundryVersion)
+	foundryupCmd.Env = cmdsEnv
+	out, err := foundryupCmd.CombinedOutput()
 	ux.Logger.PrintToUser(string(out))
 	if err != nil {
 		ux.Logger.PrintToUser("")

--- a/pkg/interchain/relayer/relayer.go
+++ b/pkg/interchain/relayer/relayer.go
@@ -40,8 +40,9 @@ const (
 
 var relayerRequiredBalance = big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(500)) // 500 AVAX
 
-func GetRelayerKeyInfo(app *application.Avalanche) (string, string, error) {
-	keyPath := app.GetKeyPath(constants.ICMRelayerKeyName)
+func GetDefaultRelayerKeyInfo(app *application.Avalanche) (string, string, string, error) {
+	keyName := constants.ICMRelayerKeyName
+	keyPath := app.GetKeyPath(keyName)
 	var (
 		k   *key.SoftKey
 		err error
@@ -49,18 +50,18 @@ func GetRelayerKeyInfo(app *application.Avalanche) (string, string, error) {
 	if utils.FileExists(keyPath) {
 		k, err = key.LoadSoft(models.NewLocalNetwork().ID, keyPath)
 		if err != nil {
-			return "", "", err
+			return "", "", "", err
 		}
 	} else {
 		k, err = key.NewSoft(0)
 		if err != nil {
-			return "", "", err
+			return "", "", "", err
 		}
 		if err := k.Save(keyPath); err != nil {
-			return "", "", err
+			return "", "", "", err
 		}
 	}
-	return k.C(), k.PrivKeyHex(), nil
+	return keyName, k.C(), k.PrivKeyHex(), nil
 }
 
 func FundRelayer(

--- a/pkg/vm/create_evm.go
+++ b/pkg/vm/create_evm.go
@@ -158,7 +158,7 @@ func CreateEVMGenesis(
 	genesisBlock0Timestamp := utils.TimeToNewUint64(time.Now())
 	precompiles := getPrecompiles(params, genesisBlock0Timestamp)
 
-	relayerAddress, _, err := relayer.GetRelayerKeyInfo(app)
+	_, relayerAddress, _, err := relayer.GetDefaultRelayerKeyInfo(app)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Why this should be merged

Fixes two bugs that need solution for new key transfer e2e at https://github.com/ava-labs/avalanche-cli/pull/2776:

- the relayer default key is not created when the l1 configuration uses a given genesis file. later on, the relayer deploy fails due to this
- foundry CLI installation fails when XDG_CONFIG_HOME is set, and this happens on CI

## How this works
- the relayer default key now is created on demand, every time it is needed, in this case, during blockchain deploy
- foundry CLI installation removes XDG_CONFIG_HOME environment var, so foundry is always installed where CLI expects (unless previously installed)

## How this was tested
CI - local executions of ictt deploy and blockchain deploy using 2776 as base

## How is this documented
