### PR TITLE
fix go run main.go execution

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -146,7 +146,7 @@ func createApp(cmd *cobra.Command, _ []string) error {
 	if err := checkForUpdates(cmd, app); err != nil {
 		return err
 	}
-	if err := version.CheckCLIVersionIsOverMin(app, Version); err != nil {
+	if err := version.CheckCLIVersionIsOverMin(app, metrics.GetCLIVersion()); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Why this should be merged
Currently `go run main.go network stop` for example, prints:

```
Error: CLI version is required to be at least v1.9.0, current CLI version is v, please upgrade CLI by calling `avalanche update`
exit status 1
```

This was introduced by a recent min version check for CLI.

This PR fix this.

## How this works
Uses metrics.GetCLIVersion to get the version, instead of just Version field which is empty if directly using go run

## How this was tested

## How is this documented
