### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/pkg/binutils/binaries.go
+++ b/pkg/binutils/binaries.go
@@ -111,7 +111,7 @@ func installZipArchive(zipfile []byte, binDir string) error {
 		return fmt.Errorf("failed to create app binary directory: %w", err)
 	}
 
-	// Closure to address file descriptors issue, uses Close to to not leave open descriptors
+	// Closure to address file descriptors issue, uses Close to not leave open descriptors
 	extractAndWriteFile := func(f *zip.File) error {
 		rc, err := f.Open()
 		if err != nil {

--- a/pkg/localnet/output.go
+++ b/pkg/localnet/output.go
@@ -54,7 +54,7 @@ func PrintEndpoints(
 }
 
 // PrintBlockchainEndpoints prints out a table of (RPC Kind, RPC) for the given
-// [blockchain] associated to the the given tmpnet [networkDir]
+// [blockchain] associated to the given tmpnet [networkDir]
 // RPC Kind to be in [Localhost, Codespace] where the latest
 // is used only if inside a codespace environment
 func PrintBlockchainEndpoints(


### PR DESCRIPTION
## Why this should be merged

remove redundant word in comment

## How this works

## How this was tested

## How is this documented
