### PR TITLE
Sig agg Flag groups

### DIFF
--- a/cmd/blockchaincmd/add_validator.go
+++ b/cmd/blockchaincmd/add_validator.go
@@ -91,12 +91,12 @@ staking token. Both processes will issue a RegisterL1ValidatorTx on the P-Chain.
 
 This command currently only works on Blockchains deployed to either the Fuji
 Testnet or Mainnet.`,
-		RunE: addValidator,
-		Args: cobrautils.MaximumNArgs(1),
+		RunE:    addValidator,
+		PreRunE: cobrautils.MaximumNArgs(1),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, true, networkoptions.DefaultSupportedNetworkOptions)
 	flags.AddRPCFlagToCmd(cmd, app, &addValidatorFlags.RPC)
-	flags.AddSignatureAggregatorFlagsToCmd(cmd, &addValidatorFlags.SigAggFlags)
+	sigAggGroup := flags.AddSignatureAggregatorFlagsToCmd(cmd, &addValidatorFlags.SigAggFlags)
 	cmd.Flags().StringVarP(&keyName, "key", "k", "", "select the key to use [fuji/devnet only]")
 	cmd.Flags().Float64Var(
 		&balanceAVAX,
@@ -131,7 +131,7 @@ Testnet or Mainnet.`,
 	cmd.Flags().StringVar(&initiateTxHash, "initiate-tx-hash", "", "initiate tx is already issued, with the given hash")
 	cmd.Flags().Uint32Var(&httpPort, "http-port", 0, "http port for node")
 	cmd.Flags().Uint32Var(&stakingPort, "staking-port", 0, "staking port for node")
-
+	cmd.SetHelpFunc(flags.WithGroupedHelp([]flags.GroupedFlags{sigAggGroup}))
 	return cmd
 }
 

--- a/cmd/blockchaincmd/change_weight.go
+++ b/cmd/blockchaincmd/change_weight.go
@@ -54,12 +54,12 @@ func newChangeWeightCmd() *cobra.Command {
 		Long: `The blockchain changeWeight command changes the weight of a L1 Validator.
 
 The L1 has to be a Proof of Authority L1.`,
-		RunE: setWeight,
-		Args: cobrautils.ExactArgs(1),
+		RunE:    setWeight,
+		PreRunE: cobrautils.ExactArgs(1),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, true, networkoptions.DefaultSupportedNetworkOptions)
 	flags.AddRPCFlagToCmd(cmd, app, &changeWeightFlags.RPC)
-	flags.AddSignatureAggregatorFlagsToCmd(cmd, &changeWeightFlags.SigAggFlags)
+	sigAggGroup := flags.AddSignatureAggregatorFlagsToCmd(cmd, &changeWeightFlags.SigAggFlags)
 	cmd.Flags().StringVarP(&keyName, "key", "k", "", "select the key to use [fuji/devnet only]")
 	cmd.Flags().Uint64Var(&newWeight, "weight", 0, "set the new staking weight of the validator")
 	cmd.Flags().BoolVarP(&useEwoq, "ewoq", "e", false, "use ewoq key [fuji/devnet only]")
@@ -70,6 +70,7 @@ The L1 has to be a Proof of Authority L1.`,
 	cmd.Flags().BoolVar(&externalValidatorManagerOwner, "external-evm-signature", false, "set this value to true when signing validator manager tx outside of cli (for multisig or ledger)")
 	cmd.Flags().StringVar(&validatorManagerOwner, "validator-manager-owner", "", "force using this address to issue transactions to the validator manager")
 	cmd.Flags().StringVar(&initiateTxHash, "initiate-tx-hash", "", "initiate tx is already issued, with the given hash")
+	cmd.SetHelpFunc(flags.WithGroupedHelp([]flags.GroupedFlags{sigAggGroup}))
 	return cmd
 }
 

--- a/cmd/blockchaincmd/convert.go
+++ b/cmd/blockchaincmd/convert.go
@@ -66,10 +66,10 @@ Sovereign L1s require bootstrap validators. avalanche blockchain convert command
 - or using remote nodes (we require the node's Node-ID and BLS info)`,
 		RunE:              convertBlockchain,
 		PersistentPostRun: handlePostRun,
