### PR TITLE
increase timeout when querying xchain balance

### DIFF
--- a/cmd/keycmd/list.go
+++ b/cmd/keycmd/list.go
@@ -701,7 +701,7 @@ func getXChainBalanceStr(xClient avm.Client, addr string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	ctx, cancel = utils.GetAPIContext()
+	ctx, cancel = utils.GetAPILargeContext()
 	defer cancel()
 	resp, err := xClient.GetBalance(ctx, xID, asset.AssetID.String(), false)
 	if err != nil {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -59,7 +59,7 @@ const (
 
 	ANRRequestTimeout      = 3 * time.Minute
 	APIRequestTimeout      = 10 * time.Second
-	APIRequestLargeTimeout = 10 * time.Second
+	APIRequestLargeTimeout = 30 * time.Second
 	FastGRPCDialTimeout    = 100 * time.Millisecond
 
 	FujiBootstrapTimeout    = 15 * time.Minute


### PR DESCRIPTION
## Why this should be merged
currently the timeout of 10 seconds can be too low for certain mainnet balance queries

## How this works

## How this was tested

## How is this documented
