### PR TITLE
add spec of staking key/cert/bls for new nodes on local cluster

### DIFF
--- a/cmd/blockchaincmd/convert.go
+++ b/cmd/blockchaincmd/convert.go
@@ -89,6 +89,9 @@ Sovereign L1s require bootstrap validators. avalanche blockchain convert command
 		"set the AVAX balance of each bootstrap validator that will be used for continuous fee on P-Chain",
 	)
 	cmd.Flags().IntVar(&numLocalNodes, "num-local-nodes", 0, "number of nodes to be created on local machine")
+	cmd.Flags().StringSliceVar(&stakingTLSKeyPaths, "staking-tls-key-path", []string{}, "path to provided staking tls key for node(s)")
+	cmd.Flags().StringSliceVar(&stakingCertKeyPaths, "staking-cert-key-path", []string{}, "path to provided staking cert key for node(s)")
+	cmd.Flags().StringSliceVar(&stakingSignerKeyPaths, "staking-signer-key-path", []string{}, "path to provided staking signer key for node(s)")
 	cmd.Flags().UintSliceVar(&httpPorts, "http-port", []uint{}, "http port for node(s)")
 	cmd.Flags().UintSliceVar(&stakingPorts, "staking-port", []uint{}, "staking port for node(s)")
 	cmd.Flags().StringVar(&changeOwnerAddress, "change-owner-address", "", "address that will receive change if node is no longer L1 validator")
@@ -120,6 +123,9 @@ func StartLocalMachine(
 	availableBalance uint64,
 	httpPorts []uint,
 	stakingPorts []uint,
+	stakingTLSKeyPaths []string,
+	stakingCertKeyPaths []string,
+	stakingSignerKeyPaths []string,
 ) (bool, error) {
 	var err error
 	if network.Kind == models.Local {
@@ -216,10 +222,30 @@ func StartLocalMachine(
 		if network.Kind == models.Mainnet {
 			globalNetworkFlags.UseMainnet = true
 		}
-		nodeSettingsLen := max(len(httpPorts), len(stakingPorts))
+		if len(stakingSignerKeyPaths) != len(stakingCertKeyPaths) || len(stakingSignerKeyPaths) != len(stakingTLSKeyPaths) {
+			return false, fmt.Errorf("staking key inputs must be for the same number of nodes")
+		}
+		nodeSettingsLen := max(len(stakingSignerKeyPaths), len(httpPorts), len(stakingPorts))
 		nodeSettings := make([]localnet.NodeSetting, nodeSettingsLen)
 		for i := range nodeSettingsLen {
 			nodeSetting := localnet.NodeSetting{}
+			if i < len(stakingSignerKeyPaths) {
+				stakingSignerKey, err := os.ReadFile(stakingSignerKeyPaths[i])
+				if err != nil {
+					return false, fmt.Errorf("could not read staking signer key at %s: %w", stakingSignerKeyPaths[i], err)
+				}
+				stakingCertKey, err := os.ReadFile(stakingCertKeyPaths[i])
+				if err != nil {
+					return false, fmt.Errorf("could not read staking cert key at %s: %w", stakingCertKeyPaths[i], err)
+				}
+				stakingTLSKey, err := os.ReadFile(stakingTLSKeyPaths[i])
+				if err != nil {
+					return false, fmt.Errorf("could not read staking TLS key at %s: %w", stakingTLSKeyPaths[i], err)
+				}
+				nodeSetting.StakingSignerKey = stakingSignerKey
+				nodeSetting.StakingCertKey = stakingCertKey
+				nodeSetting.StakingTLSKey = stakingTLSKey
+			}
 			if i < len(httpPorts) {
 				nodeSetting.HTTPPort = uint64(httpPorts[i])
 			}
@@ -660,6 +686,9 @@ func convertBlockchain(_ *cobra.Command, args []string) error {
 				availableBalance,
 				httpPorts,
 				stakingPorts,
+				stakingTLSKeyPaths,
+				stakingCertKeyPaths,
+				stakingSignerKeyPaths,
 			); err != nil {
 				return err
 			} else if cancel {

--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -71,6 +71,9 @@ var (
 	avagoBinaryPath                 string
 	numBootstrapValidators          int
 	numLocalNodes                   int
+	stakingTLSKeyPaths              []string
+	stakingCertKeyPaths             []string
+	stakingSignerKeyPaths           []string
 	httpPorts                       []uint
 	stakingPorts                    []uint
 	partialSync                     bool
@@ -198,6 +201,9 @@ so you can take your locally tested Blockchain and deploy it on Fuji or Mainnet.
 		"set the AVAX balance of each bootstrap validator that will be used for continuous fee on P-Chain",
 	)
 	cmd.Flags().IntVar(&numLocalNodes, "num-local-nodes", 0, "number of nodes to be created on local machine")
+	cmd.Flags().StringSliceVar(&stakingTLSKeyPaths, "staking-tls-key-path", []string{}, "path to provided staking tls key for node(s)")
+	cmd.Flags().StringSliceVar(&stakingCertKeyPaths, "staking-cert-key-path", []string{}, "path to provided staking cert key for node(s)")
+	cmd.Flags().StringSliceVar(&stakingSignerKeyPaths, "staking-signer-key-path", []string{}, "path to provided staking signer key for node(s)")
 	cmd.Flags().UintSliceVar(&httpPorts, "http-port", []uint{}, "http port for node(s)")
 	cmd.Flags().UintSliceVar(&stakingPorts, "staking-port", []uint{}, "staking port for node(s)")
 	cmd.Flags().StringVar(&changeOwnerAddress, "change-owner-address", "", "address that will receive change if node is no longer L1 validator")
@@ -596,6 +602,9 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 				availableBalance,
 				httpPorts,
 				stakingPorts,
+				stakingTLSKeyPaths,
+				stakingCertKeyPaths,
+				stakingSignerKeyPaths,
 			); err != nil {
 				return err
 			} else if cancel {


### PR DESCRIPTION
## Why this should be merged
Currently, on deploy and convert, no staking key/cert/bls can be specified, always obtaining fresh ids.
But a expected use case is to be able to specify info from a previous validator.
This is also pretty useful for testing, in order to repeat cluster node details.

## How this works
Adds flags to deploy/convert and use the values as appropriate on the lib calls.

## How this was tested
tests on local environment

## How is this documented
