### PR TITLE
Update node create CI avago version

### DIFF
--- a/tests/e2e/testcases/node/create/suite.go
+++ b/tests/e2e/testcases/node/create/suite.go
@@ -152,7 +152,6 @@ var _ = ginkgo.Describe("[Node create]", func() {
 	ginkgo.It("can upgrade the nodes", func() {
 		output := commands.NodeUpgrade()
 		fmt.Println(output)
-		gomega.Expect(output).To(gomega.ContainSubstring("Upgrading Avalanche Go"))
 		latestAvagoVersion := commands.GetLatestAvagoVersionFromGithub()
 		avalanchegoVersion := commands.NodeSSH(constants.E2EClusterName, "docker ps --no-trunc")
 		gomega.Expect(avalanchegoVersion).To(gomega.ContainSubstring("avaplatform/avalanchego:" + latestAvagoVersion))

--- a/tests/e2e/testcases/node/create/suite.go
+++ b/tests/e2e/testcases/node/create/suite.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	avalanchegoVersion = "v1.11.5"
+	avalanchegoVersion = "v1.13.0"
 	network            = "fuji"
 	networkCapitalized = "Fuji"
 	numNodes           = 1

--- a/tests/e2e/testcases/node/devnet/suite.go
+++ b/tests/e2e/testcases/node/devnet/suite.go
@@ -30,7 +30,7 @@ var (
 const (
 	NumNodes           = 1
 	NumAPINodes        = 1
-	avalanchegoVersion = "v1.11.5"
+	avalanchegoVersion = "v1.13.0"
 )
 
 var _ = ginkgo.Describe("[Node devnet]", func() {


### PR DESCRIPTION
````
[Node create] can create a node
/home/runner/work/avalanche-cli/avalanche-cli/tests/e2e/testcases/node/create/suite.go:42
About to run: ./bin/avalanche node create e2e --use-static-ip=false --custom-avalanchego-version=v1.11.5 --enable-monitoring=false --region=local --num-validators=1 --fuji --node-type=docker
---------------->

Error: minimum version of avalanchego that is supported by CLI is v1.13.0-fuji, current version provided is v1.11.5

````