-		Args:              cobrautils.ExactArgs(1),
+		PreRunE:           cobrautils.ExactArgs(1),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, true, networkoptions.DefaultSupportedNetworkOptions)
-	flags.AddSignatureAggregatorFlagsToCmd(cmd, &convertFlags.SigAggFlags)
+	sigAggGroup := flags.AddSignatureAggregatorFlagsToCmd(cmd, &convertFlags.SigAggFlags)
 	cmd.Flags().StringVarP(&keyName, "key", "k", "", "select the key to use [fuji/devnet convert to l1 tx only]")
 	cmd.Flags().StringSliceVar(&subnetAuthKeys, "auth-keys", nil, "control keys that will be used to authenticate convert to L1 tx")
 	cmd.Flags().StringVar(&outputTxPath, "output-tx-path", "", "file path of the convert to L1 tx (for multi-sig)")
@@ -109,6 +109,7 @@ Sovereign L1s require bootstrap validators. avalanche blockchain convert command
 	cmd.Flags().Uint64Var(&createFlags.rewardBasisPoints, "reward-basis-points", 100, "(PoS only) reward basis points for PoS Reward Calculator")
 	cmd.Flags().StringVar(&validatorManagerAddress, "validator-manager-address", "", "validator manager address")
 	cmd.Flags().BoolVar(&doStrongInputChecks, "verify-input", true, "check for input confirmation")
+	cmd.SetHelpFunc(flags.WithGroupedHelp([]flags.GroupedFlags{sigAggGroup}))
 	return cmd
 }
 

--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"os"
 	"path/filepath"
 
@@ -126,17 +127,10 @@ redeploy the chain with fresh state. You can deploy the same Blockchain to multi
 so you can take your locally tested Blockchain and deploy it on Fuji or Mainnet.`,
 		RunE:              deployBlockchain,
 		PersistentPostRun: handlePostRun,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			requiredArgCount := 1
-			if len(args) != requiredArgCount {
-				_ = cmd.Help() // show full help with flag grouping
-				return utils.ErrWrongArgCount(requiredArgCount, len(args))
-			}
-			return nil
-		},
+		PreRunE:           cobrautils.ExactArgs(1),
 	}
 	networkGroup := networkoptions.GetNetworkFlagsGroup(cmd, &globalNetworkFlags, true, networkoptions.DefaultSupportedNetworkOptions)
-	flags.AddSignatureAggregatorFlagsToCmd(cmd, &deployFlags.SigAggFlags)
+	sigAggGroup := flags.AddSignatureAggregatorFlagsToCmd(cmd, &deployFlags.SigAggFlags)
 
 	cmd.Flags().StringVarP(&keyName, "key", "k", "", "select the key to use [fuji/devnet deploy only]")
 	cmd.Flags().StringVar(&outputTxPath, "output-tx-path", "", "file path of the blockchain creation tx")
@@ -231,7 +225,7 @@ so you can take your locally tested Blockchain and deploy it on Fuji or Mainnet.
 		set.Uint64Var(&poSWeightToValueFactor, "pos-weight-to-value-factor", 1, "weight to value factor")
 	})
 
-	cmd.SetHelpFunc(flags.WithGroupedHelp([]flags.GroupedFlags{networkGroup, bootstrapValidatorGroup, localMachineGroup, localNetworkGroup, nonSovGroup, icmGroup, posGroup}))
+	cmd.SetHelpFunc(flags.WithGroupedHelp([]flags.GroupedFlags{networkGroup, bootstrapValidatorGroup, localMachineGroup, localNetworkGroup, nonSovGroup, icmGroup, posGroup, sigAggGroup}))
 	return cmd
 }
 

--- a/cmd/blockchaincmd/remove_validator.go
+++ b/cmd/blockchaincmd/remove_validator.go
@@ -56,12 +56,12 @@ validating your deployed Blockchain.
 
 To remove the validator from the Subnet's allow list, provide the validator's unique NodeID. You can bypass
 these prompts by providing the values with flags.`,
