### PR TITLE
feat: sets execute permissions for copied VM binary

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -623,6 +623,14 @@ func RunSSHCopyBinaryFile(host *models.Host, sc models.Sidecar) error {
 	); err != nil {
 		return err
 	}
+
+	// set execute permissions
+	cmd := fmt.Sprintf("chmod +x %s", subnetVMBinaryPath)
+	ux.Logger.Info("Setting permissions for %s on %s", subnetVMBinaryPath, host.NodeID)
+	if _, err := host.Command(cmd, nil, constants.SSHScriptTimeout); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Why this should be merged
This PR adds execute permission setting for custom VM binary.

## How this works
PR updates `RunSSHCopyBinaryFile` function for include permission setting.

## How this was tested

## How is this documented
