### PR TITLE
improve validator manager event lookup speed

### DIFF
--- a/pkg/validatormanager/removal.go
+++ b/pkg/validatormanager/removal.go
@@ -304,7 +304,7 @@ func InitValidatorRemoval(
 
 	var nonce uint64
 	if unsignedMessage == nil {
-		nonce, err = GetValidatorNonce(rpcURL, validationID)
+		nonce, err = GetValidatorNonce(ctx, rpcURL, validationID)
 		if err != nil {
 			return nil, ids.Empty, nil, err
 		}

--- a/pkg/validatormanager/weight_update.go
+++ b/pkg/validatormanager/weight_update.go
@@ -116,7 +116,7 @@ func InitValidatorWeightChange(
 	}
 
 	if unsignedMessage == nil {
-		unsignedMessage, err = SearchForL1ValidatorWeightMessage(rpcURL, validationID, weight)
+		unsignedMessage, err = SearchForL1ValidatorWeightMessage(ctx, rpcURL, validationID, weight)
 		if err != nil {
 			printFunc(logging.Red.Wrap("Failure checking for warp messages of previous operations: %s. Proceeding."), err)
 		}
@@ -155,7 +155,7 @@ func InitValidatorWeightChange(
 
 	var nonce uint64
 	if unsignedMessage == nil {
-		nonce, err = GetValidatorNonce(rpcURL, validationID)
+		nonce, err = GetValidatorNonce(ctx, rpcURL, validationID)
 		if err != nil {
 			return nil, ids.Empty, nil, err
 		}
@@ -228,7 +228,7 @@ func FinishValidatorWeightChange(
 	}
 	var nonce uint64
 	if l1ValidatorRegistrationSignedMessage == nil {
-		nonce, err = GetValidatorNonce(rpcURL, validationID)
+		nonce, err = GetValidatorNonce(ctx, rpcURL, validationID)
 		if err != nil {
 			return nil, err
 		}
@@ -426,11 +426,12 @@ func GetL1ValidatorWeightMessageFromTx(
 }
 
 func SearchForL1ValidatorWeightMessage(
+	ctx context.Context,
 	rpcURL string,
 	validationID ids.ID,
 	weight uint64,
 ) (*warp.UnsignedMessage, error) {
-	const maxBlocksToSearch = 500
+	maxBlocksToSearch := int64(5000000)
 	client, err := evm.GetClient(rpcURL)
 	if err != nil {
 		return nil, err
@@ -441,14 +442,21 @@ func SearchForL1ValidatorWeightMessage(
 	}
 	maxBlock := int64(height)
 	minBlock := max(maxBlock-maxBlocksToSearch, 0)
-	for blockNumber := maxBlock; blockNumber >= minBlock; blockNumber-- {
-		block, err := client.BlockByNumber(big.NewInt(blockNumber))
-		if err != nil {
-			return nil, err
+	blockStep := int64(5000)
+	for blockNumber := maxBlock; blockNumber >= minBlock; blockNumber -= blockStep {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
 		}
-		blockHash := block.Hash()
+		fromBlock := big.NewInt(blockNumber - blockStep)
+		if fromBlock.Sign() < 0 {
+			fromBlock = big.NewInt(0)
+		}
+		toBlock := big.NewInt(blockNumber)
 		logs, err := client.FilterLogs(interfaces.FilterQuery{
-			BlockHash: &blockHash,
+			FromBlock: fromBlock,
+			ToBlock:   toBlock,
 			Addresses: []common.Address{subnetEvmWarp.Module.Address},
 		})
 		if err != nil {


### PR DESCRIPTION
## Why this should be merged
Currently the lookup for validator manager events (mainly registration logs), was done 1 block at a time,
which took just too long. 
Also, weight change does not support specifying 0 weight
It also adds ctx management to the search functions so the user can nicely cancel with Ctrl+C

## How this works
Used a 5000 log range on eth_getLogs

## How this was tested
Execution of a remove validator command on DFK

## How is this documented