-		RunE: removeValidator,
-		Args: cobrautils.ExactArgs(1),
+		RunE:    removeValidator,
+		PreRunE: cobrautils.ExactArgs(1),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &globalNetworkFlags, false, networkoptions.DefaultSupportedNetworkOptions)
 	flags.AddRPCFlagToCmd(cmd, app, &removeValidatorFlags.RPC)
-	flags.AddSignatureAggregatorFlagsToCmd(cmd, &removeValidatorFlags.SigAggFlags)
+	sigAggGroup := flags.AddSignatureAggregatorFlagsToCmd(cmd, &removeValidatorFlags.SigAggFlags)
 	cmd.Flags().StringVarP(&keyName, "key", "k", "", "select the key to use [fuji deploy only]")
 	cmd.Flags().StringSliceVar(&subnetAuthKeys, "auth-keys", nil, "(for non-SOV blockchain only) control keys that will be used to authenticate the removeValidator tx")
 	cmd.Flags().StringVar(&outputTxPath, "output-tx-path", "", "(for non-SOV blockchain only) file path of the removeValidator tx")
@@ -74,6 +74,7 @@ these prompts by providing the values with flags.`,
 	cmd.Flags().BoolVar(&externalValidatorManagerOwner, "external-evm-signature", false, "set this value to true when signing validator manager tx outside of cli (for multisig or ledger)")
 	cmd.Flags().StringVar(&validatorManagerOwner, "validator-manager-owner", "", "force using this address to issue transactions to the validator manager")
 	cmd.Flags().StringVar(&initiateTxHash, "initiate-tx-hash", "", "initiate tx is already issued, with the given hash")
+	cmd.SetHelpFunc(flags.WithGroupedHelp([]flags.GroupedFlags{sigAggGroup}))
 	return cmd
 }
 

--- a/cmd/contractcmd/init_validator_manager.go
+++ b/cmd/contractcmd/init_validator_manager.go
@@ -54,16 +54,16 @@ type ContractInitValidatorManagerFlags struct {
 // avalanche contract initValidatorManager
 func newInitValidatorManagerCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "initValidatorManager blockchainName",
-		Short: "Initializes Proof of Authority(PoA) or Proof of Stake(PoS) Validator Manager on a given Network and Blockchain",
-		Long:  "Initializes Proof of Authority(PoA) or Proof of Stake(PoS)Validator Manager contract on a Blockchain and sets up initial validator set on the Blockchain. For more info on Validator Manager, please head to https://github.com/ava-labs/icm-contracts/tree/main/contracts/validator-manager",
-		RunE:  initValidatorManager,
-		Args:  cobrautils.ExactArgs(1),
+		Use:     "initValidatorManager blockchainName",
+		Short:   "Initializes Proof of Authority(PoA) or Proof of Stake(PoS) Validator Manager on a given Network and Blockchain",
+		Long:    "Initializes Proof of Authority(PoA) or Proof of Stake(PoS)Validator Manager contract on a Blockchain and sets up initial validator set on the Blockchain. For more info on Validator Manager, please head to https://github.com/ava-labs/icm-contracts/tree/main/contracts/validator-manager",
+		RunE:    initValidatorManager,
+		PreRunE: cobrautils.ExactArgs(1),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &network, true, networkoptions.DefaultSupportedNetworkOptions)
 	privateKeyFlags.AddToCmd(cmd, "as contract deployer")
 	flags.AddRPCFlagToCmd(cmd, app, &initValidatorManagerFlags.RPC)
-	flags.AddSignatureAggregatorFlagsToCmd(cmd, &initValidatorManagerFlags.SigAggFlags)
+	sigAggGroup := flags.AddSignatureAggregatorFlagsToCmd(cmd, &initValidatorManagerFlags.SigAggFlags)
 
 	cmd.Flags().StringVar(&initPOSManagerFlags.rewardCalculatorAddress, "pos-reward-calculator-address", "", "(PoS only) initialize the ValidatorManager with reward calculator address")
 	cmd.Flags().Uint64Var(&initPOSManagerFlags.minimumStakeAmount, "pos-minimum-stake-amount", 1, "(PoS only) minimum stake amount")
@@ -72,6 +72,7 @@ func newInitValidatorManagerCmd() *cobra.Command {
 	cmd.Flags().Uint16Var(&initPOSManagerFlags.minimumDelegationFee, "pos-minimum-delegation-fee", 1, "(PoS only) minimum delegation fee")
 	cmd.Flags().Uint8Var(&initPOSManagerFlags.maximumStakeMultiplier, "pos-maximum-stake-multiplier", 1, "(PoS only )maximum stake multiplier")
 	cmd.Flags().Uint64Var(&initPOSManagerFlags.weightToValueFactor, "pos-weight-to-value-factor", 1, "(PoS only) weight to value factor")
+	cmd.SetHelpFunc(flags.WithGroupedHelp([]flags.GroupedFlags{sigAggGroup}))
 	return cmd
 }
 

--- a/cmd/nodecmd/local.go
+++ b/cmd/nodecmd/local.go
@@ -363,11 +363,11 @@ func newLocalValidateCmd() *cobra.Command {
 RPC URL of the L1. 
 
 This command can only be used to validate Proof of Stake L1.`,
