### PR TITLE
remove all previous blockchain conf on create --force

### DIFF
--- a/cmd/blockchaincmd/create.go
+++ b/cmd/blockchaincmd/create.go
@@ -223,6 +223,11 @@ func createBlockchainConfig(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("reward basis points cannot be zero")
 	}
 
+	// clean up all blockchain info to start over
+	if forceCreate {
+		_ = CallDeleteBlockchain(blockchainName)
+	}
+
 	// get vm kind
 	vmType, err := vm.PromptVMType(app, createFlags.useSubnetEvm, createFlags.useCustomVM)
 	if err != nil {
@@ -420,11 +425,6 @@ func createBlockchainConfig(cmd *cobra.Command, args []string) error {
 				}
 			}
 		}
-	}
-
-	// clean up all blockchain info to start over
-	if forceCreate {
-		_ = CallDeleteBlockchain(blockchainName)
 	}
 
 	if err = app.WriteGenesisFile(blockchainName, genesisBytes); err != nil {

--- a/cmd/blockchaincmd/create.go
+++ b/cmd/blockchaincmd/create.go
@@ -422,6 +422,11 @@ func createBlockchainConfig(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// clean up all blockchain info to start over
+	if forceCreate {
+		_ = CallDeleteBlockchain(blockchainName)
+	}
+
 	if err = app.WriteGenesisFile(blockchainName, genesisBytes); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Why this should be merged
Currently, when using --force to overwrite a blockchain conf, it may happen that secondary blockchain
conf is reused, such as subnet json, blockchain json, etc.

## How this works
This PR ensures a blockchain is removed when using create with --force arg

## How this was tested

## How is this documented
