### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/pkg/docker/compose.go
+++ b/pkg/docker/compose.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"text/template"
 	"time"
@@ -283,12 +284,6 @@ func HasRemoteComposeService(host *models.Host, composeFile string, service stri
 	if err != nil {
 		return false, err
 	}
-	found := false
-	for _, s := range services {
-		if s == service {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(services, service)
 	return found, nil
 }

--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/ava-labs/avalanche-cli/pkg/constants"
@@ -28,10 +29,8 @@ func DockerLocalImageExists(host *models.Host, image string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	for _, localImage := range parseDockerImageListOutput(output) {
-		if localImage == image {
-			return true, nil
-		}
+	if slices.Contains(parseDockerImageListOutput(output), image) {
+		return true, nil
 	}
 	return false, nil
 }

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -125,13 +125,7 @@ func CheckSubnetAuthKeys(walletKeys []string, subnetAuthKeys []string, controlKe
 		return fmt.Errorf("number of given auth keys differs from the threshold")
 	}
 	for _, subnetAuthKey := range subnetAuthKeys {
-		found := false
-		for _, controlKey := range controlKeys {
-			if subnetAuthKey == controlKey {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(controlKeys, subnetAuthKey)
 		if !found {
 			return fmt.Errorf("auth key %s does not belong to control keys", subnetAuthKey)
 		}

--- a/pkg/prompts/prompts_test.go
+++ b/pkg/prompts/prompts_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/ava-labs/avalanche-cli/pkg/key"
@@ -669,12 +670,7 @@ func TestPromptChain(t *testing.T) {
 		mockPrompt := &mocks.Prompter{}
 		mockPrompt.On("CaptureListWithSize", prompt, mock.MatchedBy(func(options []string) bool {
 			// Should contain "Custom" option
-			for _, opt := range options {
-				if opt == Custom {
-					return true
-				}
-			}
-			return false
+			return slices.Contains(options, Custom)
 		}), 11).Return(Custom, nil).Once()
 		mockPrompt.On("CaptureString", "Blockchain ID/Alias").Return("custom-blockchain-id", nil).Once()
 		notListed, pChain, xChain, cChain, subnetName, blockchainID, err := PromptChain(
@@ -693,12 +689,7 @@ func TestPromptChain(t *testing.T) {
 		mockPrompt := &mocks.Prompter{}
 		mockPrompt.On("CaptureListWithSize", prompt, mock.MatchedBy(func(options []string) bool {
 			// Should contain "My blockchain isn't listed" option
-			for _, opt := range options {
-				if opt == "My blockchain isn't listed" {
-					return true
-				}
-			}
-			return false
+			return slices.Contains(options, "My blockchain isn't listed")
 		}), 11).Return("My blockchain isn't listed", nil).Once()
 		notListed, pChain, xChain, cChain, subnetName, blockchainID, err := PromptChain(
 			mockPrompt, prompt, subnetNames, true, true, true, avoidBlockchainName, false)

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -16,6 +16,7 @@ import (
 	"os/exec"
 	"os/user"
 	"regexp"
+	slices0 "slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -88,12 +89,7 @@ func GetRealFilePath(path string) string {
 }
 
 func Any[T any](input []T, f func(T) bool) bool {
-	for _, e := range input {
-		if f(e) {
-			return true
-		}
-	}
-	return false
+	return slices0.ContainsFunc(input, f)
 }
 
 func Find[T any](input []T, f func(T) bool) *T {

--- a/pkg/vm/precompiles_test.go
+++ b/pkg/vm/precompiles_test.go
@@ -4,6 +4,7 @@
 package vm
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/ava-labs/avalanche-cli/internal/testutils"
@@ -173,13 +174,7 @@ func TestAddAddressToAllowed(t *testing.T) {
 			// Check if the address was added to enabled list when expected
 			if tt.shouldAddToEnabled {
 				expectedAddress := common.HexToAddress(tt.addressToAdd)
-				found := false
-				for _, addr := range result.EnabledAddresses {
-					if addr == expectedAddress {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(result.EnabledAddresses, expectedAddress)
 				require.True(t, found, "Address should have been added to enabled list")
 			}
 


### PR DESCRIPTION
## Why this should be merged

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.

## How this works

## How this was tested

## How is this documented