-		Args: cobra.ExactArgs(1),
-		RunE: localValidate,
+		RunE:    localValidate,
+		PreRunE: cobra.ExactArgs(1),
 	}
 	flags.AddRPCFlagToCmd(cmd, app, &localValidateFlags.RPC)
-	flags.AddSignatureAggregatorFlagsToCmd(cmd, &localValidateFlags.SigAggFlags)
+	sigAggGroup := flags.AddSignatureAggregatorFlagsToCmd(cmd, &localValidateFlags.SigAggFlags)
 	cmd.Flags().StringVar(&blockchainName, "l1", "", "specify the blockchain the node is syncing with")
 	cmd.Flags().StringVar(&blockchainName, "blockchain", "", "specify the blockchain the node is syncing with")
 	cmd.Flags().Uint64Var(&stakeAmount, "stake-amount", 0, "amount of tokens to stake")
@@ -378,7 +378,7 @@ This command can only be used to validate Proof of Stake L1.`,
 	cmd.Flags().Uint64Var(&minimumStakeDuration, "minimum-stake-duration", constants.PoSL1MinimumStakeDurationSeconds, "minimum stake duration (in seconds)")
 	cmd.Flags().StringVar(&validatorManagerAddress, "validator-manager-address", "", "validator manager address")
 	cmd.Flags().BoolVar(&useACP99, "acp99", true, "use ACP99 contracts instead of v1.0.0 for validator managers")
-
+	cmd.SetHelpFunc(flags.WithGroupedHelp([]flags.GroupedFlags{sigAggGroup}))
 	return cmd
 }
 

--- a/pkg/cobrautils/cobra_utils.go
+++ b/pkg/cobrautils/cobra_utils.go
@@ -21,6 +21,21 @@ func (e UsageError) Error() string {
 	return fmt.Sprintf("Usage error: %s", e.err)
 }
 
+func ErrWrongArgCount(expected, got int) error {
+	return fmt.Errorf("requires %d arg(s), received %d args(s)", expected, got)
+}
+func ErrMaxArgCount(expected, got int) error {
+	return fmt.Errorf("max %d arg(s), received %d args(s)", expected, got)
+}
+
+func ErrMinArgCount(expected, got int) error {
+	return fmt.Errorf("min %d arg(s), received %d args(s)", expected, got)
+}
+
+func ErrRangeArgCount(expectedLow, expectedHigh, got int) error {
+	return fmt.Errorf("accepted number of arg(s) is %d to %d, received %d args(s)", expectedLow, expectedHigh, got)
+}
+
 func NewUsageError(cmd *cobra.Command, err error) UsageError {
 	return UsageError{
 		cmd: cmd,
@@ -30,45 +45,41 @@ func NewUsageError(cmd *cobra.Command, err error) UsageError {
 
 func ExactArgs(n int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
-		err := cobra.ExactArgs(n)(cmd, args)
-		if err != nil {
-			_ = cmd.Help()
-			err = NewUsageError(cmd, err)
+		if len(args) != n {
+			_ = cmd.Help() // show full help with flag grouping
+			return ErrWrongArgCount(n, len(args))
 		}
-		return err
+		return nil
 	}
 }
 
 func MaximumNArgs(n int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
-		err := cobra.MaximumNArgs(n)(cmd, args)
-		if err != nil {
-			_ = cmd.Help()
-			err = NewUsageError(cmd, err)
+		if len(args) > n {
+			_ = cmd.Help() // show full help with flag grouping
+			return ErrMaxArgCount(n, len(args))
 		}
-		return err
+		return nil
 	}
 }
 
 func MinimumNArgs(n int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
-		err := cobra.MinimumNArgs(n)(cmd, args)
-		if err != nil {
-			_ = cmd.Help()
-			err = NewUsageError(cmd, err)
+		if len(args) < n {
+			_ = cmd.Help() // show full help with flag grouping
+			return ErrMinArgCount(n, len(args))
 		}
-		return err
+		return nil
 	}
 }
 
 func RangeArgs(min int, max int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
-		err := cobra.RangeArgs(min, max)(cmd, args)
-		if err != nil {
-			_ = cmd.Help()
-			err = NewUsageError(cmd, err)
+		if len(args) < min || len(args) > max {
+			_ = cmd.Help() // show full help with flag grouping
+			return ErrRangeArgCount(min, max, len(args))
 		}
-		return err
+		return nil
 	}
 }
 

--- a/pkg/cobrautils/cobra_utils.go
+++ b/pkg/cobrautils/cobra_utils.go
@@ -32,6 +32,7 @@ func ExactArgs(n int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		err := cobra.ExactArgs(n)(cmd, args)
 		if err != nil {
+			_ = cmd.Help()
 			err = NewUsageError(cmd, err)
 		}
 		return err
@@ -42,6 +43,7 @@ func MaximumNArgs(n int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		err := cobra.MaximumNArgs(n)(cmd, args)
 		if err != nil {
+			_ = cmd.Help()
 			err = NewUsageError(cmd, err)
 		}
 		return err
@@ -52,6 +54,7 @@ func MinimumNArgs(n int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		err := cobra.MinimumNArgs(n)(cmd, args)
 		if err != nil {
+			_ = cmd.Help()
 			err = NewUsageError(cmd, err)
 		}
 		return err
@@ -62,6 +65,7 @@ func RangeArgs(min int, max int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		err := cobra.RangeArgs(min, max)(cmd, args)
 		if err != nil {
+			_ = cmd.Help()
 			err = NewUsageError(cmd, err)
 		}
 		return err

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -41,10 +41,6 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-func ErrWrongArgCount(expected, got int) error {
-	return fmt.Errorf("requires %d arg(s), got %d", expected, got)
-}
-
 func SetupRealtimeCLIOutput(
 	cmd *exec.Cmd,
 	redirectStdout bool,


### PR DESCRIPTION
```
AVL-7H2W7V:avalanche-cli raymondsukanto$ ./bin/avalanche blockchain deploy
Usage:
  avalanche blockchain deploy [blockchainName] [flags]

