### PR TITLE
Check MacOS arch so the arm64 package would not be used for x86-64

### DIFF
--- a/pkg/binutils/github.go
+++ b/pkg/binutils/github.go
@@ -14,6 +14,8 @@ const (
 	darwin  = "darwin"
 	windows = "windows"
 
+	arch_arm64 = "arm64"
+
 	zipExtension = "zip"
 	tarExtension = "tar.gz"
 )
@@ -59,6 +61,10 @@ func (avalancheGoDownloader) GetDownloadURL(version string, installer Installer)
 		)
 		ext = tarExtension
 	case darwin:
+		if goarch != arch_arm64 {
+			// no pre-built package for MacOS x86_64
+			return "", "", fmt.Errorf("No pre-built avalanche package for MacOS %s, you may need to build it by yourself", goarch)
+		}
 		avalanchegoURL = fmt.Sprintf(
 			"https://github.com/%s/%s/releases/download/%s/avalanchego-macos-%s.zip",
 			constants.AvaLabsOrg,

--- a/pkg/binutils/github_test.go
+++ b/pkg/binutils/github_test.go
@@ -47,6 +47,14 @@ func TestGetDownloadURL_AvalancheGo(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			version:     "v1.18.5",
+			goarch:      "x86_64",
+			goos:        "darwin",
+			expectedURL: "",
+			expectedExt: "",
+			expectedErr: errors.New("No pre-built avalanche package for MacOS x86_64, you may need to build it by yourself"),
+		},
+		{
 			version:     "v2.1.4",
 			goarch:      "amd64",
 			goos:        "windows",

--- a/pkg/binutils/release_test.go
+++ b/pkg/binutils/release_test.go
@@ -48,7 +48,7 @@ func Test_installAvalancheGoWithVersion_Zip(t *testing.T) {
 	app := setupInstallDir(require)
 
 	mockInstaller := &mocks.Installer{}
-	mockInstaller.On("GetArch").Return("amd64", "darwin")
+	mockInstaller.On("GetArch").Return("arm64", "darwin")
 
 	githubDownloader := NewAvagoDownloader()
 
@@ -104,7 +104,7 @@ func Test_installAvalancheGoWithVersion_MultipleCoinstalls(t *testing.T) {
 	app := setupInstallDir(require)
 
 	mockInstaller := &mocks.Installer{}
-	mockInstaller.On("GetArch").Return("amd64", "darwin")
+	mockInstaller.On("GetArch").Return("arm64", "darwin")
 
 	downloader := NewAvagoDownloader()
 	url1, _, err := downloader.GetDownloadURL(version1, mockInstaller)

--- a/pkg/ssh/installer.go
+++ b/pkg/ssh/installer.go
@@ -26,5 +26,11 @@ func (h *HostInstaller) GetArch() (string, string) {
 	if err != nil {
 		return "", ""
 	}
+	if string(goOSBytes) == "darwin" {
+		goArhBytes, err = h.Host.Command("uname -m", nil, constants.SSHScriptTimeout)
+		if err != nil {
+			return "", ""
+		}
+	}
 	return strings.TrimSpace(string(goArhBytes)), strings.TrimSpace(strings.ToLower(string(goOSBytes)))
 }


### PR DESCRIPTION
My MacOS is x86-64, and when I tried to run "avalanche network start", I got an error like this:

```
avalanchego-v1.13.0 installation successful
AvalancheGo path: /Users/calvin/.avalanche-cli/bin/avalanchego/avalanchego-v1.13.0/avalanchego
Booting Network. Wait until healthy...
Error: fork/exec /Users/calvin/.avalanche-cli/bin/avalanchego/avalanchego-v1.13.0/avalanchego: bad CPU type in executable
```

Then I found out that avalanche didn't provide pre-built package for MacOS x86-64 (only for MacOS arm64), but in source code it checked OS type only without checking for arch type.

This is the fix and accordingly added/fixed test cases.