### PR TITLE
fix relayer logs command

### DIFF
--- a/cmd/interchaincmd/relayercmd/logs.go
+++ b/cmd/interchaincmd/relayercmd/logs.go
@@ -103,7 +103,7 @@ func logs(_ *cobra.Command, _ []string) error {
 			logMap := map[string]interface{}{}
 			err := json.Unmarshal([]byte(logLine), &logMap)
 			if err != nil {
-				return err
+				continue
 			}
 			levelEmoji := ""
 			levelStr, b := logMap["level"].(string)


### PR DESCRIPTION
## Why this should be merged
currently the command fails because it assumes all log lines are json encoded, which is no more the case
as the relayer now logs a non json header

## How this works

## How this was tested

## How is this documented