Flags:
      --aggregator-log-level string    log level to use with signature aggregator (default "Debug")
      --aggregator-log-to-stdout       use stdout for signature aggregator logs
      --auth-keys strings              control keys that will be used to authenticate chain creation
      --avalanchego-path string        use this avalanchego binary path
      --avalanchego-version string     use this version of avalanchego (ex: v1.17.12) (default "latest")
      --balance float                  set the AVAX balance of each bootstrap validator that will be used for continuous fee on P-Chain (default 0.1)
      --bootstrap-endpoints strings    take validator node info from the given endpoints
      --bootstrap-filepath string      JSON file path that provides details about bootstrap validators, leave Node-ID and BLS values empty if using --generate-node-id=true
      --change-owner-address string    address that will receive change if node is no longer L1 validator
      --control-keys strings           addresses that may make blockchain changes
      --convert-only                   avoid node track, restart and poa manager setup
  -e, --ewoq                           use ewoq key [local/devnet deploy only]
      --generate-node-id               whether to create new node id for bootstrap validators (Node-ID and BLS values in bootstrap JSON file will be overridden if --bootstrap-filepath flag is used)
  -h, --help                           help for deploy
      --http-port uints                http port for node(s) (default [])
  -k, --key string                     select the key to use [fuji/devnet deploy only]
  -g, --ledger                         use ledger instead of key (always true on mainnet, defaults to false on fuji/devnet)
      --ledger-addrs strings           use the given ledger addresses
      --mainnet-chain-id uint32        use different ChainID for mainnet deployment
      --num-bootstrap-validators int   (only if --generate-node-id is true) number of bootstrap validators to set up in sovereign L1 validator)
      --num-local-nodes int            number of nodes to be created on local machine
      --num-nodes uint32               number of nodes to be created on local network deploy (default 2)
      --output-tx-path string          file path of the blockchain creation tx
      --partial-sync                   set primary network partial sync for new validators (default true)
  -s, --same-control-key               use the fee-paying key as control key
      --staking-port uints             staking port for node(s) (default [])
  -u, --subnet-id string               do not create a subnet, deploy the blockchain into the given subnet id
      --subnet-only                    only create a subnet
      --threshold uint32               required number of control key signatures to make blockchain changes
      --use-local-machine              use local machine as a blockchain validator

