### PR TITLE
set up flag so subnet confs dir is used

### DIFF
--- a/pkg/localnet/tmpnet.go
+++ b/pkg/localnet/tmpnet.go
@@ -567,9 +567,15 @@ func TmpNetSetSubnetConfig(
 	subnetID ids.ID,
 	subnetConfig []byte,
 ) error {
+	subnetConfigsDir := filepath.Join(network.Dir, "subnets")
+	for _, node := range network.Nodes {
+		node.Flags[config.SubnetConfigDirKey] = subnetConfigsDir
+		if err := node.Write(); err != nil {
+			return err
+		}
+	}
 	configPath := filepath.Join(
-		network.Dir,
-		"subnets",
+		subnetConfigsDir,
 		subnetID.String()+".json",
 	)
 	configDir := filepath.Dir(configPath)


### PR DESCRIPTION
## Why this should be merged
Currently, subnet confs are not loaded by the local cluster, even after setting up the blockchain configure command.

## How this works
A flag is missing to avalanchego knows where the files are. This PR sets up the flag.

## How this was tested
local network deploys

## How is this documented
