### PR TITLE
fix version for release

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -146,7 +146,7 @@ func createApp(cmd *cobra.Command, _ []string) error {
 	if err := checkForUpdates(cmd, app); err != nil {
 		return err
 	}
-	if err := version.CheckCLIVersionIsOverMin(app, metrics.GetCLIVersion()); err != nil {
+	if err := version.CheckCLIVersionIsOverMin(app, app.GetVersion()); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -989,3 +989,19 @@ func (app *Avalanche) GetNetworkFromSidecarNetworkName(
 	}
 	return models.UndefinedNetwork, fmt.Errorf("unsupported network name")
 }
+
+func (app *Avalanche) GetVersion() string {
+	if app.Version != "" {
+		return app.Version
+	}
+	wdPath, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	versionPath := filepath.Join(wdPath, "VERSION")
+	content, err := os.ReadFile(versionPath)
+	if err != nil {
+		return ""
+	}
+	return string(content)
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -5,7 +5,6 @@ package metrics
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -24,19 +23,6 @@ var (
 	telemetryInstance = "https://app.posthog.com"
 	sent              = false
 )
-
-func GetCLIVersion() string {
-	wdPath, err := os.Getwd()
-	if err != nil {
-		return ""
-	}
-	versionPath := filepath.Join(wdPath, "VERSION")
-	content, err := os.ReadFile(versionPath)
-	if err != nil {
-		return ""
-	}
-	return string(content)
-}
 
 func getMetricsUserID(app *application.Avalanche) string {
 	if !app.Conf.ConfigFileExists() || !app.Conf.ConfigValueIsSet(constants.ConfigMetricsUserIDKey) {
@@ -108,10 +94,7 @@ func trackMetrics(app *application.Avalanche, flags map[string]string, cmdErr er
 		app.Log.Warn(fmt.Sprintf("failure creating metrics client: %s", err))
 	}
 
-	version := app.Version
-	if version == "" {
-		version = GetCLIVersion()
-	}
+	version := app.GetVersion()
 
 	userID := getMetricsUserID(app)
 


### PR DESCRIPTION
## Why this should be merged
The min version check continues failing for binaries compiled by scripts/builld.sh.
Basically the Version variable is set during compilation but the check of metrics.GetCLIVersion overrides it and provides
empty string in many contexts.

The error affects prerelease and release process. Error is:
```
CLI version is required to be at least v1.9.0, current CLI version is v, please upgrade CLI by calling `avalanche update`
```

## How this works
Makes a new function under application that first returns the Version variable if not empty, and, only
if this is not the case, tries to read VERSION file (for go run executions).

## How this was tested
A prerelease was made with the change. Execution of go run and built binaries was made

## How is this documented
