### PR TITLE
stop relayer before restarting local network

### DIFF
--- a/cmd/blockchaincmd/deploy.go
+++ b/cmd/blockchaincmd/deploy.go
@@ -823,6 +823,11 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// needs to first stop relayer so non sovereign subnets successfully restart
+	if sidecar.TeleporterReady && !icmSpec.SkipICMDeploy && !icmSpec.SkipRelayerDeploy && network.Kind != models.Mainnet {
+		_ = relayercmd.CallStop(nil, relayercmd.StopFlags{}, network)
+	}
+
 	tracked := false
 
 	if sidecar.Sovereign {
@@ -955,7 +960,6 @@ func deployBlockchain(cmd *cobra.Command, args []string) error {
 				}
 			}
 			if !icmSpec.SkipRelayerDeploy && network.Kind != models.Mainnet {
-				_ = relayercmd.CallStop(nil, relayercmd.StopFlags{}, network)
 				if network.Kind == models.Local && icmSpec.RelayerBinPath == "" && icmSpec.RelayerVersion == constants.DefaultRelayerVersion {
 					if b, extraLocalNetworkData, err := localnet.GetExtraLocalNetworkData(app, ""); err != nil {
 						return err


### PR DESCRIPTION
## Why this should be merged
A combination of L1 deploy plus a non sovereign deploy fails in local network, with following error:
```
Restarting node NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg to track newly deployed subnet/s
Restarting node NodeID-MFrZFVCXPv5iCn6M9K6XduxGTYp891xXZ to track newly deployed subnet/s
Waiting for blockchain J6ahmBAQMEfG2zQNGdgLm1meKW56Cca9JZgnRjFQm5xxMDLaS to be bootstrapped
✓ Local Network successfully tracking nonsov1
Error: failed to issue request: Post "http://127.0.0.1:9650/ext/admin": context deadline exceeded
exit status 1
```

It was found that the issue is avoided if the relayer/icm is not involved, or the relayer is stopped before
restarting the nodes.

## How this works
This PR restarts the relayer before restarting the network.

## How this was tested
The described deploy combination stopped failing.

## How is this documented
