### PR TITLE
fix icm deploy message to indicate automatic c-chain deploy happens on local network

### DIFF
--- a/cmd/commands.md
+++ b/cmd/commands.md
@@ -1294,6 +1294,8 @@ avalanche icm [subcommand] [flags]
 
 Deploys ICM Messenger and Registry into a given L1.
 
+For Local Networks, it also deploys into C-Chain.
+
 **Usage:**
 ```bash
 avalanche icm deploy [subcommand] [flags]

--- a/cmd/interchaincmd/messengercmd/deploy.go
+++ b/cmd/interchaincmd/messengercmd/deploy.go
@@ -49,7 +49,9 @@ func NewDeployCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deploy",
 		Short: "Deploys ICM Messenger and Registry into a given L1",
-		Long:  `Deploys ICM Messenger and Registry into a given L1.`,
+		Long:  `Deploys ICM Messenger and Registry into a given L1.
+
+For Local Networks, it also deploys into C-Chain.`,
 		RunE:  deploy,
 		Args:  cobrautils.ExactArgs(0),
 	}

--- a/cmd/interchaincmd/messengercmd/deploy.go
+++ b/cmd/interchaincmd/messengercmd/deploy.go
@@ -49,11 +49,11 @@ func NewDeployCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deploy",
 		Short: "Deploys ICM Messenger and Registry into a given L1",
-		Long:  `Deploys ICM Messenger and Registry into a given L1.
+		Long: `Deploys ICM Messenger and Registry into a given L1.
 
 For Local Networks, it also deploys into C-Chain.`,
-		RunE:  deploy,
-		Args:  cobrautils.ExactArgs(0),
+		RunE: deploy,
+		Args: cobrautils.ExactArgs(0),
 	}
 	networkoptions.AddNetworkFlagsToCmd(cmd, &deployFlags.Network, true, networkoptions.DefaultSupportedNetworkOptions)
 	deployFlags.PrivateKeyFlags.AddToCmd(cmd, "to fund ICM deploy")


### PR DESCRIPTION
## Why this should be merged
Makes it clear of automatic stuff happening in the background, otherwise unnoticed

## How this works

## How this was tested

## How is this documented
