### PR TITLE
reenable package management suite at CI

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -23,7 +23,7 @@ jobs:
             "\\[Local Network\\]",
             "\\[Network\\]",
             "\\[Blockchain Configure\\]",
-            # "\\[Package Management\\]",
+            "\\[Package Management\\]",
             "\\[Root\\]",
             "\\[Local Subnet non SOV\\]",
             "\\[Subnet Compatibility\\]",

--- a/tests/e2e/testcases/packageman/suite.go
+++ b/tests/e2e/testcases/packageman/suite.go
@@ -189,6 +189,9 @@ var _ = ginkgo.Describe("[Package Management]", ginkgo.Ordered, func() {
 	})
 
 	ginkgo.It("can deploy with multiple avalanchego versions non SOV", func() {
+		if binaryToVersion[utils.MultiAvago1Key] == binaryToVersion[utils.MultiAvago2Key] {
+			ginkgo.Skip("this needs two different rpc-compatible avalanchego to be available")
+		}
 		// check avago install precondition
 		gomega.Expect(utils.CheckAvalancheGoExists(binaryToVersion[utils.MultiAvago1Key])).Should(gomega.BeFalse())
 		gomega.Expect(utils.CheckAvalancheGoExists(binaryToVersion[utils.MultiAvago2Key])).Should(gomega.BeFalse())


### PR DESCRIPTION
## Why this should be merged
it was disabled due to an issue. issue is fixed in this PR also.
case is that current number of avalanchego release with same rpc compat is one,
so one test needs to be skipped in this case.

## How this works

## How this was tested

## How is this documented
