### PR TITLE
fix main url

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -298,7 +298,7 @@ const (
 	FujiAvalancheGoV113          = "v1.13.0-fuji"
 	AvalancheGoCompatibilityURL  = "https://raw.githubusercontent.com/ava-labs/avalanchego/master/version/compatibility.json"
 	SubnetEVMRPCCompatibilityURL = "https://raw.githubusercontent.com/ava-labs/subnet-evm/master/compatibility.json"
-	CLILatestDependencyURL       = "https://raw.githubusercontent.com/ava-labs/avalanche-cli/support-rpc43/versions/latest.json"
+	CLILatestDependencyURL       = "https://raw.githubusercontent.com/ava-labs/avalanche-cli/main/versions/latest.json"
 	CLIMinVersionURL             = "https://raw.githubusercontent.com/ava-labs/avalanche-cli/main/versions/min_cli_version.json"
 
 	YesLabel = "Yes"


### PR DESCRIPTION
Revert back to https://raw.githubusercontent.com/ava-labs/avalanche-cli/main/versions/latest.json