### PR TITLE
add prompts and tables to main log

### DIFF
--- a/cmd/blockchaincmd/list.go
+++ b/cmd/blockchaincmd/list.go
@@ -3,6 +3,7 @@
 package blockchaincmd
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"sort"
@@ -14,7 +15,9 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
+	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanchego/ids"
+
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
@@ -55,7 +58,8 @@ func listBlockchains(cmd *cobra.Command, args []string) error {
 		return listDeployInfo(cmd, args)
 	}
 	header := []string{"subnet", "chain", "chainID", "vmID", "type", "vm version", "from repo"}
-	table := tablewriter.NewWriter(os.Stdout)
+	var tableBuf bytes.Buffer
+	table := tablewriter.NewWriter(&tableBuf)
 	table.SetHeader(header)
 	table.SetAutoMergeCellsByColumnIndex([]int{0})
 	table.SetAutoMergeCells(true)
@@ -103,6 +107,7 @@ func listBlockchains(cmd *cobra.Command, args []string) error {
 		table.Append(row)
 	}
 	table.Render()
+	ux.Logger.Print(tableBuf.String())
 	return nil
 }
 
@@ -140,7 +145,8 @@ func getSidecars(app *application.Avalanche) ([]*models.Sidecar, error) {
 
 func listDeployInfo(*cobra.Command, []string) error {
 	header := []string{"subnet", "chain", "vm ID", "Local Network", "Fuji (testnet)", "Mainnet"}
-	table := tablewriter.NewWriter(os.Stdout)
+	var tableBuf bytes.Buffer
+	table := tablewriter.NewWriter(&tableBuf)
 	table.SetHeader(header)
 	table.SetAutoMergeCellsByColumnIndex([]int{0, 1, 2, 3, 4})
 	table.SetAutoMergeCells(true)
@@ -228,6 +234,7 @@ func listDeployInfo(*cobra.Command, []string) error {
 		table.Append(row)
 	}
 	table.Render()
+	ux.Logger.Print(tableBuf.String())
 
 	return nil
 }

--- a/cmd/blockchaincmd/stats.go
+++ b/cmd/blockchaincmd/stats.go
@@ -3,10 +3,10 @@
 package blockchaincmd
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"time"
 
@@ -70,7 +70,8 @@ func stats(_ *cobra.Command, args []string) error {
 		return errors.New("failed to create a client to an API endpoint")
 	}
 
-	table := tablewriter.NewWriter(os.Stdout)
+	var tableBuf bytes.Buffer
+	table := tablewriter.NewWriter(&tableBuf)
 	rows, err := buildCurrentValidatorStats(pClient, infoClient, table, subnetID)
 	if err != nil {
 		return err
@@ -79,6 +80,7 @@ func stats(_ *cobra.Command, args []string) error {
 		table.Append(row)
 	}
 	table.Render()
+	ux.Logger.Print(tableBuf.String())
 
 	return nil
 }

--- a/cmd/blockchaincmd/validators.go
+++ b/cmd/blockchaincmd/validators.go
@@ -4,8 +4,8 @@
 package blockchaincmd
 
 import (
+	"bytes"
 	"errors"
-	"os"
 	"strconv"
 	"time"
 
@@ -13,9 +13,11 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/networkoptions"
 	"github.com/ava-labs/avalanche-cli/pkg/subnet"
+	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	validatorsdk "github.com/ava-labs/avalanche-cli/sdk/validator"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
+
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
@@ -73,7 +75,8 @@ func printValidators(_ *cobra.Command, args []string) error {
 
 func printValidatorsFromList(network models.Network, subnetID ids.ID, validators []platformvm.ClientPermissionlessValidator) error {
 	header := []string{"NodeID", "Weight", "Delegator Weight", "Start Time", "End Time", "Type"}
-	table := tablewriter.NewWriter(os.Stdout)
+	var tableBuf bytes.Buffer
+	table := tablewriter.NewWriter(&tableBuf)
 	table.SetHeader(header)
 	table.SetRowLine(true)
 
@@ -103,6 +106,7 @@ func printValidatorsFromList(network models.Network, subnetID ids.ID, validators
 	}
 
 	table.Render()
+	ux.Logger.Print(tableBuf.String())
 
 	return nil
 }

--- a/cmd/interchaincmd/relayercmd/configList.go
+++ b/cmd/interchaincmd/relayercmd/configList.go
@@ -3,8 +3,8 @@
 package relayercmd
 
 import (
+	"bytes"
 	"fmt"
-	"os"
 
 	"github.com/ava-labs/avalanche-cli/pkg/contract"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
@@ -46,7 +46,8 @@ const (
 )
 
 func preview(configSpec ConfigSpec) {
-	table := tablewriter.NewWriter(os.Stdout)
+	var tableBuf bytes.Buffer
+	table := tablewriter.NewWriter(&tableBuf)
 	table.SetRowLine(true)
 	table.SetAutoMergeCellsByColumnIndex([]int{0})
 	if len(configSpec.sources) > 0 {
@@ -60,7 +61,8 @@ func preview(configSpec ConfigSpec) {
 		}
 	}
 	table.Render()
-	fmt.Println()
+	ux.Logger.Print(tableBuf.String())
+	ux.Logger.PrintToUser("")
 }
 
 func addBoth(network models.Network, configSpec ConfigSpec, chainSpec contract.ChainSpec, defaultKey string) (ConfigSpec, error) {

--- a/cmd/keycmd/list.go
+++ b/cmd/keycmd/list.go
@@ -3,9 +3,9 @@
 package keycmd
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
-	"os"
 
 	"github.com/ava-labs/avalanche-cli/cmd/blockchaincmd"
 	"github.com/ava-labs/avalanche-cli/pkg/contract"
@@ -620,7 +620,8 @@ func getEvmBasedChainAddrInfo(
 
 func printAddrInfos(addrInfos []addressInfo) {
 	header := []string{"Kind", "Name", "Subnet", "Address", "Token", "Balance", "Network"}
-	table := tablewriter.NewWriter(os.Stdout)
+	var tableBuf bytes.Buffer
+	table := tablewriter.NewWriter(&tableBuf)
 	table.SetHeader(header)
 	table.SetRowLine(true)
 	table.SetAutoMergeCellsByColumnIndex([]int{0, 1, 2})
@@ -636,6 +637,7 @@ func printAddrInfos(addrInfos []addressInfo) {
 		})
 	}
 	table.Render()
+	ux.Logger.Print(tableBuf.String())
 }
 
 func getCChainBalanceStr(cClient ethclient.Client, addrStr string) (string, error) {

--- a/cmd/nodecmd/status.go
+++ b/cmd/nodecmd/status.go
@@ -3,8 +3,8 @@
 package nodecmd
 
 import (
+	"bytes"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 
@@ -263,7 +263,8 @@ func printOutput(
 	if blockchainName != "" {
 		header = append(header, "Subnet "+blockchainName)
 	}
-	table := tablewriter.NewWriter(os.Stdout)
+	var tableBuf bytes.Buffer
+	table := tablewriter.NewWriter(&tableBuf)
 	table.SetHeader(header)
 	table.SetRowLine(true)
 	for i, cloudID := range cloudIDs {
@@ -310,6 +311,7 @@ func printOutput(
 		table.Append(row)
 	}
 	table.Render()
+	ux.Logger.Print(tableBuf.String())
 }
 
 func removeColors(s string) string {

--- a/cmd/nodecmd/whitelist.go
+++ b/cmd/nodecmd/whitelist.go
@@ -17,10 +17,12 @@ import (
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
+	"github.com/ava-labs/avalanche-cli/pkg/prompts"
 	"github.com/ava-labs/avalanche-cli/pkg/ssh"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
 	"github.com/ava-labs/avalanchego/utils/logging"
+
 	"github.com/pingcap/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
@@ -87,7 +89,7 @@ func whitelist(_ *cobra.Command, args []string) error {
 	}
 	if userIPAddress == "" && userPubKey == "" {
 		// prompt for ssh key
-		userPubKey, err = utils.ReadLongString("Enter SSH public key to whitelist (leave empty to skip):\n")
+		userPubKey, err = prompts.PromptLongString("Enter SSH public key to whitelist (leave empty to skip):\n")
 		if err != nil {
 			return err
 		}

--- a/cmd/primarycmd/describe.go
+++ b/cmd/primarycmd/describe.go
@@ -3,10 +3,10 @@
 package primarycmd
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"math/big"
-	"os"
 	"strings"
 
 	"github.com/ava-labs/avalanche-cli/pkg/cobrautils"
@@ -113,7 +113,8 @@ func describe(_ *cobra.Command, _ []string) error {
 	}
 	balance = balance.Div(balance, big.NewInt(int64(units.Avax)))
 	balanceStr := fmt.Sprintf("%.9f", float64(balance.Uint64())/float64(units.Avax))
-	table := tablewriter.NewWriter(os.Stdout)
+	var tableBuf bytes.Buffer
+	table := tablewriter.NewWriter(&tableBuf)
 	header := []string{"Parameter", "Value"}
 	table.SetHeader(header)
 	table.SetRowLine(true)
@@ -141,5 +142,6 @@ func describe(_ *cobra.Command, _ []string) error {
 		table.Append([]string{"ICM Registry Address", icmRegistryAddress})
 	}
 	table.Render()
+	ux.Logger.Print(tableBuf.String())
 	return nil
 }

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -3,10 +3,12 @@
 package prompts
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"math/big"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -208,6 +210,7 @@ func CaptureListDecision[T comparable](
 
 func (*realPrompter) CaptureDuration(promptStr string) (time.Duration, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: validateDuration,
 	}
@@ -222,6 +225,7 @@ func (*realPrompter) CaptureDuration(promptStr string) (time.Duration, error) {
 
 func (*realPrompter) CaptureFujiDuration(promptStr string) (time.Duration, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: validateFujiStakingDuration,
 	}
@@ -236,6 +240,7 @@ func (*realPrompter) CaptureFujiDuration(promptStr string) (time.Duration, error
 
 func (*realPrompter) CaptureMainnetDuration(promptStr string) (time.Duration, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: validateMainnetStakingDuration,
 	}
@@ -250,6 +255,7 @@ func (*realPrompter) CaptureMainnetDuration(promptStr string) (time.Duration, er
 
 func (*realPrompter) CaptureMainnetL1StakingDuration(promptStr string) (time.Duration, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: validateMainnetL1StakingDuration,
 	}
@@ -264,6 +270,7 @@ func (*realPrompter) CaptureMainnetL1StakingDuration(promptStr string) (time.Dur
 
 func (*realPrompter) CaptureDate(promptStr string) (time.Time, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: validateTime,
 	}
@@ -278,6 +285,7 @@ func (*realPrompter) CaptureDate(promptStr string) (time.Time, error) {
 
 func (*realPrompter) CaptureID(promptStr string) (ids.ID, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: validateID,
 	}
@@ -291,6 +299,7 @@ func (*realPrompter) CaptureID(promptStr string) (ids.ID, error) {
 
 func (*realPrompter) CaptureNodeID(promptStr string) (ids.NodeID, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: ValidateNodeID,
 	}
@@ -309,6 +318,7 @@ func (*realPrompter) CaptureValidatorBalance(
 	minBalance float64,
 ) (float64, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: validateValidatorBalanceFunc(availableBalance, minBalance),
 	}
@@ -327,7 +337,8 @@ func (*realPrompter) CaptureValidatorBalance(
 
 func (*realPrompter) CaptureWeight(promptStr string, validator func(uint64) error) (uint64, error) {
 	prompt := promptui.Prompt{
-		Label: promptStr,
+		Stdout: ux.Logger,
+		Label:  promptStr,
 		Validate: func(input string) error {
 			if err := validateWeight(input); err != nil {
 				return err
@@ -350,7 +361,8 @@ func (*realPrompter) CaptureWeight(promptStr string, validator func(uint64) erro
 
 func (*realPrompter) CaptureInt(promptStr string, validator func(int) error) (int, error) {
 	prompt := promptui.Prompt{
-		Label: promptStr,
+		Stdout: ux.Logger,
+		Label:  promptStr,
 		Validate: func(input string) error {
 			val, err := strconv.Atoi(input)
 			if err != nil {
@@ -372,7 +384,8 @@ func (*realPrompter) CaptureInt(promptStr string, validator func(int) error) (in
 
 func (*realPrompter) CaptureUint8(promptStr string) (uint8, error) {
 	prompt := promptui.Prompt{
-		Label: promptStr,
+		Stdout: ux.Logger,
+		Label:  promptStr,
 		Validate: func(input string) error {
 			_, err := strconv.ParseUint(input, 0, 8)
 			if err != nil {
@@ -394,7 +407,8 @@ func (*realPrompter) CaptureUint8(promptStr string) (uint8, error) {
 
 func (*realPrompter) CaptureUint16(promptStr string) (uint16, error) {
 	prompt := promptui.Prompt{
-		Label: promptStr,
+		Stdout: ux.Logger,
+		Label:  promptStr,
 		Validate: func(input string) error {
 			_, err := strconv.ParseUint(input, 0, 16)
 			if err != nil {
@@ -416,7 +430,8 @@ func (*realPrompter) CaptureUint16(promptStr string) (uint16, error) {
 
 func (*realPrompter) CaptureUint32(promptStr string) (uint32, error) {
 	prompt := promptui.Prompt{
-		Label: promptStr,
+		Stdout: ux.Logger,
+		Label:  promptStr,
 		Validate: func(input string) error {
 			_, err := strconv.ParseUint(input, 0, 32)
 			if err != nil {
@@ -438,6 +453,7 @@ func (*realPrompter) CaptureUint32(promptStr string) (uint32, error) {
 
 func (*realPrompter) CaptureUint64(promptStr string) (uint64, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: validateBiggerThanZero,
 	}
@@ -451,7 +467,8 @@ func (*realPrompter) CaptureUint64(promptStr string) (uint64, error) {
 
 func (*realPrompter) CaptureFloat(promptStr string, validator func(float64) error) (float64, error) {
 	prompt := promptui.Prompt{
-		Label: promptStr,
+		Stdout: ux.Logger,
+		Label:  promptStr,
 		Validate: func(input string) error {
 			val, err := strconv.ParseFloat(input, 64)
 			if err != nil {
@@ -470,7 +487,8 @@ func (*realPrompter) CaptureFloat(promptStr string, validator func(float64) erro
 
 func (*realPrompter) CapturePositiveInt(promptStr string, comparators []Comparator) (int, error) {
 	prompt := promptui.Prompt{
-		Label: promptStr,
+		Stdout: ux.Logger,
+		Label:  promptStr,
 		Validate: func(input string) error {
 			val, err := strconv.Atoi(input)
 			if err != nil {
@@ -497,7 +515,8 @@ func (*realPrompter) CapturePositiveInt(promptStr string, comparators []Comparat
 
 func (*realPrompter) CaptureUint64Compare(promptStr string, comparators []Comparator) (uint64, error) {
 	prompt := promptui.Prompt{
-		Label: promptStr,
+		Stdout: ux.Logger,
+		Label:  promptStr,
 		Validate: func(input string) error {
 			val, err := strconv.ParseUint(input, 0, 64)
 			if err != nil {
@@ -522,6 +541,7 @@ func (*realPrompter) CaptureUint64Compare(promptStr string, comparators []Compar
 
 func (*realPrompter) CapturePositiveBigInt(promptStr string) (*big.Int, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: validatePositiveBigInt,
 	}
@@ -541,6 +561,7 @@ func (*realPrompter) CapturePositiveBigInt(promptStr string) (*big.Int, error) {
 
 func (*realPrompter) CapturePChainAddress(promptStr string, network models.Network) (string, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: getPChainValidationFunc(network),
 	}
@@ -550,6 +571,7 @@ func (*realPrompter) CapturePChainAddress(promptStr string, network models.Netwo
 
 func (*realPrompter) CaptureXChainAddress(promptStr string, network models.Network) (string, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: getXChainValidationFunc(network),
 	}
@@ -559,6 +581,7 @@ func (*realPrompter) CaptureXChainAddress(promptStr string, network models.Netwo
 
 func (*realPrompter) CaptureAddress(promptStr string) (common.Address, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: ValidateAddress,
 	}
@@ -577,7 +600,7 @@ func (*realPrompter) CaptureAddresses(promptStr string) ([]common.Address, error
 	validated := false
 	for !validated {
 		var err error
-		addressesStr, err = utils.ReadLongString(promptui.IconGood + " " + promptStr + " ")
+		addressesStr, err = PromptLongString(promptui.IconGood + " " + promptStr + " ")
 		if err != nil {
 			return nil, err
 		}
@@ -598,6 +621,7 @@ func (*realPrompter) CaptureAddresses(promptStr string) ([]common.Address, error
 
 func (*realPrompter) CaptureExistingFilepath(promptStr string) (string, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: validateExistingFilepath,
 	}
@@ -613,6 +637,7 @@ func (*realPrompter) CaptureExistingFilepath(promptStr string) (string, error) {
 
 func (*realPrompter) CaptureNewFilepath(promptStr string) (string, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: validateNewFilepath,
 	}
@@ -627,8 +652,9 @@ func (*realPrompter) CaptureNewFilepath(promptStr string) (string, error) {
 
 func yesNoBase(promptStr string, orderedOptions []string) (bool, error) {
 	prompt := promptui.Select{
-		Label: promptStr,
-		Items: orderedOptions,
+		Stdout: ux.Logger,
+		Label:  promptStr,
+		Items:  orderedOptions,
 	}
 
 	_, decision, err := prompt.Run()
@@ -648,8 +674,9 @@ func (*realPrompter) CaptureNoYes(promptStr string) (bool, error) {
 
 func (*realPrompter) CaptureList(promptStr string, options []string) (string, error) {
 	prompt := promptui.Select{
-		Label: promptStr,
-		Items: options,
+		Stdout: ux.Logger,
+		Label:  promptStr,
+		Items:  options,
 	}
 	_, listDecision, err := prompt.Run()
 	if err != nil {
@@ -660,9 +687,10 @@ func (*realPrompter) CaptureList(promptStr string, options []string) (string, er
 
 func (*realPrompter) CaptureListWithSize(promptStr string, options []string, size int) (string, error) {
 	prompt := promptui.Select{
-		Label: promptStr,
-		Items: options,
-		Size:  size,
+		Stdout: ux.Logger,
+		Label:  promptStr,
+		Items:  options,
+		Size:   size,
 	}
 	_, listDecision, err := prompt.Run()
 	if err != nil {
@@ -673,6 +701,7 @@ func (*realPrompter) CaptureListWithSize(promptStr string, options []string, siz
 
 func (*realPrompter) CaptureEmail(promptStr string) (string, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: validateEmail,
 	}
@@ -687,7 +716,8 @@ func (*realPrompter) CaptureEmail(promptStr string) (string, error) {
 
 func (*realPrompter) CaptureStringAllowEmpty(promptStr string) (string, error) {
 	prompt := promptui.Prompt{
-		Label: promptStr,
+		Stdout: ux.Logger,
+		Label:  promptStr,
 	}
 
 	str, err := prompt.Run()
@@ -701,6 +731,7 @@ func (*realPrompter) CaptureStringAllowEmpty(promptStr string) (string, error) {
 func (*realPrompter) CaptureURL(promptStr string, validateConnection bool) (string, error) {
 	for {
 		prompt := promptui.Prompt{
+			Stdout:   ux.Logger,
 			Label:    promptStr,
 			Validate: ValidateURLFormat,
 		}
@@ -722,6 +753,7 @@ func (*realPrompter) CaptureRepoBranch(promptStr string, repo string) (string, e
 	for {
 		var err error
 		prompt := promptui.Prompt{
+			Stdout:   ux.Logger,
 			Label:    promptStr,
 			Validate: validateNonEmpty,
 		}
@@ -740,6 +772,7 @@ func (*realPrompter) CaptureRepoFile(promptStr string, repo string, branch strin
 	for {
 		var err error
 		prompt := promptui.Prompt{
+			Stdout:   ux.Logger,
 			Label:    promptStr,
 			Validate: validateNonEmpty,
 		}
@@ -756,6 +789,7 @@ func (*realPrompter) CaptureRepoFile(promptStr string, repo string, branch strin
 
 func (*realPrompter) CaptureString(promptStr string) (string, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: validateNonEmpty,
 	}
@@ -770,6 +804,7 @@ func (*realPrompter) CaptureString(promptStr string) (string, error) {
 
 func (*realPrompter) CaptureValidatedString(promptStr string, validator func(string) error) (string, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: validator,
 	}
@@ -784,6 +819,7 @@ func (*realPrompter) CaptureValidatedString(promptStr string, validator func(str
 
 func (*realPrompter) CaptureGitURL(promptStr string) (*url.URL, error) {
 	prompt := promptui.Prompt{
+		Stdout:   ux.Logger,
 		Label:    promptStr,
 		Validate: ValidateURLFormat,
 	}
@@ -803,7 +839,8 @@ func (*realPrompter) CaptureGitURL(promptStr string) (*url.URL, error) {
 
 func (*realPrompter) CaptureVersion(promptStr string) (string, error) {
 	prompt := promptui.Prompt{
-		Label: promptStr,
+		Stdout: ux.Logger,
+		Label:  promptStr,
 		Validate: func(input string) error {
 			if !semver.IsValid(input) {
 				return errors.New("version must be a legal semantic version (ex: v1.1.1)")
@@ -822,8 +859,9 @@ func (*realPrompter) CaptureVersion(promptStr string) (string, error) {
 
 func (*realPrompter) CaptureIndex(promptStr string, options []any) (int, error) {
 	prompt := promptui.Select{
-		Label: promptStr,
-		Items: options,
+		Stdout: ux.Logger,
+		Label:  promptStr,
+		Items:  options,
 	}
 
 	listIndex, _, err := prompt.Run()
@@ -838,7 +876,8 @@ func (*realPrompter) CaptureIndex(promptStr string, options []any) (int, error) 
 // Otherwise, time from time.Now() is chosen.
 func (*realPrompter) CaptureFutureDate(promptStr string, minDate time.Time) (time.Time, error) {
 	prompt := promptui.Prompt{
-		Label: promptStr,
+		Stdout: ux.Logger,
+		Label:  promptStr,
 		Validate: func(s string) error {
 			t, err := time.Parse(constants.TimeParseLayout, s)
 			if err != nil {
@@ -1203,4 +1242,18 @@ func CaptureKeyAddress(
 		return k.C(), nil
 	}
 	return "", nil
+}
+
+// PromptLongString reads a long string from the user input.
+func PromptLongString(msg string, args ...interface{}) (string, error) {
+	_, _ = ux.Logger.Write([]byte(fmt.Sprintf(msg, args...)))
+	reader := bufio.NewReader(os.Stdin)
+	longString, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	// Remove newline character at the end
+	longString = strings.TrimSuffix(longString, "\n")
+	ux.Logger.Info(longString)
+	return longString, nil
 }

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -3,7 +3,6 @@
 package utils
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/hex"
@@ -351,19 +350,6 @@ func GetGitCommit(gitRepoURL string) string {
 		}
 	}
 	return ""
-}
-
-// ReadLongString reads a long string from the user input.
-func ReadLongString(msg string, args ...interface{}) (string, error) {
-	fmt.Printf(msg, args...)
-	reader := bufio.NewReader(os.Stdin)
-	longString, err := reader.ReadString('\n')
-	if err != nil {
-		return "", err
-	}
-	// Remove newline character at the end
-	longString = strings.TrimSuffix(longString, "\n")
-	return longString, nil
 }
 
 func SupportedAvagoArch() []string {

--- a/pkg/ux/output.go
+++ b/pkg/ux/output.go
@@ -31,18 +31,34 @@ func NewUserLog(log logging.Logger, userwriter io.Writer) {
 	}
 }
 
+// WriteCloser interface (promptui)
+func (ul *UserLog) Write(p []byte) (n int, err error) {
+	ul.Print(string(p))
+	return len(string(p)), nil
+}
+
+// WriteCloser interface (promptui)
+func (*UserLog) Close() error {
+	return nil
+}
+
 // PrintToUser prints msg directly on the screen, but also to log file
 func (ul *UserLog) PrintToUser(msg string, args ...interface{}) {
 	fmt.Print("\r\033[K") // Clear the line from the cursor position to the end
-	ul.print(fmt.Sprintf(msg, args...) + "\n")
+	ul.Printf(msg+"\n", args...)
 }
 
-func (ul *UserLog) print(msg string) {
+func (ul *UserLog) Printf(msg string, args ...interface{}) {
+	s := fmt.Sprintf(msg, args...)
+	ul.Print(s)
+}
+
+func (ul *UserLog) Print(s string) {
 	if ul != nil {
-		fmt.Fprint(ul.Writer, msg)
-		ul.log.Info(msg)
+		fmt.Fprint(ul.Writer, s)
+		ul.log.Info(strings.TrimSpace(s))
 	} else {
-		fmt.Print(msg)
+		fmt.Print(s)
 	}
 }
 

--- a/pkg/vm/evm_prompts.go
+++ b/pkg/vm/evm_prompts.go
@@ -3,14 +3,14 @@
 package vm
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
 	"os"
 
-	"github.com/ava-labs/avalanche-cli/pkg/dependencies"
-
 	"github.com/ava-labs/avalanche-cli/pkg/application"
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
+	"github.com/ava-labs/avalanche-cli/pkg/dependencies"
 	"github.com/ava-labs/avalanche-cli/pkg/models"
 	"github.com/ava-labs/avalanche-cli/pkg/utils"
 	"github.com/ava-labs/avalanche-cli/pkg/ux"
@@ -333,7 +333,8 @@ func PromptDefaults(
 
 func displayAllocations(alloc core.GenesisAlloc) {
 	header := []string{"Address", "Balance"}
-	table := tablewriter.NewWriter(os.Stdout)
+	var tableBuf bytes.Buffer
+	table := tablewriter.NewWriter(&tableBuf)
 	table.SetHeader(header)
 	table.SetAutoMergeCellsByColumnIndex([]int{0})
 	table.SetAutoMergeCells(true)
@@ -342,6 +343,7 @@ func displayAllocations(alloc core.GenesisAlloc) {
 		table.Append([]string{address.Hex(), utils.FormatAmount(account.Balance, 18)})
 	}
 	table.Render()
+	ux.Logger.Print(tableBuf.String())
 }
 
 func addNewKeyAllocation(allocations core.GenesisAlloc, app *application.Avalanche, subnetName string) error {
@@ -391,8 +393,8 @@ func getNativeGasTokenAllocationConfig(
 
 	if allocOption == customAllocationOption {
 		if len(allocations) != 0 {
-			fmt.Println()
-			fmt.Println(logging.Bold.Wrap("Addresses automatically allocated"))
+			ux.Logger.PrintToUser("")
+			ux.Logger.PrintToUser(logging.Bold.Wrap("Addresses automatically allocated"))
 			displayAllocations(allocations)
 		}
 		for {


### PR DESCRIPTION
## Why this should be merged
Currently, prompt options and tables and not included in the main log, which makes it difficult
to fully check what were the inputs and the processing results.

## How this works

## How this was tested

## How is this documented