Global Flags:
      --config string       config file (default is $HOME/.avalanche-cli/config.json)
      --log-level string    log level for the application (default "ERROR")
      --skip-update-check   skip check for new versions

Network Flags (Select One):
  --cluster string   operate on the given cluster
  --devnet           operate on a devnet network
  --endpoint string  use the given endpoint for network operations
  --fuji             operate on fuji (alias to `testnet`)
  --local            operate on a local network
  --mainnet          operate on mainnet
  --testnet          operate on testnet (alias to `fuji`)

ICM Flags:
  (hidden) Use --show-icm-flags to show these options

Proof Of Stake Flags:
  (hidden) Use --show-pos-flags to show these options
Usage:
  avalanche blockchain deploy [blockchainName] [flags]

Flags:
      --aggregator-log-level string    log level to use with signature aggregator (default "Debug")
      --aggregator-log-to-stdout       use stdout for signature aggregator logs
      --auth-keys strings              control keys that will be used to authenticate chain creation
      --avalanchego-path string        use this avalanchego binary path
      --avalanchego-version string     use this version of avalanchego (ex: v1.17.12) (default "latest")
      --balance float                  set the AVAX balance of each bootstrap validator that will be used for continuous fee on P-Chain (default 0.1)
      --bootstrap-endpoints strings    take validator node info from the given endpoints
      --bootstrap-filepath string      JSON file path that provides details about bootstrap validators, leave Node-ID and BLS values empty if using --generate-node-id=true
      --change-owner-address string    address that will receive change if node is no longer L1 validator
      --control-keys strings           addresses that may make blockchain changes
      --convert-only                   avoid node track, restart and poa manager setup
  -e, --ewoq                           use ewoq key [local/devnet deploy only]
      --generate-node-id               whether to create new node id for bootstrap validators (Node-ID and BLS values in bootstrap JSON file will be overridden if --bootstrap-filepath flag is used)
  -h, --help                           help for deploy
      --http-port uints                http port for node(s) (default [])
  -k, --key string                     select the key to use [fuji/devnet deploy only]
  -g, --ledger                         use ledger instead of key (always true on mainnet, defaults to false on fuji/devnet)
      --ledger-addrs strings           use the given ledger addresses
      --mainnet-chain-id uint32        use different ChainID for mainnet deployment
      --num-bootstrap-validators int   (only if --generate-node-id is true) number of bootstrap validators to set up in sovereign L1 validator)
      --num-local-nodes int            number of nodes to be created on local machine
      --num-nodes uint32               number of nodes to be created on local network deploy (default 2)
      --output-tx-path string          file path of the blockchain creation tx
      --partial-sync                   set primary network partial sync for new validators (default true)
  -s, --same-control-key               use the fee-paying key as control key
      --staking-port uints             staking port for node(s) (default [])
  -u, --subnet-id string               do not create a subnet, deploy the blockchain into the given subnet id
      --subnet-only                    only create a subnet
      --threshold uint32               required number of control key signatures to make blockchain changes
      --use-local-machine              use local machine as a blockchain validator

Global Flags:
      --config string       config file (default is $HOME/.avalanche-cli/config.json)
      --log-level string    log level for the application (default "ERROR")
      --skip-update-check   skip check for new versions


Usage error: accepts 1 arg(s), received 0
```