### PR TITLE
bump golang version of dockerfile to match go.mod version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ============= Build Stage ================
-FROM golang:1.22.10-bookworm AS builder
+FROM golang:1.23.7-bookworm AS builder
 
 WORKDIR /build
 # Copy and download avalanche dependencies using go mod


### PR DESCRIPTION
## Why this should be merged
Currently golang version at dockerfile is behing go.mod version, and it causes issues on
locally building the image:

```
docker build -f Dockerfile .
...
=> ERROR [builder 5/7] RUN go mod download                                                                                                                           0.2s
------
 > [builder 5/7] RUN go mod download:
0.138 go: go.mod requires go >= 1.23.6 (running go 1.22.10; GOTOOLCHAIN=local)
------
Dockerfile:8
--------------------
   6 |     COPY go.mod .
   7 |     COPY go.sum .
   8 | >>> RUN go mod download
   9 |     # Copy the code into the container
  10 |     COPY . .
--------------------
ERROR: failed to solve: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

## How this works
golang version is bumped at dockerfile to match 1.23.7, which is the one used by toolchain at go.mod

## How this was tested
The image was build with success after the change

## How is this documented
